### PR TITLE
Add exhibit binder management utilities

### DIFF
--- a/agents--features and memory/condensed_agents.md
+++ b/agents--features and memory/condensed_agents.md
@@ -126,3 +126,14 @@ WE STARTED ON #3, INSTEAD OF #1. DEAL WITH IT, FINISH IMPLEMENTING #3, AND THEN 
 - Delivered 3.5 Case Theory dashboard tab with neon element highlight
 - Next: proceed to feature #1 planning and implementation
 
+## Update 2025-08-04T12:30Z
+- Began feature #5 Exhibit & Trial Binder Creator.
+- Added exhibit fields to Document model and created ExhibitCounter and audit log tables.
+- Implemented exhibit_manager service with binder generation and export helpers.
+- Next: connect service to UI and implement comprehensive compliance checks.
+
+## Update 2025-08-04T12:45Z
+- Resolved test environment issues and confirmed binder generation works via unit tests.
+- Cleaned up exhibit manager module imports.
+- Next: build frontend controls for exhibit numbering and binder export.
+

--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -462,3 +462,14 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 - Expanded legal theory ontology with negligence, defamation, false imprisonment, intentional infliction of emotional distress, and strict products liability.
 - LegalTheoryEngine now exposes defenses and factual indicators alongside element support scores.
 - Next: implement weighted scoring and add jurisdiction-specific defenses.
+
+## Update 2025-08-04T12:30Z
+- Extended Document model with exhibit fields and added ExhibitCounter and audit log tables.
+- Introduced `exhibit_manager` service with binder generation and export helpers.
+- Added unit test covering exhibit numbering and binder creation.
+- Next: wire exhibit manager into dashboard UI and provide export controls.
+
+## Update 2025-08-04T12:45Z
+- Fixed exhibit manager test setup to avoid detached instances.
+- Simplified exhibit_manager imports and verified all tests pass.
+- Next: begin UI integration for exhibit controls.

--- a/apps/legal_discovery/exhibit_manager.py
+++ b/apps/legal_discovery/exhibit_manager.py
@@ -1,0 +1,134 @@
+"""Exhibit management utilities for the legal discovery module."""
+
+import json
+import tempfile
+import zipfile
+from io import BytesIO
+from pathlib import Path
+
+from reportlab.pdfgen import canvas
+from PyPDF2 import PdfReader, PdfWriter
+
+from .database import db
+from .models import Document, ExhibitCounter, ExhibitAuditLog
+
+
+class ExhibitExportError(Exception):
+    """Raised when exhibits fail validation prior to export."""
+
+
+def _get_or_create_counter(case_id: int) -> ExhibitCounter:
+    counter = ExhibitCounter.query.filter_by(case_id=case_id).first()
+    if counter is None:
+        counter = ExhibitCounter(case_id=case_id, next_num=1)
+        db.session.add(counter)
+        db.session.commit()
+    return counter
+
+
+def get_next_exhibit_counter(case_id: int) -> int:
+    counter = _get_or_create_counter(case_id)
+    value = counter.next_num
+    counter.next_num += 1
+    db.session.commit()
+    return value
+
+
+def log_action(case_id: int, document_id: int, action: str, user: str | None = None, details: dict | None = None) -> None:
+    log = ExhibitAuditLog(
+        case_id=case_id,
+        document_id=document_id,
+        user=user,
+        action=action,
+        details=details or {},
+    )
+    db.session.add(log)
+    db.session.commit()
+
+
+def assign_exhibit_number(document_id: int, title: str | None = None, user: str | None = None) -> str:
+    doc = Document.query.get(document_id)
+    if doc is None:
+        raise ValueError("Document not found")
+    next_num = get_next_exhibit_counter(doc.case_id)
+    doc.exhibit_number = f"EX_{next_num:04}"
+    doc.exhibit_title = title or doc.name
+    doc.is_exhibit = True
+    db.session.commit()
+    log_action(doc.case_id, doc.id, "ASSIGN", user, {"exhibit_number": doc.exhibit_number})
+    return doc.exhibit_number
+
+
+def create_cover_sheet(exhibit: Document) -> BytesIO:
+    buffer = BytesIO()
+    c = canvas.Canvas(buffer)
+    c.setFont("Helvetica-Bold", 20)
+    c.drawString(100, 750, f"Exhibit {exhibit.exhibit_number}")
+    c.setFont("Helvetica", 14)
+    if exhibit.exhibit_title:
+        c.drawString(100, 720, exhibit.exhibit_title)
+    c.showPage()
+    c.save()
+    buffer.seek(0)
+    return buffer
+
+
+def merge_pdf(cover: BytesIO, exhibit_path: str, writer: PdfWriter) -> None:
+    writer.append(PdfReader(cover))
+    writer.append(PdfReader(exhibit_path))
+
+
+def validate_exhibits(case_id: int) -> None:
+    exhibits = Document.query.filter_by(case_id=case_id, is_exhibit=True).all()
+    for ex in exhibits:
+        if not ex.bates_number:
+            raise ExhibitExportError(f"Missing Bates number for {ex.exhibit_number}")
+        if ex.is_privileged:
+            raise ExhibitExportError(f"Exhibit {ex.exhibit_number} is marked privileged")
+
+
+def generate_binder(case_id: int, output_path: str | None = None) -> str:
+    validate_exhibits(case_id)
+    exhibits = (
+        Document.query.filter_by(case_id=case_id, is_exhibit=True)
+        .order_by(Document.exhibit_number)
+        .all()
+    )
+    writer = PdfWriter()
+    for exhibit in exhibits:
+        cover = create_cover_sheet(exhibit)
+        merge_pdf(cover, exhibit.file_path, writer)
+    if output_path is None:
+        output_path = Path(tempfile.gettempdir()) / f"case_{case_id}_binder.pdf"
+    with open(output_path, "wb") as f:
+        writer.write(f)
+    log_action(case_id, 0, "EXPORT_BINDER", details={"path": str(output_path)})
+    return str(output_path)
+
+
+def export_zip(case_id: int, output_path: str | None = None) -> str:
+    validate_exhibits(case_id)
+    exhibits = (
+        Document.query.filter_by(case_id=case_id, is_exhibit=True)
+        .order_by(Document.exhibit_number)
+        .all()
+    )
+    if output_path is None:
+        output_path = Path(tempfile.gettempdir()) / f"case_{case_id}_exhibits.zip"
+    manifest = []
+    with zipfile.ZipFile(output_path, "w") as z:
+        for ex in exhibits:
+            name = f"{ex.exhibit_number}_{(ex.exhibit_title or '').replace(' ', '_')}.pdf"
+            z.write(ex.file_path, name)
+            manifest.append(
+                {
+                    "exhibit_number": ex.exhibit_number,
+                    "title": ex.exhibit_title,
+                    "path": name,
+                    "bates_number": ex.bates_number,
+                }
+            )
+        z.writestr("manifest.json", json.dumps(manifest, indent=2))
+    log_action(case_id, 0, "EXPORT_ZIP", details={"path": str(output_path)})
+    return str(output_path)
+

--- a/apps/legal_discovery/models.py
+++ b/apps/legal_discovery/models.py
@@ -42,6 +42,9 @@ class Document(db.Model):
     is_privileged = db.Column(db.Boolean, nullable=False, default=False)
     is_redacted = db.Column(db.Boolean, nullable=False, default=False)
     needs_review = db.Column(db.Boolean, nullable=False, default=False)
+    is_exhibit = db.Column(db.Boolean, nullable=False, default=False)
+    exhibit_number = db.Column(db.String(50), unique=True)
+    exhibit_title = db.Column(db.String(255))
     metadata_entries = db.relationship(
         "DocumentMetadata",
         backref="document",
@@ -60,6 +63,22 @@ class Document(db.Model):
         lazy=True,
         cascade="all, delete-orphan",
     )
+
+
+class ExhibitCounter(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    case_id = db.Column(db.Integer, db.ForeignKey("case.id"), nullable=False, unique=True)
+    next_num = db.Column(db.Integer, nullable=False, default=1)
+
+
+class ExhibitAuditLog(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    case_id = db.Column(db.Integer, db.ForeignKey("case.id"), nullable=False)
+    document_id = db.Column(db.Integer, db.ForeignKey("document.id"), nullable=False)
+    user = db.Column(db.String(255), nullable=True)
+    action = db.Column(db.String(50), nullable=False)
+    timestamp = db.Column(db.DateTime, server_default=db.func.now())
+    details = db.Column(db.JSON, nullable=True)
 
 
 class DocumentMetadata(db.Model):

--- a/apps/legal_discovery/requirements.txt
+++ b/apps/legal_discovery/requirements.txt
@@ -24,3 +24,4 @@ openai
 pyvis
 networkx
 spacy
+reportlab

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ pyvis>=0.3.2
 schedule>=1.1.0
 Flask-SQLAlchemy>=2.5.1
 pandas>=1.3.5
+reportlab
 
 # We separate out requirements that are specific to the build, but not
 # necessary for operation to minimize the size of containers

--- a/tests/coded_tools/legal_discovery/test_exhibit_manager.py
+++ b/tests/coded_tools/legal_discovery/test_exhibit_manager.py
@@ -1,0 +1,48 @@
+import os
+from flask import Flask
+from reportlab.pdfgen import canvas
+
+from apps.legal_discovery.database import db
+from apps.legal_discovery.models import Case, Document
+from apps.legal_discovery.exhibit_manager import assign_exhibit_number, generate_binder
+
+
+def _create_pdf(path):
+    c = canvas.Canvas(str(path))
+    c.drawString(100, 750, "Test")
+    c.save()
+
+
+def _setup_app(tmp_path):
+    app = Flask(__name__)
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite://"
+    app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
+    db.init_app(app)
+    with app.app_context():
+        db.create_all()
+        case = Case(name="Test Case")
+        db.session.add(case)
+        db.session.commit()
+        pdf_path = tmp_path / "doc.pdf"
+        _create_pdf(pdf_path)
+        doc = Document(
+            case_id=case.id,
+            name="Doc",
+            file_path=str(pdf_path),
+            content_hash="hash1",
+            bates_number="BATES1",
+        )
+        db.session.add(doc)
+        db.session.commit()
+        return app, case.id, doc.id
+
+
+def test_assign_and_generate_binder(tmp_path):
+    app, case_id, doc_id = _setup_app(tmp_path)
+    with app.app_context():
+        num = assign_exhibit_number(doc_id, "Title")
+        assert num == "EX_0001"
+        binder_path = tmp_path / "binder.pdf"
+        result = generate_binder(case_id, binder_path)
+        assert result == str(binder_path)
+        assert os.path.exists(result)


### PR DESCRIPTION
## Summary
- extend Document model with exhibit metadata and tracking tables
- add exhibit_manager service for numbering, binder/zip export, and validation
- cover exhibit workflow with unit test

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68906b5936ac8333a7c636f838a12ead