### PR TITLE
Add simple dashboard UI

### DIFF
--- a/apps/legal_discovery/interface_flask.py
+++ b/apps/legal_discovery/interface_flask.py
@@ -208,6 +208,16 @@ def list_files():
     return jsonify({"status": "ok", "data": data})
 
 
+@app.route("/api/organized-files", methods=["GET"])
+def organized_files():
+    """Return a placeholder organized file structure."""
+    root = os.path.abspath(app.config["UPLOAD_FOLDER"])
+    if not os.path.exists(root):
+        return jsonify({"status": "ok", "data": {}})
+    data = build_file_tree(root, len(root))
+    return jsonify({"status": "ok", "data": {"Uncategorized": data}})
+
+
 def cleanup_upload_folder(max_age_hours: int = 24) -> None:
     """Remove uploaded files older than ``max_age_hours``."""
     cutoff = time.time() - max_age_hours * 3600
@@ -389,6 +399,12 @@ def export_report():
 def index():
     """Return the html."""
     return render_template("index.html")
+
+
+@app.route("/dashboard")
+def dashboard():
+    """Return the dashboard UI."""
+    return render_template("dashboard.html")
 
 
 @socketio.on("user_input", namespace="/chat")

--- a/apps/legal_discovery/interface_flask.py
+++ b/apps/legal_discovery/interface_flask.py
@@ -208,14 +208,78 @@ def list_files():
     return jsonify({"status": "ok", "data": data})
 
 
+def _collect_paths(root: str) -> list:
+    paths = []
+    for dirpath, _, filenames in os.walk(root):
+        for f in filenames:
+            paths.append(os.path.relpath(os.path.join(dirpath, f), root))
+    return paths
+
+
+def _categorize_name(name: str) -> str:
+    name = name.lower()
+    if any(k in name for k in ["complaint", "response", "petition"]):
+        return "Pleadings"
+    if "deposition" in name:
+        return "Depositions"
+    if any(k in name for k in ["contract", "agreement"]):
+        return "Contracts"
+    if "email" in name:
+        return "Emails"
+    if any(k in name for k in ["memo", "memorandum"]):
+        return "Memos"
+    return "Other"
+
+
+def _paths_to_tree(paths: list) -> list:
+    tree = {}
+    for p in paths:
+        parts = p.split(os.sep)
+        node = tree
+        for part in parts[:-1]:
+            node = node.setdefault(part, {})
+        node.setdefault("_files", []).append(parts[-1])
+
+    def convert(d, prefix=""):
+        items = []
+        for name, val in sorted(d.items()):
+            if name == "_files":
+                for fname in val:
+                    items.append({"name": fname, "path": os.path.join(prefix, fname)})
+            else:
+                items.append(
+                    {
+                        "name": name,
+                        "path": os.path.join(prefix, name),
+                        "children": convert(val, os.path.join(prefix, name)),
+                    }
+                )
+        return items
+
+    return convert(tree)
+
+
 @app.route("/api/organized-files", methods=["GET"])
 def organized_files():
-    """Return a placeholder organized file structure."""
+    """Return files grouped into simple categories."""
     root = os.path.abspath(app.config["UPLOAD_FOLDER"])
     if not os.path.exists(root):
         return jsonify({"status": "ok", "data": {}})
-    data = build_file_tree(root, len(root))
-    return jsonify({"status": "ok", "data": {"Uncategorized": data}})
+
+    files = _collect_paths(root)
+    categories = {}
+    for path in files:
+        cat = _categorize_name(os.path.basename(path))
+        categories.setdefault(cat, []).append(path)
+
+    data = {cat: _paths_to_tree(paths) for cat, paths in categories.items()}
+    return jsonify({"status": "ok", "data": data})
+
+
+@app.route("/uploads/<path:filename>")
+def serve_upload(filename):
+    """Serve a file from the uploads folder."""
+    return send_from_directory(app.config["UPLOAD_FOLDER"], filename, as_attachment=False)
 
 
 def cleanup_upload_folder(max_age_hours: int = 24) -> None:
@@ -295,13 +359,12 @@ def forensic_logs():
 
 @app.route("/api/progress", methods=["GET"])
 def progress_status():
-    """Stubbed progress information for the frontend."""
-    data = {
-        "upload": 0,
-        "export": 0,
-        "timeline": 0,
-        "forensic": 0,
-    }
+    """Return basic progress metrics."""
+    root = app.config["UPLOAD_FOLDER"]
+    upload_count = 0
+    if os.path.exists(root):
+        upload_count = sum(len(f) for _, _, f in os.walk(root))
+    data = {"uploaded_files": upload_count}
     return jsonify({"status": "ok", "data": data})
 
 

--- a/apps/legal_discovery/static/dashboard.js
+++ b/apps/legal_discovery/static/dashboard.js
@@ -10,10 +10,31 @@ function buildTree(el, nodes) {
   nodes.forEach(n => {
     const li = document.createElement('li');
     li.textContent = n.name;
-    if (n.children) buildTree(li, n.children);
+    if (n.children) {
+      buildTree(li, n.children);
+    } else {
+      li.onclick = () => window.open('/uploads/' + n.path, '_blank');
+    }
     ul.appendChild(li);
   });
   el.appendChild(ul);
+}
+
+function fetchOrganized() {
+  fetch('/api/organized-files')
+    .then(r => r.json())
+    .then(d => {
+      const container = document.getElementById('organized-tree');
+      container.innerHTML = '';
+      Object.entries(d.data).forEach(([cat, nodes]) => {
+        const section = document.createElement('div');
+        const h3 = document.createElement('h3');
+        h3.textContent = cat;
+        section.appendChild(h3);
+        buildTree(section, nodes);
+        container.appendChild(section);
+      });
+    });
 }
 
 function upload() {
@@ -69,4 +90,6 @@ document.addEventListener('DOMContentLoaded', () => {
   document.getElementById('upload-button').onclick = upload;
   document.getElementById('export-button').onclick = exportAll;
   document.getElementById('load-timeline').onclick = loadTimeline;
+  const orgBtn = document.getElementById('organized-button');
+  if (orgBtn) orgBtn.onclick = fetchOrganized;
 });

--- a/apps/legal_discovery/static/dashboard.js
+++ b/apps/legal_discovery/static/dashboard.js
@@ -1,0 +1,72 @@
+function fetchFiles() {
+  fetch('/api/files')
+    .then(r => r.json())
+    .then(d => buildTree(document.getElementById('file-tree'), d.data));
+}
+
+function buildTree(el, nodes) {
+  if (!nodes) return;
+  const ul = document.createElement('ul');
+  nodes.forEach(n => {
+    const li = document.createElement('li');
+    li.textContent = n.name;
+    if (n.children) buildTree(li, n.children);
+    ul.appendChild(li);
+  });
+  el.appendChild(ul);
+}
+
+function upload() {
+  const files = document.getElementById('file-input').files;
+  if (!files.length) return;
+  const fd = new FormData();
+  for (const f of files) fd.append('files', f, f.webkitRelativePath || f.name);
+  fetch('/api/upload', { method:'POST', body:fd })
+    .then(r => r.json())
+    .then(_ => fetchFiles());
+}
+
+function exportAll() {
+  window.open('/api/export', '_blank');
+}
+
+function loadTimeline() {
+  const query = document.getElementById('timeline-query').value;
+  fetch('/api/timeline?query=' + encodeURIComponent(query))
+    .then(r => r.json())
+    .then(d => renderTimeline(d.data));
+}
+
+function renderTimeline(items) {
+  const container = document.getElementById('timeline');
+  container.innerHTML='';
+  const dataset = new vis.DataSet(items.map(e => ({id:e.id, content:e.description, start:e.date, citation:e.citation})));
+  const timeline = new vis.Timeline(container, dataset, {});
+  timeline.on('click', props => {
+    const item = dataset.get(props.item);
+    if (item && item.citation) {
+      const modal = document.getElementById('modal');
+      modal.querySelector('iframe').src = item.citation;
+      modal.style.display='flex';
+    }
+  });
+}
+
+function loadGraph() {
+  fetch('/api/graph')
+    .then(r => r.json())
+    .then(d => {
+      const cy = cytoscape({ container: document.getElementById('graph'), elements: [] });
+      cy.add(d.data.nodes.map(n => ({ data:{ id:n.id, label:n.labels[0] }})));
+      cy.add(d.data.edges.map(e => ({ data:{ id:e.source+'_'+e.target, source:e.source, target:e.target }})));
+      cy.layout({ name:'breadthfirst', directed:true }).run();
+    });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  fetchFiles();
+  loadGraph();
+  document.getElementById('upload-button').onclick = upload;
+  document.getElementById('export-button').onclick = exportAll;
+  document.getElementById('load-timeline').onclick = loadTimeline;
+});

--- a/apps/legal_discovery/templates/dashboard.html
+++ b/apps/legal_discovery/templates/dashboard.html
@@ -3,27 +3,47 @@
 <head>
   <meta charset="UTF-8">
   <title>Legal Discovery Dashboard</title>
-  <link rel="stylesheet" href="{{ url_for('static', filename='dashboard.css') }}">
-  <script src="{{ url_for('static', filename='dashboardLogic.js') }}" defer></script>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.1/normalize.min.css">
+  <script src="https://cdn.jsdelivr.net/npm/cytoscape@3.26.0/dist/cytoscape.min.js"></script>
+  <link rel="stylesheet" href="{{ url_for('static', filename='vis-timeline/vis-timeline-graph2d.min.css') }}" />
+  <script src="{{ url_for('static', filename='vis-timeline/vis-timeline-graph2d.min.js') }}"></script>
+  <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+  <script src="{{ url_for('static', filename='dashboard.js') }}" defer></script>
+  <style>
+    #graph { height: 300px; border: 1px solid #ccc; margin-top: 1rem; }
+    #timeline { height: 200px; border: 1px solid #ccc; margin-top: 1rem; }
+    .folder-tree ul { list-style: none; padding-left: 1rem; }
+    .folder-tree li { cursor: pointer; }
+    #modal { position: fixed; inset: 0; background: rgba(0,0,0,0.7); display:none; align-items:center; justify-content:center; }
+    #modal iframe { width: 80vw; height: 80vh; background:#fff; }
+  </style>
 </head>
 <body>
-  <h1>Legal Discovery Assistant</h1>
+  <h1>Legal Discovery Dashboard</h1>
 
-  <form id="queryForm" method="POST">
-    <label for="text">Query:</label><br>
-    <textarea name="text" rows="5" cols="80" placeholder="e.g. Find deposition transcripts related to expert testimony"></textarea><br><br>
+  <section>
+    <h2>Upload</h2>
+    <input type="file" id="file-input" webkitdirectory directory multiple />
+    <button id="upload-button">Upload</button>
+    <button id="export-button">Export All</button>
+    <div id="file-tree" class="folder-tree"></div>
+  </section>
 
-    <label for="session_id">Session ID:</label><br>
-    <input name="session_id" value="demo-session"><br><br>
+  <section>
+    <h2>Timeline</h2>
+    <textarea id="timeline-query" rows="2" cols="60" placeholder="Request events..."></textarea>
+    <button id="load-timeline">Load Timeline</button>
+    <div id="timeline"></div>
+  </section>
 
-    <button type="submit">Run</button>
-  </form>
+  <section>
+    <h2>Knowledge Graph</h2>
+    <div id="graph"></div>
+  </section>
 
-  <hr>
-
-  <div id="responseContainer">
-    <h2>Response:</h2>
-    <pre id="outputBox"></pre>
+  <div id="modal" onclick="this.style.display='none'">
+    <iframe></iframe>
   </div>
 </body>
 </html>

--- a/apps/legal_discovery/templates/dashboard.html
+++ b/apps/legal_discovery/templates/dashboard.html
@@ -5,10 +5,11 @@
   <title>Legal Discovery Dashboard</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.1/normalize.min.css">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap">
+  <script src="https://cdn.tailwindcss.com?plugins=forms"></script>
   <script src="https://cdn.jsdelivr.net/npm/cytoscape@3.26.0/dist/cytoscape.min.js"></script>
   <link rel="stylesheet" href="{{ url_for('static', filename='vis-timeline/vis-timeline-graph2d.min.css') }}" />
   <script src="{{ url_for('static', filename='vis-timeline/vis-timeline-graph2d.min.js') }}"></script>
-  <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
   <script src="{{ url_for('static', filename='dashboard.js') }}" defer></script>
   <style>
     #graph { height: 300px; border: 1px solid #ccc; margin-top: 1rem; }
@@ -20,26 +21,30 @@
   </style>
 </head>
 <body>
-  <h1>Legal Discovery Dashboard</h1>
+  <h1 class="text-2xl font-semibold mb-4">Legal Discovery Dashboard</h1>
 
-  <section>
-    <h2>Upload</h2>
-    <input type="file" id="file-input" webkitdirectory directory multiple />
-    <button id="upload-button">Upload</button>
-    <button id="export-button">Export All</button>
-    <div id="file-tree" class="folder-tree"></div>
+  <section class="bg-slate-800 p-4 rounded mb-6">
+    <h2 class="text-lg font-medium mb-2">Upload</h2>
+    <input type="file" id="file-input" class="mb-2" webkitdirectory directory multiple />
+    <div class="space-x-2 mb-2">
+      <button id="upload-button" class="px-3 py-1 rounded bg-orange-600 text-white">Upload</button>
+      <button id="export-button" class="px-3 py-1 rounded bg-slate-600 text-white">Export All</button>
+      <button id="organized-button" class="px-3 py-1 rounded bg-slate-700 text-white">Organize</button>
+    </div>
+    <div id="file-tree" class="folder-tree text-sm"></div>
+    <div id="organized-tree" class="folder-tree text-sm mt-4"></div>
   </section>
 
-  <section>
-    <h2>Timeline</h2>
-    <textarea id="timeline-query" rows="2" cols="60" placeholder="Request events..."></textarea>
-    <button id="load-timeline">Load Timeline</button>
-    <div id="timeline"></div>
+  <section class="bg-slate-800 p-4 rounded mb-6">
+    <h2 class="text-lg font-medium mb-2">Timeline</h2>
+    <textarea id="timeline-query" rows="2" cols="60" class="w-full mb-2 p-2 rounded bg-slate-700" placeholder="Request events..."></textarea>
+    <button id="load-timeline" class="px-3 py-1 rounded bg-orange-600 text-white">Load Timeline</button>
+    <div id="timeline" class="mt-4"></div>
   </section>
 
-  <section>
-    <h2>Knowledge Graph</h2>
-    <div id="graph"></div>
+  <section class="bg-slate-800 p-4 rounded mb-6">
+    <h2 class="text-lg font-medium mb-2">Knowledge Graph</h2>
+    <div id="graph" class="mt-2"></div>
   </section>
 
   <div id="modal" onclick="this.style.display='none'">


### PR DESCRIPTION
## Summary
- add new `/dashboard` UI template with timeline, graph, and file upload widgets
- add lightweight browser script `dashboard.js` for API calls
- expose `/api/organized-files` endpoint for future categorization

## Testing
- `pytest -v tests/coded_tools/legal_discovery/test_knowledge_graph_manager.py` *(fails: RuntimeError: Failed to connect to Neo4j at bolt://localhost:7687)*

------
https://chatgpt.com/codex/tasks/task_e_6884fccb6c908333ad10961f20f77e2f