### PR TITLE
Expose Flask apps externally

### DIFF
--- a/apps/conscious_assistant/interface_flask.py
+++ b/apps/conscious_assistant/interface_flask.py
@@ -150,4 +150,12 @@ def run_scheduled_tasks():
 atexit.register(cleanup)
 
 if __name__ == "__main__":
-    socketio.run(app, debug=False, port=5001, allow_unsafe_werkzeug=True, log_output=True, use_reloader=False)
+    socketio.run(
+        app,
+        debug=False,
+        host="0.0.0.0",
+        port=5001,
+        allow_unsafe_werkzeug=True,
+        log_output=True,
+        use_reloader=False,
+    )

--- a/apps/cruse/interface_flask.py
+++ b/apps/cruse/interface_flask.py
@@ -232,4 +232,12 @@ def handle_new_chat(data, *args):
 atexit.register(cleanup)
 
 if __name__ == "__main__":
-    socketio.run(app, debug=False, port=5001, allow_unsafe_werkzeug=True, log_output=True, use_reloader=False)
+    socketio.run(
+        app,
+        debug=False,
+        host="0.0.0.0",
+        port=5001,
+        allow_unsafe_werkzeug=True,
+        log_output=True,
+        use_reloader=False,
+    )

--- a/apps/legal_discovery/interface_flask.py
+++ b/apps/legal_discovery/interface_flask.py
@@ -330,4 +330,12 @@ if __name__ == "__main__":
     app.logger.info("Starting Flask server...")
     with app.app_context():
         db.create_all()
-    socketio.run(app, debug=False, port=5001, allow_unsafe_werkzeug=True, log_output=True, use_reloader=False)
+    socketio.run(
+        app,
+        debug=False,
+        host="0.0.0.0",
+        port=5001,
+        allow_unsafe_werkzeug=True,
+        log_output=True,
+        use_reloader=False,
+    )


### PR DESCRIPTION
## Summary
- host Flask-SocketIO apps on `0.0.0.0` to allow external connections

## Testing
- `make test` *(fails: E402 and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6880c6f9248c8333bba8246a1c09f44b