### PR TITLE
feat: enable postgres backend

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -516,3 +516,9 @@ echo "Setup complete. To activate the virtual environment, run 'source venv/bin/
 - Wired settings button to trigger modal and exposed `/api/graph/cypher` endpoint with starter query buttons
 - Shifted dashboard container to dark gunmetal glass for clearer contrast against neon cards
 - Next: enrich cypher results formatting and continue tightening glass theme consistency
+
+## Update 2025-08-04T00:30Z
+- Added PostgreSQL configuration for Flask via `DATABASE_URL` with SQLite fallback
+- Pointed vector database manager to an external Chroma service
+- Extended docker-compose with a PostgreSQL service and wiring for Chroma
+- Next: refine graph exploration UI and document deployment steps

--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -416,3 +416,9 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 - Added preset Cypher query buttons and backend endpoint so graph exploration works without manual query knowledge
 - Darkened dashboard backdrop with gunmetal gradient to differentiate cards
 - Next: style query results output and refine hover animations across components
+
+## Update 2025-08-04T00:30Z
+- Enabled PostgreSQL via `DATABASE_URL` and wired Chroma host/port through environment variables
+- Vector database manager now uses `HttpClient` for external Postgres-backed Chroma
+- `docker-compose.yml` includes a PostgreSQL service for persistent storage
+- Next: surface ingestion metrics and improve graph exploration usability

--- a/apps/legal_discovery/README.md
+++ b/apps/legal_discovery/README.md
@@ -6,6 +6,7 @@ Neuro SAN's legal discovery agent network.
 ## Prerequisites
 
 - [Docker](https://docs.docker.com/get-docker/) and `docker-compose`
+- A running PostgreSQL instance (the provided `docker-compose.yml` spins one up automatically)
 - API keys configured in `.env`
 
 Make a copy of `.env.example` to `.env` and fill in the required values. In

--- a/apps/legal_discovery/interface_flask.py
+++ b/apps/legal_discovery/interface_flask.py
@@ -73,7 +73,13 @@ if not os.path.exists(BUNDLE_PATH):
     )
 app = Flask(__name__)
 app.config["SECRET_KEY"] = os.environ.get("FLASK_SECRET_KEY", os.urandom(24).hex())
-app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///legal_discovery.db"
+# Allow the primary relational store to be configured at runtime. Default to
+# SQLite for local development but override with an environment-provided
+# PostgreSQL connection string when available so the application scales under
+# concurrent load.
+app.config["SQLALCHEMY_DATABASE_URI"] = os.environ.get(
+    "DATABASE_URL", "sqlite:///legal_discovery.db"
+)
 app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
 db.init_app(app)
 socketio = SocketIO(app)

--- a/apps/legal_discovery/requirements.txt
+++ b/apps/legal_discovery/requirements.txt
@@ -18,6 +18,7 @@ beautifulsoup4
 python-docx
 python-pptx
 flask-sqlalchemy
+psycopg2-binary
 langchain-google-genai
 openai
 pyvis

--- a/coded_tools/legal_discovery/vector_database_manager.py
+++ b/coded_tools/legal_discovery/vector_database_manager.py
@@ -1,4 +1,5 @@
 import logging
+import os
 
 import chromadb
 from neuro_san.interfaces.coded_tool import CodedTool
@@ -7,7 +8,11 @@ from neuro_san.interfaces.coded_tool import CodedTool
 class VectorDatabaseManager(CodedTool):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.client = chromadb.Client()
+        host = os.getenv("CHROMA_HOST", "localhost")
+        port = int(os.getenv("CHROMA_PORT", "8000"))
+        # Use the HTTP client so vector storage can reside on an external
+        # Chroma service backed by PostgreSQL for concurrent access.
+        self.client = chromadb.HttpClient(host=host, port=port)
         self.collection = self.client.get_or_create_collection("legal_documents")
 
     def add_documents(self, documents: list[str], metadatas: list[dict], ids: list[str]):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,26 @@ services:
       dockerfile: apps/legal_discovery/Dockerfile
     ports:
       - "8080:5001"
+    environment:
+      - DATABASE_URL=postgresql+psycopg2://postgres:postgres@postgres:5432/legal_discovery
+      - CHROMA_HOST=chromadb
+      - CHROMA_PORT=8000
+    depends_on:
+      - postgres
+      - chromadb
     volumes:
       - /mnt/e/docker_volumes/legal_discovery/uploads:/usr/src/app/uploads
+
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      - POSTGRES_DB=legal_discovery
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+    ports:
+      - "5432:5432"
+    volumes:
+      - /mnt/e/docker_volumes/postgres/data:/var/lib/postgresql/data
 
   neo4j:
     image: neo4j:4.4
@@ -24,6 +42,15 @@ services:
     image: chromadb/chroma
     ports:
       - "8000:8000"
+    environment:
+      - CHROMA_DB_IMPL=postgresql
+      - POSTGRES_HOST=postgres
+      - POSTGRES_PORT=5432
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_DATABASE=chroma
+    depends_on:
+      - postgres
     volumes:
       - /mnt/e/docker_volumes/chroma:/chroma_data
 
@@ -31,7 +58,3 @@ services:
     image: tesseractshadow/tesseract4re
     ports:
       - "5000:5000"
-
-volumes:
-  neo4j_data: - /mnt/e/docker_volumes/neo4j/data:/data
-  uploads_data: - /mnt/e/docker_volumes/chroma:/chroma_data

--- a/requirements.txt
+++ b/requirements.txt
@@ -62,6 +62,7 @@ beautifulsoup4
 python-docx
 python-pptx
 flask-sqlalchemy
+psycopg2-binary
 langchain-google-genai
 openai
 pyvis


### PR DESCRIPTION
## Summary
- configure Flask to read DATABASE_URL for PostgreSQL with SQLite fallback
- connect vector database manager to external Chroma service and wire Postgres in docker-compose
- document PostgreSQL requirement and add psycopg2 dependency

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68900b1f6f10833398131938da4617d2