### PR TITLE
feat: add deposition contradictions and pdf export

### DIFF
--- a/agents--features and memory/condensed_agents.md
+++ b/agents--features and memory/condensed_agents.md
@@ -126,3 +126,12 @@ WE STARTED ON #3, INSTEAD OF #1. DEAL WITH IT, FINISH IMPLEMENTING #3, AND THEN 
 - Delivered 3.5 Case Theory dashboard tab with neon element highlight
 - Next: proceed to feature #1 planning and implementation
 
+## Update 2025-08-04T08:30Z
+- Began feature #4 deposition prep generator: introduced witness models, question generation tool, export endpoint and React tab.
+- Next: add contradiction detection and PDF export options.
+
+## Update 2025-08-04T09:30Z
+- Added FactConflict model and contradiction detection during deposition prep.
+- Export now supports PDF with case metadata and source footnotes; React tab offers DOCX/PDF buttons with styled list items.
+- Next: implement review logging and attorney approval workflow.
+

--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -462,3 +462,12 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 - Expanded legal theory ontology with negligence, defamation, false imprisonment, intentional infliction of emotional distress, and strict products liability.
 - LegalTheoryEngine now exposes defenses and factual indicators alongside element support scores.
 - Next: implement weighted scoring and add jurisdiction-specific defenses.
+
+## Update 2025-08-04T12:00Z
+- Introduced witness models and deposition prep tool with question generation, export, and React dashboard tab.
+- Next: enhance review logging and offer PDF export.
+
+## Update 2025-08-04T13:30Z
+- Added contradiction detection with FactConflict records and prompt context.
+- Export supports PDF including case ID, timestamp, and footnoted sources; UI offers separate DOCX/PDF buttons with improved styling.
+- Next: implement deposition review approvals with permission controls.

--- a/apps/legal_discovery/__init__.py
+++ b/apps/legal_discovery/__init__.py
@@ -1,10 +1,9 @@
 """Flask application factory for the Legal Discovery module."""
 
-from .interface_flask import app as _app
-
-__all__ = ["create_app", "_app"]
+__all__ = ["create_app"]
 
 
 def create_app():
     """Return the configured Flask application."""
-    return _app
+    from .interface_flask import app
+    return app

--- a/apps/legal_discovery/interface_flask.py
+++ b/apps/legal_discovery/interface_flask.py
@@ -18,6 +18,7 @@ from flask import Flask
 from flask import jsonify
 from flask import render_template
 from flask import request
+from flask import send_file
 from werkzeug.utils import secure_filename
 from flask_socketio import SocketIO
 
@@ -33,6 +34,7 @@ from pyhocon import ConfigFactory
 
 from apps.legal_discovery import settings
 from apps.legal_discovery.database import db
+from coded_tools.legal_discovery.deposition_prep import DepositionPrep
 from apps.legal_discovery.models import (
     Case,
     Document,
@@ -44,6 +46,9 @@ from apps.legal_discovery.models import (
     Fact,
     RedactionLog,
     RedactionAudit,
+    Witness,
+    DepositionQuestion,
+    DepositionReviewLog,
 )
 
 # Configure logging before any other setup so early steps are captured
@@ -961,6 +966,55 @@ def manage_cases():
     cases = Case.query.all()
     data = [{"id": c.id, "name": c.name} for c in cases]
     return jsonify({"status": "ok", "data": data})
+
+
+@app.route("/api/witnesses", methods=["GET", "POST"])
+def manage_witnesses():
+    if request.method == "POST":
+        data = request.get_json() or {}
+        name = data.get("name")
+        case_id = data.get("case_id")
+        if not name:
+            return jsonify({"error": "Missing name"}), 400
+        witness = Witness(name=name, role=data.get("role"), associated_case=case_id)
+        db.session.add(witness)
+        db.session.commit()
+        return jsonify({"status": "ok", "id": witness.id})
+    case_id = request.args.get("case_id", type=int)
+    query = Witness.query
+    if case_id:
+        query = query.filter_by(associated_case=case_id)
+    witnesses = query.all()
+    data = [{"id": w.id, "name": w.name} for w in witnesses]
+    return jsonify({"status": "ok", "data": data})
+
+
+@app.route("/api/deposition/questions", methods=["POST"])
+def generate_deposition_questions():
+    data = request.get_json() or {}
+    witness_id = data.get("witness_id")
+    include_privileged = data.get("include_privileged", False)
+    if not witness_id:
+        return jsonify({"error": "Missing witness_id"}), 400
+    questions = DepositionPrep.generate_questions(
+        witness_id, include_privileged=include_privileged
+    )
+    return jsonify({"status": "ok", "data": questions})
+
+
+@app.route("/api/deposition/questions/<int:question_id>/flag", methods=["POST"])
+def flag_deposition_question(question_id: int):
+    DepositionPrep.flag_question(question_id)
+    return jsonify({"status": "ok"})
+
+
+@app.route("/api/deposition/export/<int:witness_id>", methods=["GET"])
+def export_deposition_questions(witness_id: int):
+    fmt = request.args.get("format", "docx")
+    os.makedirs("exports", exist_ok=True)
+    path = os.path.join("exports", f"deposition_{witness_id}.{fmt}")
+    DepositionPrep.export_questions(witness_id, path)
+    return send_file(path, as_attachment=True)
 
 
 @app.route("/api/subpoena/draft", methods=["POST"])

--- a/apps/legal_discovery/requirements.txt
+++ b/apps/legal_discovery/requirements.txt
@@ -24,3 +24,4 @@ openai
 pyvis
 networkx
 spacy
+weasyprint

--- a/apps/legal_discovery/src/Dashboard.jsx
+++ b/apps/legal_discovery/src/Dashboard.jsx
@@ -18,6 +18,7 @@ import PresentationSection from "./components/PresentationSection";
 import AgentNetworkSection from "./components/AgentNetworkSection";
 import SettingsModal from "./components/SettingsModal";
 import LegalTheorySection from "./components/LegalTheorySection";
+import DepositionPrepSection from "./components/DepositionPrepSection";
 const TABS = [
   {id:'network', label:'Agent Network', icon:'fa-sitemap'},
   {id:'overview', label:'Overview', icon:'fa-home'},
@@ -35,7 +36,8 @@ const TABS = [
   {id:'case', label:'Case Mgmt', icon:'fa-folder-open'},
   {id:'research', label:'Legal Research', icon:'fa-book-open'},
   {id:'subpoena', label:'Subpoena', icon:'fa-gavel'},
-  {id:'presentation', label:'Trial Prep', icon:'fa-slideshare'}
+  {id:'presentation', label:'Trial Prep', icon:'fa-slideshare'},
+  {id:'deposition', label:'Deposition Prep', icon:'fa-user-tie'}
 ];
 
 function Dashboard() {
@@ -79,6 +81,7 @@ function Dashboard() {
       <div className="tab-content" style={{display: tab==='research'?'block':'none'}} id="tab-research"><ResearchSection/></div>
       <div className="tab-content" style={{display: tab==='subpoena'?'block':'none'}} id="tab-subpoena"><SubpoenaSection/></div>
       <div className="tab-content" style={{display: tab==='presentation'?'block':'none'}} id="tab-presentation"><PresentationSection/></div>
+      <div className="tab-content" style={{display: tab==='deposition'?'block':'none'}} id="tab-deposition"><DepositionPrepSection/></div>
       <SettingsModal open={showSettings} onClose={()=>setShowSettings(false)}/>
     </div>
   );

--- a/apps/legal_discovery/src/components/DepositionPrepSection.jsx
+++ b/apps/legal_discovery/src/components/DepositionPrepSection.jsx
@@ -1,0 +1,84 @@
+import React, { useState, useEffect } from "react";
+import { alertResponse } from "../utils";
+
+function DepositionPrepSection() {
+  const [cases, setCases] = useState([]);
+  const [caseId, setCaseId] = useState("");
+  const [witnesses, setWitnesses] = useState([]);
+  const [witnessId, setWitnessId] = useState("");
+  const [includePriv, setIncludePriv] = useState(false);
+  const [questions, setQuestions] = useState([]);
+
+  useEffect(() => {
+    fetch("/api/cases").then(r => r.json()).then(d => setCases(d.data || []));
+  }, []);
+
+  useEffect(() => {
+    if (caseId) {
+      fetch(`/api/witnesses?case_id=${caseId}`)
+        .then(r => r.json())
+        .then(d => setWitnesses(d.data || []));
+    }
+  }, [caseId]);
+
+  const generate = () => {
+    if (!witnessId) return;
+    fetch("/api/deposition/questions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ witness_id: witnessId, include_privileged: includePriv })
+    })
+      .then(r => r.json())
+      .then(d => { setQuestions(d.data || []); alertResponse(d); });
+  };
+
+  const flag = id => {
+    fetch(`/api/deposition/questions/${id}/flag`, { method: "POST" })
+      .then(r => r.json()).then(alertResponse);
+  };
+
+  const exportDoc = () => {
+    if (!witnessId) return;
+    window.open(`/api/deposition/export/${witnessId}?format=docx`, "_blank");
+  };
+
+  const exportPdf = () => {
+    if (!witnessId) return;
+    window.open(`/api/deposition/export/${witnessId}?format=pdf`, "_blank");
+  };
+
+  return (
+    <section className="card">
+      <h2>Deposition Prep</h2>
+      <select value={caseId} onChange={e => setCaseId(e.target.value)} className="p-2 rounded w-full mb-2">
+        <option value="">Select Case</option>
+        {cases.map(c => <option key={c.id} value={c.id}>{c.name}</option>)}
+      </select>
+      <select value={witnessId} onChange={e => setWitnessId(e.target.value)} className="p-2 rounded w-full mb-2">
+        <option value="">Select Witness</option>
+        {witnesses.map(w => <option key={w.id} value={w.id}>{w.name}</option>)}
+      </select>
+      <label className="flex items-center mb-2">
+        <input type="checkbox" checked={includePriv} onChange={e => setIncludePriv(e.target.checked)} className="mr-2" />
+        Include documents marked as privileged?
+      </label>
+      <div className="flex flex-wrap gap-2 mb-2">
+        <button className="button-secondary" onClick={generate}><i className="fa fa-question mr-1"></i>Generate</button>
+        <button className="button-secondary" onClick={generate}><i className="fa fa-sync mr-1"></i>Regenerate</button>
+        <button className="button-secondary" onClick={exportDoc}><i className="fa fa-file-word mr-1"></i>Export DOCX</button>
+        <button className="button-secondary" onClick={exportPdf}><i className="fa fa-file-pdf mr-1"></i>Export PDF</button>
+      </div>
+      <ul className="text-sm space-y-2">
+        {questions.map(q => (
+          <li key={q.id} className="p-2 rounded" style={{ background: "var(--color-bg-alt)", borderLeft: "2px solid var(--color-accent)" }}>
+            [{q.category}] {q.question}{q.source && <span style={{color:'var(--color-text-muted)'}}> ({q.source})</span>}
+            <button className="ml-2 text-xs button-secondary" onClick={() => flag(q.id)}><i className="fa fa-flag mr-1"></i>Flag</button>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+export default DepositionPrepSection;
+

--- a/coded_tools/legal_discovery/__init__.py
+++ b/coded_tools/legal_discovery/__init__.py
@@ -22,6 +22,7 @@ from .fact_extractor import FactExtractor
 from .legal_theory_engine import LegalTheoryEngine
 from .privilege_detector import PrivilegeDetector
 from .bates_numbering import BatesNumberingService, stamp_pdf
+from .deposition_prep import DepositionPrep
 
 __all__ = [
     "CaseManagementTools",
@@ -47,4 +48,5 @@ __all__ = [
     "PrivilegeDetector",
     "BatesNumberingService",
     "stamp_pdf",
+    "DepositionPrep",
 ]

--- a/coded_tools/legal_discovery/deposition_prep.py
+++ b/coded_tools/legal_discovery/deposition_prep.py
@@ -1,0 +1,195 @@
+"""Deposition preparation utilities."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from typing import List, Dict, Optional
+
+from openai import OpenAI
+from docx import Document as DocxDocument
+from weasyprint import HTML
+
+from apps.legal_discovery.database import db
+from apps.legal_discovery.models import (
+    Witness,
+    Fact,
+    Document,
+    DepositionQuestion,
+    FactConflict,
+)
+
+PROMPT_TMPL = (
+    "You are preparing for a deposition of {name}, who is mentioned in:\n{facts}\n"
+    "Generate a JSON array of questions with fields 'category', 'question', and 'source' "
+    "grouped into Background, Events, Inconsistencies, and Damages."
+)
+
+
+class DepositionPrep:
+    """Utilities for deposition preparation."""
+
+    @staticmethod
+    def generate_questions(
+        witness_id: int, scope: Optional[Dict] = None, include_privileged: bool = False
+    ) -> List[Dict]:
+        witness = Witness.query.get(witness_id)
+        if not witness:
+            raise ValueError("Witness not found")
+
+        query = Fact.query.join(Document).filter(Fact.witness_id == witness_id)
+        if not include_privileged:
+            query = query.filter(Document.is_privileged.is_(False))
+        facts = query.all()
+        facts_text = "\n".join(
+            f"- {f.text} (Doc: {f.document.name})" for f in facts
+        ) or "No facts available."
+
+        # Detect contradictions among gathered facts and append to prompt context
+        conflicts = DepositionPrep.detect_contradictions(facts, witness_id)
+        if conflicts:
+            conflict_lines = "\n".join(
+                f"- {c['fact1']} <> {c['fact2']}" for c in conflicts
+            )
+            facts_text += "\nPotential contradictions:\n" + conflict_lines
+
+        prompt = PROMPT_TMPL.format(name=witness.name, facts=facts_text)
+
+        client = OpenAI()
+        response = client.chat.completions.create(
+            model="gpt-4o-mini",
+            messages=[{"role": "user", "content": prompt}],
+            temperature=0.2,
+        )
+        content = response.choices[0].message.content
+
+        try:
+            data = json.loads(content)
+        except json.JSONDecodeError as exc:
+            raise ValueError("LLM response not valid JSON") from exc
+
+        DepositionQuestion.query.filter_by(witness_id=witness_id).delete()
+        questions = []
+        for item in data:
+            qobj = DepositionQuestion(
+                witness_id=witness_id,
+                category=item.get("category", "Misc"),
+                question=item.get("question", ""),
+                source=item.get("source"),
+            )
+            db.session.add(qobj)
+            questions.append(qobj)
+        db.session.commit()
+
+        return [
+            {
+                "id": q.id,
+                "category": q.category,
+                "question": q.question,
+                "source": q.source,
+                "flagged": q.flagged,
+            }
+            for q in questions
+        ]
+
+    @staticmethod
+    def detect_contradictions(
+        facts: List[Fact], witness_id: int, threshold: float = 0.8
+    ) -> List[Dict]:
+        """Identify contradictions among witness facts using an LLM."""
+
+        conflicts: List[Dict] = []
+        client = OpenAI()
+        for i in range(len(facts)):
+            for j in range(i + 1, len(facts)):
+                prompt = (
+                    "Do these statements contradict each other?\n"
+                    f"1. {facts[i].text}\n2. {facts[j].text}\n"
+                    "Respond with JSON {\"contradiction\": bool, \"score\": float}."
+                )
+                response = client.chat.completions.create(
+                    model="gpt-4o-mini",
+                    messages=[{"role": "user", "content": prompt}],
+                    temperature=0,
+                )
+                content = response.choices[0].message.content
+                try:
+                    result = json.loads(content)
+                except json.JSONDecodeError:
+                    continue
+                if result.get("contradiction") and result.get("score", 0) >= threshold:
+                    conflict = FactConflict(
+                        witness_id=witness_id,
+                        fact1_id=facts[i].id,
+                        fact2_id=facts[j].id,
+                        score=float(result.get("score", 0)),
+                        description=f'"{facts[i].text}" <> "{facts[j].text}"',
+                    )
+                    db.session.add(conflict)
+                    conflicts.append(
+                        {
+                            "fact1": facts[i].text,
+                            "fact2": facts[j].text,
+                            "score": float(result.get("score", 0)),
+                        }
+                    )
+        if conflicts:
+            db.session.commit()
+        return conflicts
+
+    @staticmethod
+    def export_questions(witness_id: int, file_path: str) -> str:
+        witness = Witness.query.get_or_404(witness_id)
+        questions = (
+            DepositionQuestion.query.filter_by(witness_id=witness_id)
+            .order_by(DepositionQuestion.id)
+            .all()
+        )
+        case_id = witness.associated_case
+        timestamp = datetime.utcnow().strftime("%Y-%m-%d %H:%M UTC")
+
+        if file_path.lower().endswith(".pdf"):
+            items_html = ""
+            sources_html = ""
+            for idx, q in enumerate(questions, 1):
+                items_html += f"<li>{q.question}"
+                if q.source:
+                    items_html += f"<sup><a href='#src{idx}'>{idx}</a></sup>"
+                    sources_html += (
+                        f"<li id='src{idx}'><a href='{q.source}'>{q.source}</a></li>"
+                    )
+                items_html += "</li>"
+            html = f"""
+            <h1>Deposition Outline: {witness.name}</h1>
+            <p>Case ID: {case_id}</p>
+            <p>Generated: {timestamp}</p>
+            <ol>{items_html}</ol>
+            <h2>Sources</h2>
+            <ol>{sources_html}</ol>
+            """
+            HTML(string=html).write_pdf(file_path)
+        else:
+            doc = DocxDocument()
+            doc.add_heading(f"Deposition Outline: {witness.name}", level=1)
+            doc.add_paragraph(f"Case ID: {case_id}")
+            doc.add_paragraph(f"Generated: {timestamp}")
+            sources: List[str] = []
+            for q in questions:
+                p = doc.add_paragraph(style="List Number")
+                p.add_run(q.question)
+                if q.source:
+                    ref = len(sources) + 1
+                    p.add_run(f" [{ref}]")
+                    sources.append(q.source)
+            if sources:
+                doc.add_heading("Sources", level=2)
+                for i, src in enumerate(sources, 1):
+                    doc.add_paragraph(f"[{i}] {src}")
+            doc.save(file_path)
+        return file_path
+
+    @staticmethod
+    def flag_question(question_id: int) -> None:
+        question = DepositionQuestion.query.get_or_404(question_id)
+        question.flagged = True
+        db.session.commit()


### PR DESCRIPTION
## Summary
- track witness fact conflicts via new FactConflict model
- detect contradictions during deposition prep and include in question prompts
- add PDF export and dual-format UI buttons for deposition outlines

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68906af12b8883339e15b8583d4def0f