### PR TITLE
fix: ensure legal discovery frontend serves build

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -405,3 +405,8 @@ echo "Setup complete. To activate the virtual environment, run 'source venv/bin/
 - Added Agent Network tab with team cards in React UI
 - Documented standalone startup steps and expanded memory_bank
 - Next: verify container startup with new defaults
+
+## Update 2025-08-02T22:08Z
+- Added missing rfc3987 dependency for Chromadb startup
+- Converted Flask imports to absolute paths so gunicorn serves the UI
+- Next: ensure frontend build assets are referenced consistently

--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -307,3 +307,8 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 - Updated defaults to use manifest.hocon for local runs
 - Rebuilt bundle and confirmed tests pass
 - Next: test docker-compose build when available
+
+## Update 2025-08-02T22:08Z
+- Added rfc3987 dependency and switched Flask imports to absolute paths
+- Verified gunicorn serves bundle.js and main.css after build
+- Next: audit dashboard for missing stylesheet references

--- a/apps/legal_discovery/interface_flask.py
+++ b/apps/legal_discovery/interface_flask.py
@@ -21,9 +21,9 @@ from apps.legal_discovery.legal_discovery import (
     tear_down_legal_discovery_assistant,
 )
 
-from . import settings
-from .database import db
-from .models import (
+from apps.legal_discovery import settings
+from apps.legal_discovery.database import db
+from apps.legal_discovery.models import (
     Case,
     Document,
     LegalReference,

--- a/apps/legal_discovery/requirements.txt
+++ b/apps/legal_discovery/requirements.txt
@@ -10,6 +10,7 @@ PyMuPDF
 pytesseract
 PyPDF2
 chromadb
+rfc3987
 neo4j
 requests
 pandas

--- a/requirements.txt
+++ b/requirements.txt
@@ -54,6 +54,7 @@ PyMuPDF
 pytesseract
 PyPDF2
 chromadb
+rfc3987
 neo4j
 requests
 pandas


### PR DESCRIPTION
## Summary
- add `rfc3987` dependency so Chromadb and jsonschema load
- switch Flask imports to absolute paths for gunicorn compatibility
- document progress in AGENTS logs

## Testing
- `npm --prefix apps/legal_discovery run build --silent`
- `pytest -q`
- `curl -I http://localhost:5001/`
- `curl -I http://localhost:5001/static/bundle.js`


------
https://chatgpt.com/codex/tasks/task_e_688e850d9d648333b5eafe2c640500f6