### PR TITLE
Parallelize file ingestion with thread pool

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -522,3 +522,7 @@ echo "Setup complete. To activate the virtual environment, run 'source venv/bin/
 - Pointed vector database manager to an external Chroma service
 - Extended docker-compose with a PostgreSQL service and wiring for Chroma
 - Next: refine graph exploration UI and document deployment steps
+
+## Update 2025-08-04T02:00Z
+- Parallelized document ingestion using a thread pool with per-file timeouts
+- Next: observe upload performance and tune worker counts

--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -422,3 +422,7 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 - Vector database manager now uses `HttpClient` for external Postgres-backed Chroma
 - `docker-compose.yml` includes a PostgreSQL service for persistent storage
 - Next: surface ingestion metrics and improve graph exploration usability
+
+## Update 2025-08-04T02:00Z
+- Switched upload route to a thread pool for parallel file processing with 30s timeouts
+- Next: monitor executor load and refine async workflow


### PR DESCRIPTION
## Summary
- parallelize legal discovery upload processing with a shared thread pool and per-file timeouts
- add ingest_document helper for extraction, vectorization and graph linking
- log updates in AGENTS guides

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68900ed14ad883339eb8914fc2f49e79