### PR TITLE
Add Bates numbering and PDF stamping utilities

### DIFF
--- a/coded_tools/legal_discovery/__init__.py
+++ b/coded_tools/legal_discovery/__init__.py
@@ -21,6 +21,7 @@ from .ontology_loader import OntologyLoader
 from .fact_extractor import FactExtractor
 from .legal_theory_engine import LegalTheoryEngine
 from .privilege_detector import PrivilegeDetector
+from .bates_numbering import BatesNumberingService, stamp_pdf
 
 __all__ = [
     "CaseManagementTools",
@@ -44,4 +45,6 @@ __all__ = [
     "FactExtractor",
     "LegalTheoryEngine",
     "PrivilegeDetector",
+    "BatesNumberingService",
+    "stamp_pdf",
 ]

--- a/coded_tools/legal_discovery/bates_numbering.py
+++ b/coded_tools/legal_discovery/bates_numbering.py
@@ -1,0 +1,105 @@
+"""Bates numbering and PDF stamping utilities.
+
+This module provides a small, self-contained Bates numbering service
+backed by SQLite via SQLAlchemy.  It also exposes a helper for stamping
+PDF files with Bates numbers using PyMuPDF (``fitz``).
+"""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+import fitz  # PyMuPDF
+from sqlalchemy import Column, Integer, String, create_engine, text
+from sqlalchemy.orm import Session, declarative_base
+
+
+Base = declarative_base()
+
+
+class BatesCounter(Base):
+    """SQLAlchemy model storing the current Bates counter for a prefix."""
+
+    __tablename__ = "bates_counter"
+
+    id = Column(Integer, primary_key=True)
+    prefix = Column(String, nullable=False, default="BATES")
+    current_number = Column(Integer, nullable=False, default=0)
+
+
+class BatesNumberingService:
+    """Service that generates sequential Bates numbers.
+
+    Parameters
+    ----------
+    db_url: str, optional
+        Database URL used by SQLAlchemy.  Defaults to an in-memory SQLite
+        database which is sufficient for testing and light-weight use.
+    """
+
+    def __init__(self, db_url: str = "sqlite+pysqlite:///:memory:") -> None:
+        self.engine = create_engine(db_url, future=True)
+        # Create the table on first use
+        Base.metadata.create_all(self.engine)
+
+    def get_next_bates_number(self, prefix: str = "ABCD") -> str:
+        """Atomically fetch the next Bates number for *prefix*.
+
+        If ``prefix`` is new it will be initialised starting at 1.
+        """
+
+        with Session(self.engine) as session, session.begin():
+            row = session.execute(
+                text(
+                    "UPDATE bates_counter SET current_number = current_number + 1 "
+                    "WHERE prefix = :p RETURNING current_number"
+                ),
+                {"p": prefix},
+            ).fetchone()
+            if row is None:
+                # No row for this prefix yet; insert starting at 1.
+                session.execute(
+                    text(
+                        "INSERT INTO bates_counter (prefix, current_number) "
+                        "VALUES (:p, 1)"
+                    ),
+                    {"p": prefix},
+                )
+                number = 1
+            else:
+                number = row.current_number
+        return f"{prefix}_{number:06d}"
+
+
+def stamp_pdf(
+    file_path: str, output_path: str, start_number: int, prefix: str = "ABCD"
+) -> Tuple[str, str]:
+    """Stamp *file_path* with sequential Bates numbers.
+
+    Parameters
+    ----------
+    file_path: str
+        Path to the input PDF.
+    output_path: str
+        Path where the stamped PDF will be written.
+    start_number: int
+        First Bates number to use for stamping.
+    prefix: str
+        Bates prefix to apply.  Default ``"ABCD"``.
+
+    Returns
+    -------
+    Tuple[str, str]
+        The start and end Bates numbers applied to the document.
+    """
+
+    doc = fitz.open(file_path)
+    for i, page in enumerate(doc, start=start_number):
+        stamp = f"{prefix}_{i:06d}"
+        page.insert_text((50, 20), stamp, fontsize=8, color=(0, 0, 0), overlay=True)
+    doc.save(output_path)
+    end_number = start_number + len(doc) - 1
+    return f"{prefix}_{start_number:06d}", f"{prefix}_{end_number:06d}"
+
+
+__all__ = ["BatesNumberingService", "stamp_pdf"]

--- a/tests/coded_tools/legal_discovery/test_bates_numbering.py
+++ b/tests/coded_tools/legal_discovery/test_bates_numbering.py
@@ -1,0 +1,33 @@
+import fitz
+
+from coded_tools.legal_discovery.bates_numbering import (
+    BatesNumberingService,
+    stamp_pdf,
+)
+
+
+def create_sample_pdf(path: str) -> None:
+    doc = fitz.open()
+    doc.new_page()
+    doc.save(path)
+
+
+def test_get_next_bates_number_increments():
+    service = BatesNumberingService()
+    first = service.get_next_bates_number("TEST")
+    second = service.get_next_bates_number("TEST")
+    assert first == "TEST_000001"
+    assert second == "TEST_000002"
+    assert first != second
+
+
+def test_stamp_pdf(tmp_path):
+    input_pdf = tmp_path / "input.pdf"
+    output_pdf = tmp_path / "output.pdf"
+    create_sample_pdf(str(input_pdf))
+    start, end = stamp_pdf(str(input_pdf), str(output_pdf), 1, prefix="TEST")
+    assert start == "TEST_000001"
+    assert end == "TEST_000001"
+    doc = fitz.open(str(output_pdf))
+    text = doc[0].get_text()
+    assert "TEST_000001" in text


### PR DESCRIPTION
## Summary
- introduce `BatesNumberingService` backed by SQLite/SQLAlchemy for atomic Bates counters
- add `stamp_pdf` helper to overlay Bates numbers on PDF pages
- expose new utilities and provide unit tests verifying numbering and stamping

## Testing
- `PYTHONPATH=$(pwd) pytest tests/coded_tools/legal_discovery/test_bates_numbering.py -q`
- `PYTHONPATH=$(pwd) pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68906a48f1d88333906f75bb7ca5ef72