### PR TITLE
Fix neuro_san import paths in legal discovery tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,3 +107,8 @@ echo "Setup complete. To activate the virtual environment, run 'source venv/bin/
 - Refined card grid layout and sticky nav for better UX
 - Created module AGENTS guide and logged tasks
 - Next: polish graphs and timeline exports
+
+## Update 2025-07-27T21:07Z
+- Fixed imports for CodedTool modules to use `neuro_san.interfaces.coded_tool`
+- Attempted installing requirements but network prevented completion
+- Next: rebuild Docker images and verify gunicorn now loads without ModuleNotFoundError

--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -20,3 +20,8 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 - Refined styles with responsive grid and sticky navigation.
 - Connected all controls to backend APIs via `dashboard.js`.
 - Next: enhance data visualisations for the knowledge graph and timeline.
+
+## Update 2025-07-27T21:07Z
+- Updated imports for legal discovery tools to match new neuro_san package layout
+- Install attempts failed due to network restrictions
+- Next: test the Flask app in Docker once dependencies are resolved

--- a/coded_tools/legal_discovery/case_management_tools.py
+++ b/coded_tools/legal_discovery/case_management_tools.py
@@ -1,5 +1,5 @@
 import schedule
-from neuro_san.coded_tool import CodedTool
+from neuro_san.interfaces.coded_tool import CodedTool
 
 
 class CaseManagementTools(CodedTool):

--- a/coded_tools/legal_discovery/code_editor.py
+++ b/coded_tools/legal_discovery/code_editor.py
@@ -1,5 +1,5 @@
 import os
-from neuro_san.coded_tool import CodedTool
+from neuro_san.interfaces.coded_tool import CodedTool
 
 class CodeEditor(CodedTool):
     def __init__(self, **kwargs):

--- a/coded_tools/legal_discovery/courtlistener_client.py
+++ b/coded_tools/legal_discovery/courtlistener_client.py
@@ -1,7 +1,7 @@
 import os
 
 import requests
-from neuro_san.coded_tool import CodedTool
+from neuro_san.interfaces.coded_tool import CodedTool
 
 
 class CourtListenerClient(CodedTool):

--- a/coded_tools/legal_discovery/document_drafter.py
+++ b/coded_tools/legal_discovery/document_drafter.py
@@ -1,5 +1,5 @@
 from docx import Document
-from neuro_san.coded_tool import CodedTool
+from neuro_san.interfaces.coded_tool import CodedTool
 
 
 class DocumentDrafter(CodedTool):

--- a/coded_tools/legal_discovery/document_modifier.py
+++ b/coded_tools/legal_discovery/document_modifier.py
@@ -1,5 +1,5 @@
 import fitz
-from neuro_san.coded_tool import CodedTool
+from neuro_san.interfaces.coded_tool import CodedTool
 
 
 class DocumentModifier(CodedTool):

--- a/coded_tools/legal_discovery/document_processor.py
+++ b/coded_tools/legal_discovery/document_processor.py
@@ -1,6 +1,6 @@
 import fitz  # PyMuPDF
 import pytesseract
-from neuro_san.coded_tool import CodedTool
+from neuro_san.interfaces.coded_tool import CodedTool
 from PIL import Image
 
 

--- a/coded_tools/legal_discovery/file_manager.py
+++ b/coded_tools/legal_discovery/file_manager.py
@@ -1,6 +1,6 @@
 import os
 
-from neuro_san.coded_tool import CodedTool
+from neuro_san.interfaces.coded_tool import CodedTool
 
 
 class FileManager(CodedTool):

--- a/coded_tools/legal_discovery/presentation_generator.py
+++ b/coded_tools/legal_discovery/presentation_generator.py
@@ -1,4 +1,4 @@
-from neuro_san.coded_tool import CodedTool
+from neuro_san.interfaces.coded_tool import CodedTool
 from pptx import Presentation
 from pptx.util import Inches
 

--- a/coded_tools/legal_discovery/subpoena_manager.py
+++ b/coded_tools/legal_discovery/subpoena_manager.py
@@ -1,5 +1,5 @@
 from docx import Document
-from neuro_san.coded_tool import CodedTool
+from neuro_san.interfaces.coded_tool import CodedTool
 
 
 class SubpoenaManager(CodedTool):

--- a/coded_tools/legal_discovery/task_tracker.py
+++ b/coded_tools/legal_discovery/task_tracker.py
@@ -1,6 +1,6 @@
 import os
 
-from neuro_san.coded_tool import CodedTool
+from neuro_san.interfaces.coded_tool import CodedTool
 
 
 class TaskTracker(CodedTool):

--- a/coded_tools/legal_discovery/vector_database_manager.py
+++ b/coded_tools/legal_discovery/vector_database_manager.py
@@ -1,5 +1,5 @@
 import chromadb
-from neuro_san.coded_tool import CodedTool
+from neuro_san.interfaces.coded_tool import CodedTool
 
 
 class VectorDatabaseManager(CodedTool):

--- a/coded_tools/legal_discovery/web_scraper.py
+++ b/coded_tools/legal_discovery/web_scraper.py
@@ -2,7 +2,7 @@ import os
 
 import requests
 from bs4 import BeautifulSoup
-from neuro_san.coded_tool import CodedTool
+from neuro_san.interfaces.coded_tool import CodedTool
 
 
 class WebScraper(CodedTool):


### PR DESCRIPTION
## Summary
- fix outdated `neuro_san.coded_tool` imports to use `neuro_san.interfaces.coded_tool`
- document work in AGENTS logs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for dotenv, neuro_san, neo4j)*

------
https://chatgpt.com/codex/tasks/task_e_6886942b6f54833386dae05d37f5c84a