### PR TITLE
Fix compose and add legal discovery instructions

### DIFF
--- a/.env
+++ b/.env
@@ -78,3 +78,10 @@ GCP_LOCATION="<Location as in the GCP app>"
 BRAVE_API_KEY="YOUR_BRAVE_API_KEY"
 BRAVE_URL="https://api.search.brave.com/res/v1/web/search?q="
 BRAVE_TIMEOUT=30
+
+# Neo4j configuration
+# These values allow the app to connect to the Neo4j service defined in
+# docker-compose. Update the password as desired.
+NEO4J_URI=bolt://neo4j:7687
+NEO4J_USER=neo4j
+NEO4J_PASSWORD=please_change_me

--- a/.env.example
+++ b/.env.example
@@ -78,3 +78,10 @@ GCP_LOCATION="<Location as in the GCP app>"
 BRAVE_API_KEY="YOUR_BRAVE_API_KEY"
 BRAVE_URL="https://api.search.brave.com/res/v1/web/search?q="
 BRAVE_TIMEOUT=30
+
+# Neo4j configuration
+# Set these values so the application can connect to the Neo4j instance started
+# via docker-compose. The default URI points at the internal service name.
+NEO4J_URI=bolt://neo4j:7687
+NEO4J_USER=neo4j
+NEO4J_PASSWORD=please_change_me

--- a/apps/legal_discovery/README.md
+++ b/apps/legal_discovery/README.md
@@ -1,0 +1,37 @@
+# Legal Discovery Application
+
+This directory contains a Flask application that provides a simple UI for running
+Neuro SAN's legal discovery agent network.
+
+## Prerequisites
+
+- [Docker](https://docs.docker.com/get-docker/) and `docker-compose`
+- API keys configured in `.env`
+
+Make a copy of `.env.example` to `.env` and fill in the required values. In
+particular set a password for Neo4j:
+
+```bash
+cp .env.example .env  # if you haven't created one
+# then edit .env and set NEO4J_PASSWORD=your_password
+```
+
+## Running with Docker Compose
+
+From the project root run:
+
+```bash
+docker-compose build
+docker-compose up
+```
+
+This command starts three services:
+
+- **legal_discovery** – the Flask frontend exposed on <http://localhost:5001>
+- **neo4j** – graph database used by the app
+- **tesseract** – OCR engine
+
+Once the containers are running, open <http://localhost:5001> in a browser to
+use the UI.
+
+To stop the stack press `Ctrl+C` and run `docker-compose down`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       - neo4j_data:/data
 
   tesseract:
-    image: tesseractshadow/tesseract5-ocr
+    image: tesseractshadow/tesseract4re
     ports:
       - "5000:5000"
 


### PR DESCRIPTION
## Summary
- update `tesseract` image in docker-compose
- add Neo4j variables to `.env` files
- document how to start the legal discovery app with Docker Compose

## Testing
- `pip install -r requirements-build.txt`
- `pytest -q` *(fails: Couldn't connect to localhost:7687)*

------
https://chatgpt.com/codex/tasks/task_e_6885446215a88333a363eefd9339b6b9