### PR TITLE
feat: apply glassy alien warship theme

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -488,3 +488,8 @@ echo "Setup complete. To activate the virtual environment, run 'source venv/bin/
 - Hardened file ingestion with explicit termination and skip logging for files exceeding 30s
 - Shifted UI palette toward smoky greys with translucent glass panels
 - Next: audit skipped_uploads.log for recurring file issues and polish remaining grey theme elements
+
+## Update 2025-08-03T17:30Z
+- Overhauled dashboard and timeline with a glassy neon-blue "alien warship" theme
+- Introduced shared design tokens via CSS variables, React `theme.js` and Figma export
+- Next: extend token usage across all components and confirm Docker build serves new assets

--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -391,3 +391,8 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 - Logged skipped uploads and enforced 30s kill switches so hung files no longer freeze batches
 - Restyled dashboard with smoky glass greys and backdrop blur for a spaceship-like feel
 - Next: surface skip reasons in UI and tighten grey theme across components
+
+## Update 2025-08-03T17:30Z
+- Applied alien warship glass theme with neon accents across dashboard and timeline
+- Added reusable design tokens (`theme.js`, `figma_tokens.json`) for UI expansion
+- Next: integrate tokens into remaining React components and verify Docker styling

--- a/apps/legal_discovery/figma_tokens.json
+++ b/apps/legal_discovery/figma_tokens.json
@@ -1,0 +1,17 @@
+{
+  "color": {
+    "bg": { "value": "#000000" },
+    "bgAlt": { "value": "#0b0f1a" },
+    "surface": { "value": "rgba(15,23,42,0.6)" },
+    "accent": { "value": "#00e5ff" },
+    "text": { "value": "#e5e7eb" },
+    "textMuted": { "value": "#9ca3af" }
+  },
+  "effect": {
+    "glow": { "value": "0 0 8px #00e5ff" },
+    "glassBlur": { "value": "12px" }
+  },
+  "font": {
+    "base": { "value": "Rajdhani" }
+  }
+}

--- a/apps/legal_discovery/index.html
+++ b/apps/legal_discovery/index.html
@@ -3,6 +3,8 @@
   <head>
     <meta charset="UTF-8" />
     <title>Legal Discovery Dashboard</title>
+    <link href="https://fonts.googleapis.com/css2?family=Rajdhani:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="./static/style.css">
   </head>
   <body>
     <div id="root"></div>

--- a/apps/legal_discovery/src/components/MetricCard.jsx
+++ b/apps/legal_discovery/src/components/MetricCard.jsx
@@ -1,11 +1,14 @@
 import React from "react";
+import { theme } from "../theme";
+
 function MetricCard({ icon, label, value }) {
   return (
     <div className="metric-card">
-      <i className={`fa ${icon} text-xl mb-1`}></i>
+      <i className={`fa ${icon} text-xl mb-1`} style={{ color: theme.colors.accent }}></i>
       <span className="value">{value}</span>
       <span className="label">{label}</span>
     </div>
   );
 }
+
 export default MetricCard;

--- a/apps/legal_discovery/src/theme.js
+++ b/apps/legal_discovery/src/theme.js
@@ -1,0 +1,17 @@
+export const theme = {
+  colors: {
+    background: 'var(--color-bg)',
+    surface: 'var(--color-surface)',
+    accent: 'var(--color-accent)',
+    text: 'var(--color-text)',
+    textMuted: 'var(--color-text-muted)',
+    border: 'var(--color-border)'
+  },
+  effects: {
+    glow: '0 0 8px var(--color-accent-glow)',
+    glass: 'blur(var(--glass-blur))'
+  },
+  fonts: {
+    base: 'var(--font-base)'
+  }
+};

--- a/apps/legal_discovery/static/css/folder-tree.css
+++ b/apps/legal_discovery/static/css/folder-tree.css
@@ -1,6 +1,7 @@
 .folder-tree {
-  font-family: Arial, sans-serif;
+  font-family: var(--font-base, Arial, sans-serif);
   max-width: 300px;
+  color: var(--text-colour);
 }
 
 .folder-tree .folder {
@@ -17,12 +18,13 @@
 .folder-tree .folder-icon {
   margin-right: 0.5em;
   transition: transform 0.2s ease-in-out, color 0.2s ease;
-  color: #f1c40f;      /* gold when closed */
+  color: var(--color-accent);
   font-size: 1.2em;
 }
 
 .folder-tree .folder.open .folder-icon {
-  color: #f39c12;      /* darker gold when open */
+  color: var(--color-accent);
+  filter: brightness(1.2);
 }
 
 .folder-tree .title {
@@ -48,6 +50,8 @@
 #graph-container {
   width: 100%;
   height: 400px;
-  border: 1px solid #ccc;
+  border: 1px solid var(--border-colour);
   margin-top: 1rem;
+  background: var(--card-bg);
+  backdrop-filter: blur(var(--glass-blur));
 }

--- a/apps/legal_discovery/static/style.css
+++ b/apps/legal_discovery/static/style.css
@@ -1,39 +1,51 @@
-/* Dark theme for the Legal Discovery Assistant
+/* Alien warship dark theme for the Legal Discovery Assistant
  *
- * This stylesheet redefines the palette variables used by the refined UI and
- * adjusts component colours for a dark interface. Cards, chat bubbles and
- * buttons use deeper tones with high‑contrast text. The structure and class
- * names mirror those in the light theme to ensure compatibility with the
- * existing HTML and JavaScript. Simply link this file in place of the
- * default style.css to enable dark mode.
+ * This stylesheet defines a glassy, neon‑accented design intended to feel
+ * like the control deck of an interstellar litigation AI. Colours and effects
+ * are exposed as CSS variables so components can share a consistent visual
+ * language across the app and in future design tooling.
  */
 
-/* Dark colour palette variables */
+/* Core palette and component tokens */
 :root {
-    --primary-color: #9ca3af;            /* smoky grey accent */
-    --secondary-color: #1f2937;          /* dark slate for panels */
-    --background-start: #111827;         /* dark gradient start */
-    --background-end:   #1f2937;         /* dark gradient end */
-    --chat-bg: rgba(31,41,55,0.8);       /* chat container background */
-    --user-bg: #374151;                  /* user message bubble */
-    --speech-bg: #4b5563;                /* assistant speech bubble */
-    --thought-bg: #6b7280;               /* assistant thought bubble */
-    --card-bg: rgba(31,41,55,0.6);       /* card/panel background */
-    --border-colour: rgba(255,255,255,0.08); /* subtle borders */
-    --text-colour: #e5e7eb;              /* primary text colour */
-    --subtitle-colour: #9ca3af;          /* secondary text */
-    --nav-bg: rgba(17,24,39,0.8);        /* navigation bar */
-    --nav-text: #e5e7eb;                 /* navigation text */
+    --color-bg: #000000;                 /* jet black */
+    --color-bg-alt: #0b0f1a;             /* deep charcoal */
+    --color-surface: rgba(15,23,42,0.6); /* translucent panels */
+    --color-surface-hover: rgba(15,23,42,0.8);
+    --color-border: rgba(255,255,255,0.08);
+    --color-accent: #00e5ff;             /* neon blue */
+    --color-accent-glow: rgba(0,229,255,0.7);
+    --color-text: #e5e7eb;
+    --color-text-muted: #9ca3af;
+    --font-base: 'Rajdhani', 'Segoe UI', sans-serif;
+    --glass-blur: 12px;
+
+    /* legacy variable mapping for existing classes */
+    --primary-color: var(--color-accent);
+    --secondary-color: #1f2937;
+    --background-start: var(--color-bg);
+    --background-end:   var(--color-bg-alt);
+    --chat-bg: rgba(15,23,42,0.6);
+    --user-bg: rgba(30,41,59,0.8);
+    --speech-bg: rgba(51,65,85,0.8);
+    --thought-bg: rgba(71,85,105,0.8);
+    --card-bg: var(--color-surface);
+    --border-colour: var(--color-border);
+    --text-colour: var(--color-text);
+    --subtitle-colour: var(--color-text-muted);
+    --nav-bg: rgba(5,8,13,0.85);
+    --nav-text: var(--color-text);
+    --accent-colour: var(--color-accent);
 }
 
 html, body {
     height: 100%;
     margin: 0;
     padding: 0;
-    font-family: 'Inter', 'Open Sans', Arial, sans-serif;
+    font-family: var(--font-base);
     color: var(--text-colour);
     min-height: 100vh;
-    background: linear-gradient(to right, var(--background-start), var(--background-end));
+    background: radial-gradient(circle at 50% 0%, var(--background-end), var(--background-start) 80%);
 }
 
 .main-container {
@@ -42,8 +54,8 @@ html, body {
     background: var(--card-bg);
     border: 1px solid var(--border-colour);
     border-radius: 20px;
-    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
-    backdrop-filter: blur(12px);
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.6);
+    backdrop-filter: blur(var(--glass-blur));
     padding: 40px 32px 28px 32px;
     position: relative;
 }
@@ -62,7 +74,8 @@ nav {
     position: sticky;
     top: 0;
     z-index: 50;
-    backdrop-filter: blur(8px);
+    backdrop-filter: blur(var(--glass-blur));
+    box-shadow: 0 2px 12px rgba(0,0,0,0.8);
 }
 
 nav a {
@@ -72,10 +85,12 @@ nav a {
     font-weight: 500;
     display: inline-flex;
     align-items: center;
+    transition: color 0.2s, text-shadow 0.2s;
 }
 
 nav a:hover {
-    color: var(--primary-color);
+    color: var(--color-accent);
+    text-shadow: 0 0 8px var(--color-accent-glow);
 }
 
 header h1 {
@@ -84,6 +99,7 @@ header h1 {
     font-weight: 600;
     letter-spacing: -1px;
     color: var(--primary-color);
+    text-shadow: 0 0 12px var(--color-accent-glow);
 }
 
 .subtitle {
@@ -103,6 +119,7 @@ h2 {
     font-weight: 600;
     letter-spacing: -0.5px;
     font-size: 1.4em;
+    text-shadow: 0 0 8px var(--color-accent-glow);
 }
 
 .card {
@@ -113,6 +130,12 @@ h2 {
     backdrop-filter: blur(6px);
     padding: 24px;
     margin-bottom: 24px;
+    transition: box-shadow 0.3s, background 0.3s;
+}
+
+.card:hover {
+    background: var(--color-surface-hover);
+    box-shadow: 0 0 20px rgba(0,229,255,0.15);
 }
 
 .card-grid {
@@ -153,12 +176,18 @@ h2 {
     display: inline-flex;
     align-items: center;
     gap: 4px;
+    transition: color 0.2s, box-shadow 0.2s, transform 0.2s;
+}
+
+.tab-button:hover {
+    box-shadow: 0 0 6px var(--color-accent-glow);
+    transform: translateY(-1px);
 }
 
 .tab-button.active {
     background: var(--primary-color);
     color: #ffffff;
-    box-shadow: 0 0 10px var(--primary-color), inset 0 0 5px var(--primary-color);
+    box-shadow: 0 0 15px var(--color-accent-glow), inset 0 0 5px var(--color-accent);
 }
 
 .tab-content {
@@ -193,11 +222,12 @@ h2 {
     border-radius: 7px;
     padding: 7px 14px;
     cursor: pointer;
-    transition: background 0.2s;
+    transition: background 0.2s, box-shadow 0.2s;
 }
 
 #toggle-thoughts:hover, #toggle-thoughts:focus {
-    background: #1d4ed8;
+    background: var(--color-accent);
+    box-shadow: 0 0 8px var(--color-accent-glow);
 }
 
 .chat-box {
@@ -229,7 +259,7 @@ h2 {
 
 .user-msg {
     background: var(--user-bg);
-    color: #86efac; /* light green text for contrast */
+    color: var(--color-accent);
     padding: 7px 12px;
     border-radius: 8px;
     margin-bottom: 7px;
@@ -239,7 +269,7 @@ h2 {
 
 .thought-msg {
     background: var(--thought-bg);
-    color: #fcd34d; /* light yellow text */
+    color: var(--color-text-muted);
     padding: 7px 12px;
     border-radius: 8px;
     margin-bottom: 7px;
@@ -281,34 +311,35 @@ textarea:focus {
 .button-primary {
     padding: 11px 24px;
     font-weight: bold;
-    background: var(--primary-color);
+    background: var(--color-accent);
     color: #ffffff;
-    border: none;
+    border: 1px solid var(--color-accent);
     border-radius: 8px;
     cursor: pointer;
     transition: background 0.2s, box-shadow 0.2s, transform 0.1s;
-    box-shadow: 0 2px 6px rgba(0,0,0,0.4);
+    box-shadow: 0 0 6px rgba(0,0,0,0.6);
 }
 
 .button-primary:hover, .button-primary:focus {
-    background: #ea580c;
-    box-shadow: 0 4px 12px rgba(0,0,0,0.6);
+    box-shadow: 0 0 12px var(--color-accent-glow), 0 0 4px var(--color-accent);
     transform: translateY(-1px) scale(1.04);
 }
 
 .button-secondary {
     padding: 11px 24px;
     font-weight: bold;
-    background: var(--accent-colour, #475569);
-    color: var(--text-colour);
-    border: none;
+    background: transparent;
+    color: var(--color-accent);
+    border: 1px solid var(--color-accent);
     border-radius: 8px;
     cursor: pointer;
-    transition: background 0.2s;
+    backdrop-filter: blur(4px);
+    transition: background 0.2s, box-shadow 0.2s, transform 0.1s;
 }
 
 .button-secondary:hover, .button-secondary:focus {
-    background: #3f4f6a;
+    background: var(--color-surface-hover);
+    box-shadow: 0 0 8px var(--color-accent-glow);
 }
 
 footer {

--- a/apps/legal_discovery/templates/dashboard.html
+++ b/apps/legal_discovery/templates/dashboard.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8">
     <title>Legal Discovery Dashboard</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <!-- Google Fonts -->
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <!-- Futuristic font -->
+    <link href="https://fonts.googleapis.com/css2?family=Rajdhani:wght@400;500;600;700&display=swap" rel="stylesheet">
     <!-- Application styles -->
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='main.css') }}">

--- a/apps/legal_discovery/templates/timeline.html
+++ b/apps/legal_discovery/templates/timeline.html
@@ -4,12 +4,15 @@
     <meta charset="UTF-8">
     <title>Timeline</title>
     <link href="{{ url_for('static', filename='vis-timeline/vis-timeline-graph2d.min.css') }}" rel="stylesheet" type="text/css" />
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='main.css') }}">
+    <link href="https://fonts.googleapis.com/css2?family=Rajdhani:wght@400;500;600;700&display=swap" rel="stylesheet">
     <script src="{{ url_for('static', filename='vis-timeline/vis-timeline-graph2d.min.js') }}"></script>
 </head>
 <body>
     <div id="visualization"></div>
-    <div id="citation-modal" style="display:none; position:fixed; top:0; left:0; width:100%; height:100%; background-color:rgba(0,0,0,0.5);">
-        <div style="background-color:white; margin:15% auto; padding:20px; border:1px solid #888; width:80%;">
+    <div id="citation-modal" style="display:none; position:fixed; top:0; left:0; width:100%; height:100%; background:rgba(0,0,0,0.7);">
+        <div style="background:var(--card-bg); color:var(--text-colour); margin:15% auto; padding:20px; border:1px solid var(--border-colour); width:80%; backdrop-filter:blur(var(--glass-blur));">
             <span id="close-modal" style="float:right; cursor:pointer;">&times;</span>
             <iframe id="citation-frame" style="width:100%; height:500px;"></iframe>
         </div>


### PR DESCRIPTION
## Summary
- forge a neon-blue, glass-morphism interface with reusable CSS tokens
- extend dark theme to folder tree, dashboard, and timeline views
- publish theme tokens via theme.js and figma_tokens.json for future design work

## Testing
- `npm --prefix apps/legal_discovery run build --silent`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f53322f2c8333bc32d68d3f9882fd