### PR TITLE
feat: scaffold legal theory ontology

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -526,3 +526,9 @@ echo "Setup complete. To activate the virtual environment, run 'source venv/bin/
 ## Update 2025-08-04T02:00Z
 - Parallelized document ingestion using a thread pool with per-file timeouts
 - Next: observe upload performance and tune worker counts
+
+## Update 2025-08-04T03:00Z
+- Added legal theory ontology and loader for case theory mapping
+- Expanded models with CauseOfAction, Element, Defense and Fact tables
+- Introduced ontology loader unit test
+- Next: build fact extraction pipeline and Neo4j graph persistence

--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -426,3 +426,9 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 ## Update 2025-08-04T02:00Z
 - Switched upload route to a thread pool for parallel file processing with 30s timeouts
 - Next: monitor executor load and refine async workflow
+
+## Update 2025-08-04T03:00Z
+- Added relational models for causes of action, elements, defenses and facts
+- Introduced ontology loader with initial JSON schema
+- Added unit test scaffold for ontology loading
+- Next: integrate fact extractor and graph persistence

--- a/apps/legal_discovery/models.py
+++ b/apps/legal_discovery/models.py
@@ -163,3 +163,53 @@ class CalendarEvent(db.Model):
     title = db.Column(db.String(255), nullable=False)
     event_date = db.Column(db.DateTime, nullable=False)
     created_at = db.Column(db.DateTime, server_default=db.func.now())
+
+
+class CauseOfAction(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(255), nullable=False, unique=True)
+    description = db.Column(db.Text, nullable=True)
+    elements = db.relationship(
+        "Element", backref="cause", lazy=True, cascade="all, delete-orphan"
+    )
+    defenses = db.relationship(
+        "Defense", backref="cause", lazy=True, cascade="all, delete-orphan"
+    )
+
+
+class Element(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    cause_id = db.Column(
+        db.Integer, db.ForeignKey("cause_of_action.id"), nullable=False
+    )
+    name = db.Column(db.String(255), nullable=False)
+    description = db.Column(db.Text, nullable=True)
+
+
+class Defense(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    cause_id = db.Column(
+        db.Integer, db.ForeignKey("cause_of_action.id"), nullable=False
+    )
+    name = db.Column(db.String(255), nullable=False)
+    description = db.Column(db.Text, nullable=True)
+
+
+class Fact(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    case_id = db.Column(db.Integer, db.ForeignKey("case.id"), nullable=False)
+    document_id = db.Column(
+        db.Integer, db.ForeignKey("document.id"), nullable=False
+    )
+    legal_theory_id = db.Column(
+        db.Integer, db.ForeignKey("legal_theory.id"), nullable=True
+    )
+    element_id = db.Column(db.Integer, db.ForeignKey("element.id"), nullable=True)
+    text = db.Column(db.Text, nullable=False)
+    created_at = db.Column(db.DateTime, server_default=db.func.now())
+
+    document = db.relationship("Document", backref=db.backref("facts", lazy=True))
+    legal_theory = db.relationship(
+        "LegalTheory", backref=db.backref("facts", lazy=True)
+    )
+    element = db.relationship("Element", backref=db.backref("facts", lazy=True))

--- a/coded_tools/legal_discovery/__init__.py
+++ b/coded_tools/legal_discovery/__init__.py
@@ -17,6 +17,7 @@ from .timeline_manager import TimelineManager
 from .vector_database_manager import VectorDatabaseManager
 from .web_scraper import WebScraper
 from .graph_analyzer import GraphAnalyzer
+from .ontology_loader import OntologyLoader
 
 __all__ = [
     "CaseManagementTools",
@@ -36,4 +37,5 @@ __all__ = [
     "VectorDatabaseManager",
     "WebScraper",
     "GraphAnalyzer",
+    "OntologyLoader",
 ]

--- a/coded_tools/legal_discovery/legal_theory_ontology.json
+++ b/coded_tools/legal_discovery/legal_theory_ontology.json
@@ -1,0 +1,39 @@
+{
+  "causes_of_action": {
+    "Breach of Contract": {
+      "elements": [
+        "Existence of a contract",
+        "Plaintiff's performance or excuse",
+        "Defendant's breach",
+        "Damages"
+      ],
+      "defenses": [
+        "Lack of Consideration",
+        "Statute of Frauds"
+      ],
+      "indicators": [
+        "signed agreement",
+        "non-performance",
+        "payment records"
+      ]
+    },
+    "Fraud": {
+      "elements": [
+        "Misrepresentation",
+        "Knowledge of falsity",
+        "Intent to induce reliance",
+        "Justifiable reliance",
+        "Damages"
+      ],
+      "defenses": [
+        "Truth",
+        "No reliance"
+      ],
+      "indicators": [
+        "false statement",
+        "email referencing misstatement",
+        "damage evidence"
+      ]
+    }
+  }
+}

--- a/coded_tools/legal_discovery/ontology_loader.py
+++ b/coded_tools/legal_discovery/ontology_loader.py
@@ -1,0 +1,39 @@
+"""Utilities for loading the legal theory ontology."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+
+class OntologyLoader:
+    """Load and provide access to the legal theory ontology.
+
+    The ontology is stored as a JSON file mapping causes of action to their
+    elements, defenses and typical factual indicators.  This loader caches the
+    parsed ontology so multiple tools and Flask routes can share the data
+    without repeatedly hitting the filesystem.
+    """
+
+    def __init__(self, path: Optional[Path | str] = None) -> None:
+        self.path = Path(path) if path else Path(__file__).with_name("legal_theory_ontology.json")
+        self._ontology: Optional[Dict[str, Any]] = None
+
+    def load(self) -> Dict[str, Any]:
+        """Return the ontology as a dictionary, loading it if necessary."""
+        if self._ontology is None:
+            with self.path.open("r", encoding="utf-8") as f:
+                data = json.load(f)
+            if "causes_of_action" not in data:
+                raise ValueError("Ontology must contain 'causes_of_action'")
+            self._ontology = data
+        return self._ontology
+
+    def get_cause(self, name: str) -> Optional[Dict[str, Any]]:
+        """Return a single cause of action by name."""
+        ontology = self.load()
+        return ontology.get("causes_of_action", {}).get(name)
+
+
+__all__ = ["OntologyLoader"]

--- a/tests/coded_tools/legal_discovery/test_ontology_loader.py
+++ b/tests/coded_tools/legal_discovery/test_ontology_loader.py
@@ -1,0 +1,11 @@
+from coded_tools.legal_discovery.ontology_loader import OntologyLoader
+
+
+def test_loads_ontology_and_accesses_cause():
+    loader = OntologyLoader()
+    ontology = loader.load()
+    assert "causes_of_action" in ontology
+    cause = loader.get_cause("Breach of Contract")
+    assert cause is not None
+    assert "elements" in cause
+    assert "defenses" in cause


### PR DESCRIPTION
## Summary
- add initial legal theory ontology JSON and loader utility
- expand SQLAlchemy models with CauseOfAction, Element, Defense and Fact
- cover ontology loader with unit test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689014d231a48333873c9b4c701730f0