### PR TITLE
Expand legal theory ontology

### DIFF
--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -452,3 +452,8 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 - Upload pipeline stores originals securely and serves redacted copies
 - Document tree marks privileged files for review with stealth icon
 - Next: surface override controls in dashboard
+
+## Update 2025-08-04T11:00Z
+- Expanded legal theory ontology with negligence, defamation, false imprisonment, intentional infliction of emotional distress, and strict products liability.
+- LegalTheoryEngine now exposes defenses and factual indicators alongside element support scores.
+- Next: implement weighted scoring and add jurisdiction-specific defenses.

--- a/coded_tools/legal_discovery/legal_theory_engine.py
+++ b/coded_tools/legal_discovery/legal_theory_engine.py
@@ -22,6 +22,8 @@ class LegalTheoryEngine(CodedTool):
         suggestions: List[Dict[str, Any]] = []
         for cause, data in ontology.items():
             elements = data.get("elements", [])
+            defenses = data.get("defenses", [])
+            indicators = data.get("indicators", [])
             element_results: List[Dict[str, Any]] = []
             supported = 0
             for element in elements:
@@ -36,7 +38,15 @@ class LegalTheoryEngine(CodedTool):
                     supported += 1
                 element_results.append({"name": element, "facts": facts})
             score = supported / len(elements) if elements else 0
-            suggestions.append({"cause": cause, "score": score, "elements": element_results})
+            suggestions.append(
+                {
+                    "cause": cause,
+                    "score": score,
+                    "elements": element_results,
+                    "defenses": defenses,
+                    "indicators": indicators,
+                }
+            )
         suggestions.sort(key=lambda s: s["score"], reverse=True)
         return suggestions
 

--- a/coded_tools/legal_discovery/legal_theory_ontology.json
+++ b/coded_tools/legal_discovery/legal_theory_ontology.json
@@ -34,6 +34,91 @@
         "email referencing misstatement",
         "damage evidence"
       ]
+    },
+    "Negligence": {
+      "elements": [
+        "Duty",
+        "Breach",
+        "Causation",
+        "Damages"
+      ],
+      "defenses": [
+        "Comparative negligence",
+        "Assumption of risk"
+      ],
+      "indicators": [
+        "accident report",
+        "safety policy",
+        "injury photos"
+      ]
+    },
+    "Defamation": {
+      "elements": [
+        "Defamatory statement",
+        "Publication",
+        "Falsity",
+        "Harm"
+      ],
+      "defenses": [
+        "Truth",
+        "Privilege"
+      ],
+      "indicators": [
+        "publication records",
+        "witness statements",
+        "retraction requests"
+      ]
+    },
+    "Intentional Infliction of Emotional Distress": {
+      "elements": [
+        "Extreme and outrageous conduct",
+        "Intent or recklessness",
+        "Causation",
+        "Severe emotional distress"
+      ],
+      "defenses": [
+        "Consent",
+        "Privilege"
+      ],
+      "indicators": [
+        "threatening messages",
+        "medical records",
+        "witness testimony"
+      ]
+    },
+    "False Imprisonment": {
+      "elements": [
+        "Intentional confinement",
+        "Without lawful privilege",
+        "Against plaintiff's consent",
+        "Awareness or harm"
+      ],
+      "defenses": [
+        "Consent",
+        "Legal authority"
+      ],
+      "indicators": [
+        "security footage",
+        "police records",
+        "witness accounts"
+      ]
+    },
+    "Strict Products Liability": {
+      "elements": [
+        "Defective product",
+        "Product used foreseeably",
+        "Causation",
+        "Damages"
+      ],
+      "defenses": [
+        "Product misuse",
+        "Assumption of risk"
+      ],
+      "indicators": [
+        "product recall",
+        "design schematics",
+        "injury reports"
+      ]
     }
   }
 }

--- a/tests/coded_tools/legal_discovery/test_legal_theory_engine.py
+++ b/tests/coded_tools/legal_discovery/test_legal_theory_engine.py
@@ -21,6 +21,8 @@ class TestLegalTheoryEngine(unittest.TestCase):
         self.assertAlmostEqual(breach["score"], 0.25)
         elements = {e["name"]: e for e in breach["elements"]}
         self.assertTrue(elements["Existence of a contract"]["facts"])
+        self.assertIn("defenses", breach)
+        self.assertIn("indicators", breach)
         engine.close()
 
 

--- a/tests/coded_tools/legal_discovery/test_ontology_loader.py
+++ b/tests/coded_tools/legal_discovery/test_ontology_loader.py
@@ -9,3 +9,10 @@ def test_loads_ontology_and_accesses_cause():
     assert cause is not None
     assert "elements" in cause
     assert "defenses" in cause
+
+
+def test_loader_handles_additional_causes():
+    loader = OntologyLoader()
+    negligence = loader.get_cause("Negligence")
+    assert negligence is not None
+    assert "Breach" in negligence["elements"]


### PR DESCRIPTION
## Summary
- broaden legal theory ontology with negligence, defamation, false imprisonment, intentional infliction of emotional distress, and strict products liability
- extend LegalTheoryEngine to return associated defenses and factual indicators for each theory
- add tests for ontology coverage and engine metadata

## Testing
- `PYTHONPATH=$(pwd) pytest tests/coded_tools/legal_discovery/test_ontology_loader.py tests/coded_tools/legal_discovery/test_legal_theory_engine.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68906a09224c8333a491874f74a56328