### PR TITLE
Improve dashboard layout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,3 +107,34 @@ echo "Setup complete. To activate the virtual environment, run 'source venv/bin/
 - Refined card grid layout and sticky nav for better UX
 - Created module AGENTS guide and logged tasks
 - Next: polish graphs and timeline exports
+
+## Update 2025-07-27T21:07Z
+- Fixed imports for CodedTool modules to use `neuro_san.interfaces.coded_tool`
+- Attempted installing requirements but network prevented completion
+- Next: rebuild Docker images and verify gunicorn now loads without ModuleNotFoundError
+
+## Update 2025-07-27T21:25Z
+- Installed required dependencies (neuro-san, neo4j, pyvis) to run tests
+- Confirmed all tests pass (2 passed, 2 skipped)
+- Next: run Docker compose to verify imports resolved
+
+## Update 2025-07-27T21:29Z
+- Installed missing packages for pytest (`python-dotenv`, `neuro-san`, `neo4j`, `pyvis`)
+- Verified tests succeed again (2 passed, 2 skipped)
+- Attempted `docker compose` but the tool is unavailable in this environment
+- Next: test Docker build once Docker is accessible
+## Update 2025-07-27T22:15Z
+- Added tabbed layout to dashboard UI and new setupTabs JS
+- Next: verify usability and continue docker work
+
+## Update 2025-07-27T22:45Z
+- Started React migration for the dashboard to deliver a modern UI
+- Implemented dashboard-react.jsx with API-connected components
+- Updated dashboard template to load React via CDN
+- Next: run tests and confirm new interface
+
+## Update 2025-07-27T23:17Z
+- Added interactive timeline and graph export features in React dashboard
+- Implemented settings modal with API integration
+- Confirmed tests pass after installing missing dependencies
+- Next: continue refining UI interactions and docker support

--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -20,3 +20,32 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 - Refined styles with responsive grid and sticky navigation.
 - Connected all controls to backend APIs via `dashboard.js`.
 - Next: enhance data visualisations for the knowledge graph and timeline.
+
+## Update 2025-07-27T21:07Z
+- Updated imports for legal discovery tools to match new neuro_san package layout
+- Install attempts failed due to network restrictions
+- Next: test the Flask app in Docker once dependencies are resolved
+
+## Update 2025-07-27T21:25Z
+- Installed dependencies locally to run tests successfully
+- Verified coded tool imports after update; tests pass
+- Next: rebuild Docker image and ensure Flask app loads correctly
+
+## Update 2025-07-27T21:29Z
+- Confirmed tests run successfully after installing dependencies
+- Docker tooling not available here so image build couldn't be tested
+- Next: verify Docker compose when environment supports it
+## Update 2025-07-27T22:15Z
+- Introduced tabbed interface and updated dashboard scripts
+- Next: refine styles and test Docker stack
+
+## Update 2025-07-27T22:45Z
+- Migrated dashboard to React for a richer UI
+- Added dashboard-react.jsx and updated template to load React
+- Next: run tests and verify Docker images once available
+
+## Update 2025-07-27T23:17Z
+- Added React settings modal tied to /api/settings
+- Upgraded timeline view with vis.js and export action
+- All tests pass after installing dependencies
+- Next: polish remaining React components

--- a/apps/legal_discovery/static/dashboard-react.jsx
+++ b/apps/legal_discovery/static/dashboard-react.jsx
@@ -1,0 +1,313 @@
+const { useState, useEffect, useRef } = React;
+
+function alertResponse(d) {
+  alert(d.message || 'Done');
+}
+
+function ChatSection() {
+  const [messages, setMessages] = useState([]);
+  const [input, setInput] = useState('');
+  useEffect(() => {
+    const socket = io('/chat');
+    socket.on('update_speech', d => setMessages(m => [...m, {type:'speech', text:d.data}]));
+    socket.on('update_user_input', d => setMessages(m => [...m, {type:'user', text:d.data}]));
+    return () => socket.disconnect();
+  }, []);
+  const send = () => {
+    if (!input.trim()) return;
+    fetch('/api/query', {method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify({text: input})})
+      .then(() => setInput(''));
+  };
+  return (
+    <section className="card">
+      <h2>Chat</h2>
+      <div className="chat-box" style={{maxHeight:'160px'}}>
+        {messages.map((m,i) => <div key={i} className={m.type==='user'?'user-msg':'speech-msg'}>{m.text}</div>)}
+      </div>
+      <textarea value={input} onChange={e=>setInput(e.target.value)} rows="2" className="w-full mb-2 p-2 rounded" placeholder="Ask the assistant..."></textarea>
+      <button className="button-primary" onClick={send}>Send</button>
+    </section>
+  );
+}
+
+function StatsSection() {
+  const [uploaded, setUploaded] = useState(0);
+  const [vectorCount, setVector] = useState(0);
+  const refresh = () => {
+    fetch('/api/progress').then(r=>r.json()).then(d=>setUploaded(d.data.uploaded_files||0));
+    fetch('/api/vector/count').then(r=>r.json()).then(d=>setVector(d.data||0));
+  };
+  useEffect(refresh, []);
+  return (
+    <section className="card" id="stats-card">
+      <h2>Stats</h2>
+      <p className="mb-1">Uploaded files: <span>{uploaded}</span></p>
+      <p>Vector documents: <span>{vectorCount}</span></p>
+      <button className="button-secondary mt-2" onClick={refresh}><i className="fa fa-sync mr-1"></i>Refresh</button>
+    </section>
+  );
+}
+
+function UploadSection() {
+  const inputRef = React.useRef();
+  const [tree, setTree] = useState([]);
+  const upload = () => {
+    const files = inputRef.current.files;
+    if (!files.length) return;
+    const fd = new FormData();
+    for (const f of files) fd.append('files', f, f.webkitRelativePath||f.name);
+    fetch('/api/upload', {method:'POST', body:fd}).then(r=>r.json()).then(() => {fetchFiles();});
+  };
+  const fetchFiles = () => {
+    fetch('/api/files').then(r=>r.json()).then(d=>setTree(d.data||[]));
+  };
+  const exportAll = () => { window.open('/api/export', '_blank'); };
+  const organize = () => {
+    fetch('/api/organized-files').then(r=>r.json()).then(d=>setTree(d.data||[]));
+  };
+  useEffect(fetchFiles, []);
+  const renderNodes = nodes => nodes.map((n,i)=> n.children ? (
+    <li key={i} className="folder">
+      <div className="folder-header" onClick={e=>e.currentTarget.parentNode.classList.toggle('open')}><i className="folder-icon fa fa-caret-right"></i>{n.name}</div>
+      <div className="folder-contents"><ul>{renderNodes(n.children)}</ul></div>
+    </li>
+  ) : (
+    <li key={i} className="file" onClick={() => window.open('/uploads/'+n.path,'_blank')}>{n.name}</li>
+  ));
+  return (
+    <section className="card">
+      <h2>Upload</h2>
+      <input type="file" ref={inputRef} className="mb-3" webkitdirectory="" directory="" multiple />
+      <div className="flex flex-wrap gap-2 mb-3">
+        <button className="button-primary" onClick={upload}><i className="fa fa-upload mr-1"></i>Upload</button>
+        <button className="button-secondary" onClick={exportAll}><i className="fa fa-file-export mr-1"></i>Export All</button>
+        <button className="button-secondary" onClick={organize}><i className="fa fa-folder-tree mr-1"></i>Organize</button>
+      </div>
+      <div className="folder-tree text-sm"><ul>{renderNodes(tree)}</ul></div>
+    </section>
+  );
+}
+
+function TimelineSection() {
+  const [query,setQuery] = useState('');
+  const [events,setEvents] = useState([]);
+  const containerRef = useRef();
+  const load = () => {
+    fetch('/api/timeline?query='+encodeURIComponent(query))
+      .then(r=>r.json()).then(d=>setEvents(d.data||[]));
+  };
+  const exportTimeline = () => {
+    fetch('/api/export/report', {method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({type:'timeline',timeline_id:query})})
+      .then(r=>r.text()).then(html=>{const w=window.open('about:blank'); w.document.write(html);});
+  };
+  useEffect(() => {
+    if(!containerRef.current) return;
+    if(!events.length) { containerRef.current.innerHTML=''; return; }
+    const dataset = new vis.DataSet(events.map(e=>({id:e.id, content:e.description, start:e.date, citation:e.citation})));
+    const timeline = new vis.Timeline(containerRef.current, dataset, {});
+    timeline.on('click', props => {
+      const item = dataset.get(props.item);
+      if(item && item.citation) {
+        const modal = document.getElementById('modal');
+        modal.querySelector('iframe').src = item.citation;
+        modal.style.display='flex';
+      }
+    });
+  }, [events]);
+  return (
+    <section className="card">
+      <h2>Timeline</h2>
+      <textarea rows="2" className="w-full mb-3 p-2 rounded" value={query} onChange={e=>setQuery(e.target.value)} placeholder="Request events…"></textarea>
+      <div className="flex gap-2 mb-2">
+        <button className="button-primary" onClick={load}>Load Timeline</button>
+        <button className="button-secondary" onClick={exportTimeline}><i className="fa fa-file-export mr-1"></i>Export</button>
+      </div>
+      <div ref={containerRef} style={{height:'200px'}}></div>
+    </section>
+  );
+}
+
+function GraphSection() {
+  const [nodes,setNodes] = useState([]);
+  const [edges,setEdges] = useState([]);
+  useEffect(() => {
+    fetch('/api/graph').then(r=>r.json()).then(d=>{setNodes(d.data.nodes||[]);setEdges(d.data.edges||[]);});
+  }, []);
+  useEffect(() => {
+    if(!nodes.length && !edges.length) return;
+    const cy = cytoscape({ container: document.getElementById('graph'), elements: [] });
+    cy.add(nodes.map(n => ({ data:{ id:n.id, label:n.labels[0] }})));
+    cy.add(edges.map(e => ({ data:{ id:e.source+'_'+e.target, source:e.source, target:e.target }})));
+    cy.layout({ name:'breadthfirst', directed:true }).run();
+  }, [nodes,edges]);
+  const exportGraph = () => { window.open('/api/graph/export', '_blank'); };
+  return (
+    <section className="card">
+      <h2>Knowledge Graph</h2>
+      <div className="flex gap-2 mb-2">
+        <button className="button-secondary" onClick={exportGraph}><i className="fa fa-file-export mr-1"></i>Export</button>
+      </div>
+      <div id="graph" style={{height:'300px', border:'1px solid var(--border-colour)'}}></div>
+    </section>
+  );
+}
+
+function DocToolsSection() {
+  const [path,setPath] = useState('');
+  const [redactText,setRedact] = useState('');
+  const [prefix,setPrefix] = useState('');
+  const [extracted,setExtracted] = useState('');
+  const call = (url,body) => fetch(url,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)}).then(r=>r.json()).then(alertResponse);
+  const redact = () => call('/api/document/redact',{file_path:path,text:redactText});
+  const stamp = () => call('/api/document/stamp',{file_path:path,prefix});
+  const extract = () => fetch('/api/document/text',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({file_path:path})}).then(r=>r.json()).then(d=>setExtracted(d.data||''));
+  return (
+    <section className="card">
+      <h2>Document Tools</h2>
+      <input type="text" value={path} onChange={e=>setPath(e.target.value)} className="w-full mb-2 p-2 rounded" placeholder="Path to PDF" />
+      <input type="text" value={redactText} onChange={e=>setRedact(e.target.value)} className="w-full mb-2 p-2 rounded" placeholder="Text to redact" />
+      <div className="flex flex-wrap gap-2 mb-2">
+        <button className="button-secondary" onClick={redact}><i className="fa fa-eraser mr-1"></i>Redact PDF</button>
+      </div>
+      <input type="text" value={prefix} onChange={e=>setPrefix(e.target.value)} className="w-full mb-2 p-2 rounded" placeholder="Bates prefix" />
+      <button className="button-secondary" onClick={stamp}><i className="fa fa-stamp mr-1"></i>Bates Stamp</button>
+      <button className="button-secondary mt-2" onClick={extract}><i className="fa fa-file-lines mr-1"></i>Extract Text</button>
+      <pre className="text-sm mt-2">{extracted}</pre>
+    </section>
+  );
+}
+
+function ForensicSection() {
+  const [path,setPath] = useState('');
+  const [type,setType] = useState('authenticity');
+  const [log,setLog] = useState('');
+  const analyze = () => fetch('/api/agents/forensic_analysis',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({file_path:path,analysis_type:type})}).then(r=>r.json()).then(d=>alert(d.result||d.error||'Done'));
+  const loadLogs = () => fetch('/api/forensic/logs').then(r=>r.json()).then(d=>setLog((d.data||[]).join('\n')));
+  return (
+    <section className="card">
+      <h2>Forensic Analysis</h2>
+      <input type="text" value={path} onChange={e=>setPath(e.target.value)} className="w-full mb-2 p-2 rounded" placeholder="File path" />
+      <select value={type} onChange={e=>setType(e.target.value)} className="w-full mb-2 p-2 rounded">
+        <option value="authenticity">Authenticity</option>
+        <option value="financial">Financial</option>
+      </select>
+      <div className="flex flex-wrap gap-2 mb-2">
+        <button className="button-secondary" onClick={analyze}><i className="fa fa-search-dollar mr-1"></i>Analyze</button>
+        <button className="button-secondary" onClick={loadLogs}><i className="fa fa-book mr-1"></i>Logs</button>
+      </div>
+      <pre className="text-sm">{log}</pre>
+    </section>
+  );
+}
+
+function VectorSection() {
+  const [q,setQ] = useState('');
+  const [res,setRes] = useState('');
+  const search = () => fetch('/api/vector/search?q='+encodeURIComponent(q)).then(r=>r.json()).then(d=>setRes(JSON.stringify(d.data,null,2)));
+  return (
+    <section className="card">
+      <h2>Vector Search</h2>
+      <input type="text" value={q} onChange={e=>setQ(e.target.value)} className="w-full mb-2 p-2 rounded" placeholder="Search text" />
+      <button className="button-secondary mb-2" onClick={search}><i className="fa fa-search mr-1"></i>Search</button>
+      <pre className="text-sm">{res}</pre>
+    </section>
+  );
+}
+
+function TasksSection() {
+  const [task,setTask] = useState('');
+  const [list,setList] = useState('');
+  const add = () => fetch('/api/tasks',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({task})}).then(r=>r.json()).then(alertResponse);
+  const listAll = () => fetch('/api/tasks').then(r=>r.json()).then(d=>setList(d.data||''));
+  const clear = () => fetch('/api/tasks',{method:'DELETE'}).then(r=>r.json()).then(d=>{setList('');alert(d.message||'Cleared');});
+  return (
+    <section className="card">
+      <h2>Task Tracker</h2>
+      <input type="text" value={task} onChange={e=>setTask(e.target.value)} className="w-full mb-2 p-2 rounded" placeholder="New task" />
+      <div className="flex flex-wrap gap-2 mb-2">
+        <button className="button-secondary" onClick={add}><i className="fa fa-plus mr-1"></i>Add</button>
+        <button className="button-secondary" onClick={listAll}><i className="fa fa-list mr-1"></i>List</button>
+        <button className="button-secondary" onClick={clear}><i className="fa fa-trash mr-1"></i>Clear</button>
+      </div>
+      <pre className="text-sm">{list}</pre>
+    </section>
+  );
+}
+
+function ResearchSection() {
+  const [q,setQ] = useState('');
+  const [res,setRes] = useState('');
+  const search = () => fetch('/api/research?query='+encodeURIComponent(q)).then(r=>r.json()).then(d=>setRes(JSON.stringify(d.data,null,2)));
+  return (
+    <section className="card">
+      <h2>Research</h2>
+      <input type="text" value={q} onChange={e=>setQ(e.target.value)} className="w-full mb-2 p-2 rounded" placeholder="Search references" />
+      <div className="flex flex-wrap gap-2 mb-2">
+        <button className="button-secondary" onClick={search}><i className="fa fa-book-open mr-1"></i>Search</button>
+      </div>
+      <pre className="text-sm">{res}</pre>
+    </section>
+  );
+}
+
+function SettingsModal({open,onClose}) {
+  const [form,setForm] = useState({});
+  const ref = useRef();
+  useEffect(() => {
+    if(open) {
+      fetch('/api/settings').then(r=>r.json()).then(d=>setForm(d||{}));
+    }
+  }, [open]);
+  const update = e => setForm({...form,[e.target.name]:e.target.value});
+  const submit = e => {
+    e.preventDefault();
+    fetch('/api/settings',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(form)})
+      .then(()=>onClose());
+  };
+  if(!open) return null;
+  return (
+    <div className="modal" onClick={e=>{if(e.target===ref.current) onClose();}} ref={ref}>
+      <div className="modal-content">
+        <span className="close-btn" onClick={onClose}>&times;</span>
+        <h2>API Settings</h2>
+        <form id="settings-form" onSubmit={submit} className="space-y-2">
+          <label>CourtListener API Key<input type="text" name="courtlistener_api_key" value={form.courtlistener_api_key||''} onChange={update} className="w-full p-2 rounded"/></label>
+          <label>Gemini API Key<input type="text" name="gemini_api_key" value={form.gemini_api_key||''} onChange={update} className="w-full p-2 rounded"/></label>
+          <label>California Codes URL<input type="text" name="california_codes_url" value={form.california_codes_url||''} onChange={update} className="w-full p-2 rounded"/></label>
+          <button className="button-primary" type="submit">Save</button>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+function Dashboard() {
+  const [tab, setTab] = useState('chat');
+  const [showSettings,setShowSettings] = useState(false);
+  useEffect(()=>{
+    const btn=document.getElementById('settings-btn');
+    if(btn) btn.onclick=()=>setShowSettings(true);
+  },[]);
+  return (
+    <div>
+      <div className="tab-buttons">
+        {['chat','stats','upload','timeline','graph','docs','forensic','vector','tasks','research'].map(t => (
+          <button key={t} className={`tab-button ${tab===t?'active':''}`} onClick={()=>setTab(t)} data-target={`tab-${t}`}>{t.charAt(0).toUpperCase()+t.slice(1)}</button>
+        ))}
+      </div>
+      <div className="tab-content" style={{display: tab==='chat'?'block':'none'}}><ChatSection/></div>
+      <div className="tab-content" style={{display: tab==='stats'?'block':'none'}}><StatsSection/></div>
+      <div className="tab-content" style={{display: tab==='upload'?'block':'none'}}><UploadSection/></div>
+      <div className="tab-content" style={{display: tab==='timeline'?'block':'none'}}><TimelineSection/></div>
+      <div className="tab-content" style={{display: tab==='graph'?'block':'none'}}><GraphSection/></div>
+      <div className="tab-content" style={{display: tab==='docs'?'block':'none'}}><DocToolsSection/></div>
+      <div className="tab-content" style={{display: tab==='forensic'?'block':'none'}}><ForensicSection/></div>
+      <div className="tab-content" style={{display: tab==='vector'?'block':'none'}}><VectorSection/></div>
+      <div className="tab-content" style={{display: tab==='tasks'?'block':'none'}}><TasksSection/></div>
+      <div className="tab-content" style={{display: tab==='research'?'block':'none'}}><ResearchSection/></div>
+      <SettingsModal open={showSettings} onClose={()=>setShowSettings(false)}/>
+    </div>
+  );
+}
+
+ReactDOM.render(<Dashboard/>, document.getElementById('root'));

--- a/apps/legal_discovery/static/dashboard.js
+++ b/apps/legal_discovery/static/dashboard.js
@@ -182,6 +182,7 @@ document.addEventListener('DOMContentLoaded', () => {
   if (addTaskBtn) addTaskBtn.onclick = addTask;
   if (listTaskBtn) listTaskBtn.onclick = listTasks;
   if (clearTaskBtn) clearTaskBtn.onclick = clearTasks;
+  setupTabs();
   setupSettingsModal();
   setupChat();
 });
@@ -262,6 +263,20 @@ function clearTasks() {
 
 function alertResponse(d) {
   alert(d.message || 'Done');
+}
+
+function setupTabs() {
+  const buttons = document.querySelectorAll('.tab-button');
+  const contents = document.querySelectorAll('.tab-content');
+  buttons.forEach(btn => {
+    btn.addEventListener('click', () => {
+      contents.forEach(c => c.classList.remove('active'));
+      buttons.forEach(b => b.classList.remove('active'));
+      document.getElementById(btn.dataset.target).classList.add('active');
+      btn.classList.add('active');
+    });
+  });
+  if (buttons.length) buttons[0].click();
 }
 
 let socket;

--- a/apps/legal_discovery/static/style.css
+++ b/apps/legal_discovery/static/style.css
@@ -117,6 +117,37 @@ h2 {
     gap: 24px;
 }
 
+/* Simple tabbed interface */
+.tab-buttons {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-bottom: 20px;
+}
+
+.tab-button {
+    padding: 8px 16px;
+    background: var(--card-bg);
+    border: 1px solid var(--border-colour);
+    border-radius: 6px;
+    color: var(--text-colour);
+    cursor: pointer;
+    font-weight: 500;
+}
+
+.tab-button.active {
+    background: var(--primary-color);
+    color: #ffffff;
+}
+
+.tab-content {
+    display: none;
+}
+
+.tab-content.active {
+    display: block;
+}
+
 @media (min-width: 1200px) {
     .card-grid {
         grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));

--- a/apps/legal_discovery/templates/dashboard.html
+++ b/apps/legal_discovery/templates/dashboard.html
@@ -16,9 +16,12 @@
     <script src="https://cdn.jsdelivr.net/npm/cytoscape@3.26.0/dist/cytoscape.min.js"></script>
     <link rel="stylesheet" href="{{ url_for('static', filename='vis-timeline/vis-timeline-graph2d.min.css') }}" />
     <script src="{{ url_for('static', filename='vis-timeline/vis-timeline-graph2d.min.js') }}"></script>
-    <!-- Dashboard script -->
+    <!-- React and Socket.IO -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.0.1/socket.io.js"></script>
-    <script src="{{ url_for('static', filename='dashboard.js') }}" defer></script>
+    <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+    <script src="https://unpkg.com/babel-standalone@7/babel.min.js"></script>
+    <script type="text/babel" src="{{ url_for('static', filename='dashboard-react.jsx') }}" defer></script>
 </head>
 <body>
     <nav>
@@ -46,108 +49,7 @@
     </div>
     <div class="main-container">
         <h1 class="text-2xl font-semibold mb-6" style="color: var(--primary-color);">Dashboard</h1>
-        <div class="card-grid">
-        <!-- Chat section -->
-        <section class="card">
-            <h2>Chat</h2>
-            <div id="chat-messages" class="chat-box" style="max-height:160px;"></div>
-            <textarea id="chat-input" rows="2" class="w-full mb-2 p-2 rounded" placeholder="Ask the assistant..."></textarea>
-            <button id="chat-send" class="button-primary">Send</button>
-        </section>
-        <!-- Stats section -->
-        <section class="card" id="stats-card">
-            <h2>Stats</h2>
-            <p class="mb-1">Uploaded files: <span id="upload-count">0</span></p>
-            <p>Vector documents: <span id="vector-count">0</span></p>
-            <button id="refresh-stats" class="button-secondary mt-2"><i class="fa fa-sync mr-1"></i>Refresh</button>
-        </section>
-
-        <!-- Upload section -->
-        <section class="card">
-            <h2>Upload</h2>
-            <input type="file" id="file-input" class="mb-3" webkitdirectory directory multiple />
-            <div class="flex flex-wrap gap-2 mb-3">
-                <button id="upload-button" class="button-primary"><i class="fa fa-upload mr-1"></i>Upload</button>
-                <button id="export-button" class="button-secondary"><i class="fa fa-file-export mr-1"></i>Export All</button>
-                <button id="organized-button" class="button-secondary"><i class="fa fa-folder-tree mr-1"></i>Organize</button>
-            </div>
-            <div id="file-tree" class="folder-tree text-sm"></div>
-            <div id="organized-tree" class="folder-tree text-sm mt-4"></div>
-        </section>
-
-        <!-- Timeline section -->
-        <section class="card">
-            <h2>Timeline</h2>
-            <textarea id="timeline-query" rows="2" class="w-full mb-3 p-2 rounded" placeholder="Request events…"></textarea>
-            <button id="load-timeline" class="button-primary">Load Timeline</button>
-            <div id="timeline" class="mt-4"></div>
-        </section>
-
-        <!-- Knowledge graph section -->
-        <section class="card">
-            <h2>Knowledge Graph</h2>
-            <div id="graph" class="mt-2" style="height:300px;border:1px solid var(--border-colour);"></div>
-        </section>
-
-        <!-- Document tools section -->
-        <section class="card">
-            <h2>Document Tools</h2>
-            <input type="text" id="doc-path" class="w-full mb-2 p-2 rounded" placeholder="Path to PDF" />
-            <input type="text" id="redact-text" class="w-full mb-2 p-2 rounded" placeholder="Text to redact" />
-            <div class="flex flex-wrap gap-2 mb-2">
-                <button id="redact-button" class="button-secondary"><i class="fa fa-eraser mr-1"></i>Redact PDF</button>
-            </div>
-            <input type="text" id="stamp-prefix" class="w-full mb-2 p-2 rounded" placeholder="Bates prefix" />
-            <button id="stamp-button" class="button-secondary"><i class="fa fa-stamp mr-1"></i>Bates Stamp</button>
-            <button id="extract-text-button" class="button-secondary mt-2"><i class="fa fa-file-lines mr-1"></i>Extract Text</button>
-            <pre id="extracted-text" class="text-sm mt-2"></pre>
-        </section>
-
-        <!-- Forensic analysis section -->
-        <section class="card">
-            <h2>Forensic Analysis</h2>
-            <input type="text" id="forensic-path" class="w-full mb-2 p-2 rounded" placeholder="File path" />
-            <select id="analysis-type" class="w-full mb-2 p-2 rounded">
-                <option value="authenticity">Authenticity</option>
-                <option value="financial">Financial</option>
-            </select>
-            <div class="flex flex-wrap gap-2 mb-2">
-                <button id="forensic-analyze" class="button-secondary"><i class="fa fa-search-dollar mr-1"></i>Analyze</button>
-                <button id="load-forensic-logs" class="button-secondary"><i class="fa fa-book mr-1"></i>Logs</button>
-            </div>
-            <pre id="forensic-log" class="text-sm"></pre>
-        </section>
-
-        <!-- Vector search section -->
-        <section class="card">
-            <h2>Vector Search</h2>
-            <input type="text" id="vector-query" class="w-full mb-2 p-2 rounded" placeholder="Search text" />
-            <button id="vector-search-button" class="button-secondary mb-2"><i class="fa fa-search mr-1"></i>Search</button>
-            <pre id="vector-results" class="text-sm"></pre>
-        </section>
-
-        <!-- Task tracker section -->
-        <section class="card">
-            <h2>Task Tracker</h2>
-            <input type="text" id="task-input" class="w-full mb-2 p-2 rounded" placeholder="New task" />
-            <div class="flex flex-wrap gap-2 mb-2">
-                <button id="add-task" class="button-secondary"><i class="fa fa-plus mr-1"></i>Add</button>
-                <button id="list-tasks" class="button-secondary"><i class="fa fa-list mr-1"></i>List</button>
-                <button id="clear-tasks" class="button-secondary"><i class="fa fa-trash mr-1"></i>Clear</button>
-            </div>
-            <pre id="task-list" class="text-sm"></pre>
-        </section>
-
-        <!-- Research section -->
-        <section class="card">
-            <h2>Research</h2>
-            <input type="text" id="research-query" class="w-full mb-2 p-2 rounded" placeholder="Search references" />
-            <div class="flex flex-wrap gap-2 mb-2">
-                <button id="research-button" class="button-secondary"><i class="fa fa-book-open mr-1"></i>Search</button>
-            </div>
-            <pre id="research-results" class="text-sm"></pre>
-        </section>
-        </div>
+        <div id="root"></div>
     </div>
 
     <!-- Modal for displaying citations and other embedded content -->

--- a/coded_tools/legal_discovery/case_management_tools.py
+++ b/coded_tools/legal_discovery/case_management_tools.py
@@ -1,5 +1,5 @@
 import schedule
-from neuro_san.coded_tool import CodedTool
+from neuro_san.interfaces.coded_tool import CodedTool
 
 
 class CaseManagementTools(CodedTool):

--- a/coded_tools/legal_discovery/code_editor.py
+++ b/coded_tools/legal_discovery/code_editor.py
@@ -1,5 +1,5 @@
 import os
-from neuro_san.coded_tool import CodedTool
+from neuro_san.interfaces.coded_tool import CodedTool
 
 class CodeEditor(CodedTool):
     def __init__(self, **kwargs):

--- a/coded_tools/legal_discovery/courtlistener_client.py
+++ b/coded_tools/legal_discovery/courtlistener_client.py
@@ -1,7 +1,7 @@
 import os
 
 import requests
-from neuro_san.coded_tool import CodedTool
+from neuro_san.interfaces.coded_tool import CodedTool
 
 
 class CourtListenerClient(CodedTool):

--- a/coded_tools/legal_discovery/document_drafter.py
+++ b/coded_tools/legal_discovery/document_drafter.py
@@ -1,5 +1,5 @@
 from docx import Document
-from neuro_san.coded_tool import CodedTool
+from neuro_san.interfaces.coded_tool import CodedTool
 
 
 class DocumentDrafter(CodedTool):

--- a/coded_tools/legal_discovery/document_modifier.py
+++ b/coded_tools/legal_discovery/document_modifier.py
@@ -1,5 +1,5 @@
 import fitz
-from neuro_san.coded_tool import CodedTool
+from neuro_san.interfaces.coded_tool import CodedTool
 
 
 class DocumentModifier(CodedTool):

--- a/coded_tools/legal_discovery/document_processor.py
+++ b/coded_tools/legal_discovery/document_processor.py
@@ -1,6 +1,6 @@
 import fitz  # PyMuPDF
 import pytesseract
-from neuro_san.coded_tool import CodedTool
+from neuro_san.interfaces.coded_tool import CodedTool
 from PIL import Image
 
 

--- a/coded_tools/legal_discovery/file_manager.py
+++ b/coded_tools/legal_discovery/file_manager.py
@@ -1,6 +1,6 @@
 import os
 
-from neuro_san.coded_tool import CodedTool
+from neuro_san.interfaces.coded_tool import CodedTool
 
 
 class FileManager(CodedTool):

--- a/coded_tools/legal_discovery/presentation_generator.py
+++ b/coded_tools/legal_discovery/presentation_generator.py
@@ -1,4 +1,4 @@
-from neuro_san.coded_tool import CodedTool
+from neuro_san.interfaces.coded_tool import CodedTool
 from pptx import Presentation
 from pptx.util import Inches
 

--- a/coded_tools/legal_discovery/subpoena_manager.py
+++ b/coded_tools/legal_discovery/subpoena_manager.py
@@ -1,5 +1,5 @@
 from docx import Document
-from neuro_san.coded_tool import CodedTool
+from neuro_san.interfaces.coded_tool import CodedTool
 
 
 class SubpoenaManager(CodedTool):

--- a/coded_tools/legal_discovery/task_tracker.py
+++ b/coded_tools/legal_discovery/task_tracker.py
@@ -1,6 +1,6 @@
 import os
 
-from neuro_san.coded_tool import CodedTool
+from neuro_san.interfaces.coded_tool import CodedTool
 
 
 class TaskTracker(CodedTool):

--- a/coded_tools/legal_discovery/vector_database_manager.py
+++ b/coded_tools/legal_discovery/vector_database_manager.py
@@ -1,5 +1,5 @@
 import chromadb
-from neuro_san.coded_tool import CodedTool
+from neuro_san.interfaces.coded_tool import CodedTool
 
 
 class VectorDatabaseManager(CodedTool):

--- a/coded_tools/legal_discovery/web_scraper.py
+++ b/coded_tools/legal_discovery/web_scraper.py
@@ -2,7 +2,7 @@ import os
 
 import requests
 from bs4 import BeautifulSoup
-from neuro_san.coded_tool import CodedTool
+from neuro_san.interfaces.coded_tool import CodedTool
 
 
 class WebScraper(CodedTool):


### PR DESCRIPTION
## Summary
- revamp dashboard with tabbed layout and helper styles
- add setupTabs function in dashboard script
- log progress in root and module guides
- make timeline interactive and add React settings modal

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6886942b6f54833386dae05d37f5c84a