### PR TITLE
Add exhibit binder management utilities

### DIFF
--- a/agents--features and memory/condensed_agents.md
+++ b/agents--features and memory/condensed_agents.md
@@ -126,3 +126,29 @@ WE STARTED ON #3, INSTEAD OF #1. DEAL WITH IT, FINISH IMPLEMENTING #3, AND THEN 
 - Delivered 3.5 Case Theory dashboard tab with neon element highlight
 - Next: proceed to feature #1 planning and implementation
 
+## Update 2025-08-04T12:30Z
+- Began feature #5 Exhibit & Trial Binder Creator.
+- Added exhibit fields to Document model and created ExhibitCounter and audit log tables.
+- Implemented exhibit_manager service with binder generation and export helpers.
+- Next: connect service to UI and implement comprehensive compliance checks.
+
+## Update 2025-08-04T12:45Z
+- Resolved test environment issues and confirmed binder generation works via unit tests.
+- Cleaned up exhibit manager module imports.
+- Next: build frontend controls for exhibit numbering and binder export.
+
+## Update 2025-08-04T13:30Z
+- Improved exhibit manager robustness with docstrings, idempotent assignment checks, and optional audit document links.
+- Added export ZIP test and focus-visible nav styling for accessibility.
+- Next: surface binder and ZIP export actions in the React dashboard.
+
+## Update 2025-08-04T14:00Z
+- Addressed review feedback: made exhibit assignment idempotent and fixed test imports.
+- Enhanced navigation focus style with a subtle glow for clearer keyboard cues.
+- Next: expose binder and ZIP export controls in the dashboard UI.
+
+## Update 2025-08-04T14:30Z
+- Added REST blueprint and React tab for exhibit management with binder/ZIP export.
+- Introduced neon-styled table for exhibits to polish UI aesthetics.
+- Next: implement exhibit reordering and privilege filters in organizer view.
+

--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -462,3 +462,30 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 - Expanded legal theory ontology with negligence, defamation, false imprisonment, intentional infliction of emotional distress, and strict products liability.
 - LegalTheoryEngine now exposes defenses and factual indicators alongside element support scores.
 - Next: implement weighted scoring and add jurisdiction-specific defenses.
+
+## Update 2025-08-04T12:30Z
+- Extended Document model with exhibit fields and added ExhibitCounter and audit log tables.
+- Introduced `exhibit_manager` service with binder generation and export helpers.
+- Added unit test covering exhibit numbering and binder creation.
+- Next: wire exhibit manager into dashboard UI and provide export controls.
+
+## Update 2025-08-04T12:45Z
+- Fixed exhibit manager test setup to avoid detached instances.
+- Simplified exhibit_manager imports and verified all tests pass.
+- Next: begin UI integration for exhibit controls.
+
+## Update 2025-08-04T13:30Z
+- Hardened exhibit logging with optional document IDs and export validation.
+- Added zip export test and keyboard-focus styling for navigation links.
+- Next: connect exhibit exports to dashboard controls.
+
+## Update 2025-08-04T14:00Z
+- Made exhibit numbering idempotent and corrected missing test imports.
+- Refined navigation focus styling with an accent glow for accessibility.
+- Next: wire binder and ZIP export actions into the dashboard UI.
+
+## Update 2025-08-04T14:30Z
+- Exposed exhibit operations via REST blueprint and registered routes.
+- Added React Exhibits tab with assignment, binder and ZIP export controls.
+- Styled exhibit table headers for better visual hierarchy.
+- Next: support exhibit reordering and privilege filters in UI.

--- a/apps/legal_discovery/exhibit_manager.py
+++ b/apps/legal_discovery/exhibit_manager.py
@@ -1,0 +1,159 @@
+"""Exhibit management utilities for the legal discovery module."""
+
+import json
+import tempfile
+import zipfile
+from io import BytesIO
+from pathlib import Path
+
+from reportlab.pdfgen import canvas
+from PyPDF2 import PdfReader, PdfWriter
+
+from .database import db
+from .models import Document, ExhibitCounter, ExhibitAuditLog
+
+
+class ExhibitExportError(Exception):
+    """Raised when exhibits fail validation prior to export."""
+
+
+def _get_or_create_counter(case_id: int) -> ExhibitCounter:
+    """Return the exhibit counter for a case, creating it if needed."""
+    counter = ExhibitCounter.query.filter_by(case_id=case_id).first()
+    if counter is None:
+        counter = ExhibitCounter(case_id=case_id, next_num=1)
+        db.session.add(counter)
+        db.session.commit()
+    return counter
+
+
+def get_next_exhibit_counter(case_id: int) -> int:
+    """Increment and return the next exhibit number for a case."""
+    counter = _get_or_create_counter(case_id)
+    value = counter.next_num
+    counter.next_num += 1
+    db.session.commit()
+    return value
+
+
+def log_action(
+    case_id: int,
+    document_id: int | None,
+    action: str,
+    user: str | None = None,
+    details: dict | None = None,
+) -> None:
+    """Persist an audit log entry for exhibit operations."""
+    log = ExhibitAuditLog(
+        case_id=case_id,
+        document_id=document_id,
+        user=user,
+        action=action,
+        details=details or {},
+    )
+    db.session.add(log)
+    db.session.commit()
+
+
+def assign_exhibit_number(
+    document_id: int, title: str | None = None, user: str | None = None
+) -> str:
+    """Mark a document as an exhibit and assign the next sequential number.
+
+    Repeated calls on an already-assigned document simply return the existing
+    exhibit number, keeping the operation idempotent.
+    """
+    doc = Document.query.get(document_id)
+    if doc is None:
+        raise ValueError("Document not found")
+    if doc.is_exhibit and doc.exhibit_number:
+        return doc.exhibit_number
+    next_num = get_next_exhibit_counter(doc.case_id)
+    doc.exhibit_number = f"EX_{next_num:04}"
+    doc.exhibit_title = title or doc.name
+    doc.is_exhibit = True
+    db.session.commit()
+    log_action(doc.case_id, doc.id, "ASSIGN", user, {"exhibit_number": doc.exhibit_number})
+    return doc.exhibit_number
+
+
+def create_cover_sheet(exhibit: Document) -> BytesIO:
+    """Render a simple PDF cover sheet for an exhibit."""
+    buffer = BytesIO()
+    c = canvas.Canvas(buffer)
+    c.setFont("Helvetica-Bold", 20)
+    c.drawString(100, 750, f"Exhibit {exhibit.exhibit_number}")
+    c.setFont("Helvetica", 14)
+    if exhibit.exhibit_title:
+        c.drawString(100, 720, exhibit.exhibit_title)
+    c.showPage()
+    c.save()
+    buffer.seek(0)
+    return buffer
+
+
+def merge_pdf(cover: BytesIO, exhibit_path: str, writer: PdfWriter) -> None:
+    """Append a cover sheet and exhibit file to the provided PDF writer."""
+    if not Path(exhibit_path).exists():
+        raise FileNotFoundError(exhibit_path)
+    writer.append(PdfReader(cover))
+    writer.append(PdfReader(exhibit_path))
+
+
+def validate_exhibits(case_id: int) -> None:
+    """Ensure all exhibits for a case satisfy export requirements."""
+    exhibits = Document.query.filter_by(case_id=case_id, is_exhibit=True).all()
+    for ex in exhibits:
+        if not ex.bates_number:
+            raise ExhibitExportError(f"Missing Bates number for {ex.exhibit_number}")
+        if ex.is_privileged:
+            raise ExhibitExportError(f"Exhibit {ex.exhibit_number} is marked privileged")
+
+
+def generate_binder(case_id: int, output_path: str | None = None) -> str:
+    """Combine exhibits with cover sheets into a single PDF binder."""
+    validate_exhibits(case_id)
+    exhibits = (
+        Document.query.filter_by(case_id=case_id, is_exhibit=True)
+        .order_by(Document.exhibit_number)
+        .all()
+    )
+    writer = PdfWriter()
+    for exhibit in exhibits:
+        cover = create_cover_sheet(exhibit)
+        merge_pdf(cover, exhibit.file_path, writer)
+    if output_path is None:
+        output_path = Path(tempfile.gettempdir()) / f"case_{case_id}_binder.pdf"
+    with open(output_path, "wb") as f:
+        writer.write(f)
+    log_action(case_id, None, "EXPORT_BINDER", details={"path": str(output_path)})
+    return str(output_path)
+
+
+def export_zip(case_id: int, output_path: str | None = None) -> str:
+    """Package exhibits and a manifest into a zip archive."""
+    validate_exhibits(case_id)
+    exhibits = (
+        Document.query.filter_by(case_id=case_id, is_exhibit=True)
+        .order_by(Document.exhibit_number)
+        .all()
+    )
+    if output_path is None:
+        output_path = Path(tempfile.gettempdir()) / f"case_{case_id}_exhibits.zip"
+    manifest = []
+    with zipfile.ZipFile(output_path, "w") as z:
+        for ex in exhibits:
+            name = f"{ex.exhibit_number}_{(ex.exhibit_title or '').replace(' ', '_')}.pdf"
+            z.write(ex.file_path, name)
+            manifest.append(
+                {
+                    "exhibit_number": ex.exhibit_number,
+                    "title": ex.exhibit_title,
+                    "path": name,
+                    "bates_number": ex.bates_number,
+                }
+            )
+        z.writestr("manifest.json", json.dumps(manifest, indent=2))
+    log_action(case_id, None, "EXPORT_ZIP", details={"path": str(output_path)})
+    return str(output_path)
+

--- a/apps/legal_discovery/exhibit_routes.py
+++ b/apps/legal_discovery/exhibit_routes.py
@@ -1,0 +1,85 @@
+"""Blueprint exposing REST endpoints for exhibit operations."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from flask import Blueprint, jsonify, request, current_app
+from PyPDF2 import PdfReader
+
+from .models import Document
+from .exhibit_manager import assign_exhibit_number, generate_binder, export_zip
+
+exhibits_bp = Blueprint("exhibits", __name__, url_prefix="/api/exhibits")
+
+
+@exhibits_bp.route("", methods=["GET"])
+@exhibits_bp.route("/", methods=["GET"])
+def list_exhibits():
+    """Return all exhibits for a given case."""
+    case_id = request.args.get("case_id", type=int)
+    if case_id is None:
+        return jsonify({"error": "case_id required"}), 400
+    exhibits = (
+        Document.query.filter_by(case_id=case_id, is_exhibit=True)
+        .order_by(Document.exhibit_number)
+        .all()
+    )
+    data = []
+    for ex in exhibits:
+        try:
+            pages = len(PdfReader(ex.file_path).pages)
+        except Exception:  # pylint: disable=broad-except
+            pages = 0
+        data.append(
+            {
+                "id": ex.id,
+                "exhibit_number": ex.exhibit_number,
+                "title": ex.exhibit_title,
+                "bates_number": ex.bates_number,
+                "page_count": pages,
+                "privileged": ex.is_privileged,
+            }
+        )
+    return jsonify(data)
+
+
+@exhibits_bp.post("/assign")
+def assign():
+    """Assign the next exhibit number to a document."""
+    payload = request.get_json() or {}
+    doc_id = payload.get("document_id")
+    title = payload.get("title")
+    user = payload.get("user")
+    if not doc_id:
+        return jsonify({"error": "document_id required"}), 400
+    num = assign_exhibit_number(doc_id, title, user)
+    return jsonify({"exhibit_number": num})
+
+
+@exhibits_bp.post("/binder")
+def binder():
+    """Generate a combined PDF binder for the case exhibits."""
+    payload = request.get_json() or {}
+    case_id = payload.get("case_id")
+    if not case_id:
+        return jsonify({"error": "case_id required"}), 400
+    export_dir = Path(current_app.config.get("UPLOAD_FOLDER", "uploads"))
+    export_dir.mkdir(parents=True, exist_ok=True)
+    target = export_dir / f"case_{case_id}_binder.pdf"
+    path = generate_binder(case_id, target)
+    return jsonify({"binder_path": f"/uploads/{target.name}", "path": path})
+
+
+@exhibits_bp.post("/zip")
+def zip_export():
+    """Export exhibits and manifest as a zip archive."""
+    payload = request.get_json() or {}
+    case_id = payload.get("case_id")
+    if not case_id:
+        return jsonify({"error": "case_id required"}), 400
+    export_dir = Path(current_app.config.get("UPLOAD_FOLDER", "uploads"))
+    export_dir.mkdir(parents=True, exist_ok=True)
+    target = export_dir / f"case_{case_id}_exhibits.zip"
+    path = export_zip(case_id, target)
+    return jsonify({"zip_path": f"/uploads/{target.name}", "path": path})

--- a/apps/legal_discovery/interface_flask.py
+++ b/apps/legal_discovery/interface_flask.py
@@ -45,6 +45,7 @@ from apps.legal_discovery.models import (
     RedactionLog,
     RedactionAudit,
 )
+from .exhibit_routes import exhibits_bp
 
 # Configure logging before any other setup so early steps are captured
 logging.basicConfig(level=os.environ.get("LOG_LEVEL", "INFO"))
@@ -84,6 +85,7 @@ app.config["SQLALCHEMY_DATABASE_URI"] = os.environ.get(
 app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
 db.init_app(app)
 socketio = SocketIO(app)
+app.register_blueprint(exhibits_bp)
 executor = ThreadPoolExecutor(max_workers=int(os.environ.get("INGESTION_WORKERS", "4")))
 atexit.register(executor.shutdown)
 thread_started = False  # pylint: disable=invalid-name

--- a/apps/legal_discovery/models.py
+++ b/apps/legal_discovery/models.py
@@ -42,6 +42,9 @@ class Document(db.Model):
     is_privileged = db.Column(db.Boolean, nullable=False, default=False)
     is_redacted = db.Column(db.Boolean, nullable=False, default=False)
     needs_review = db.Column(db.Boolean, nullable=False, default=False)
+    is_exhibit = db.Column(db.Boolean, nullable=False, default=False)
+    exhibit_number = db.Column(db.String(50), unique=True)
+    exhibit_title = db.Column(db.String(255))
     metadata_entries = db.relationship(
         "DocumentMetadata",
         backref="document",
@@ -60,6 +63,22 @@ class Document(db.Model):
         lazy=True,
         cascade="all, delete-orphan",
     )
+
+
+class ExhibitCounter(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    case_id = db.Column(db.Integer, db.ForeignKey("case.id"), nullable=False, unique=True)
+    next_num = db.Column(db.Integer, nullable=False, default=1)
+
+
+class ExhibitAuditLog(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    case_id = db.Column(db.Integer, db.ForeignKey("case.id"), nullable=False)
+    document_id = db.Column(db.Integer, db.ForeignKey("document.id"), nullable=True)
+    user = db.Column(db.String(255), nullable=True)
+    action = db.Column(db.String(50), nullable=False)
+    timestamp = db.Column(db.DateTime, server_default=db.func.now())
+    details = db.Column(db.JSON, nullable=True)
 
 
 class DocumentMetadata(db.Model):

--- a/apps/legal_discovery/requirements.txt
+++ b/apps/legal_discovery/requirements.txt
@@ -24,3 +24,4 @@ openai
 pyvis
 networkx
 spacy
+reportlab

--- a/apps/legal_discovery/src/Dashboard.jsx
+++ b/apps/legal_discovery/src/Dashboard.jsx
@@ -18,6 +18,7 @@ import PresentationSection from "./components/PresentationSection";
 import AgentNetworkSection from "./components/AgentNetworkSection";
 import SettingsModal from "./components/SettingsModal";
 import LegalTheorySection from "./components/LegalTheorySection";
+import ExhibitSection from "./components/ExhibitSection";
 const TABS = [
   {id:'network', label:'Agent Network', icon:'fa-sitemap'},
   {id:'overview', label:'Overview', icon:'fa-home'},
@@ -35,7 +36,8 @@ const TABS = [
   {id:'case', label:'Case Mgmt', icon:'fa-folder-open'},
   {id:'research', label:'Legal Research', icon:'fa-book-open'},
   {id:'subpoena', label:'Subpoena', icon:'fa-gavel'},
-  {id:'presentation', label:'Trial Prep', icon:'fa-slideshare'}
+  {id:'presentation', label:'Trial Prep', icon:'fa-slideshare'},
+  {id:'exhibits', label:'Exhibits', icon:'fa-book'}
 ];
 
 function Dashboard() {
@@ -79,6 +81,7 @@ function Dashboard() {
       <div className="tab-content" style={{display: tab==='research'?'block':'none'}} id="tab-research"><ResearchSection/></div>
       <div className="tab-content" style={{display: tab==='subpoena'?'block':'none'}} id="tab-subpoena"><SubpoenaSection/></div>
       <div className="tab-content" style={{display: tab==='presentation'?'block':'none'}} id="tab-presentation"><PresentationSection/></div>
+      <div className="tab-content" style={{display: tab==='exhibits'?'block':'none'}} id="tab-exhibits"><ExhibitSection/></div>
       <SettingsModal open={showSettings} onClose={()=>setShowSettings(false)}/>
     </div>
   );

--- a/apps/legal_discovery/src/components/ExhibitSection.jsx
+++ b/apps/legal_discovery/src/components/ExhibitSection.jsx
@@ -1,0 +1,130 @@
+import React, { useState, useEffect } from "react";
+import { fetchJSON, alertResponse } from "../utils";
+
+function ExhibitSection() {
+  const [caseId, setCaseId] = useState(1);
+  const [docId, setDocId] = useState("");
+  const [title, setTitle] = useState("");
+  const [exhibits, setExhibits] = useState([]);
+  const [links, setLinks] = useState({ binder: "", zip: "" });
+
+  const load = () => {
+    fetchJSON(`/api/exhibits?case_id=${caseId}`).then(setExhibits);
+  };
+
+  useEffect(() => {
+    load();
+  }, [caseId]);
+
+  const assign = () => {
+    fetchJSON("/api/exhibits/assign", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ document_id: Number(docId), title }),
+    }).then((d) => {
+      alertResponse(d);
+      load();
+    });
+  };
+
+  const exportBinder = () => {
+    fetchJSON("/api/exhibits/binder", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ case_id: caseId }),
+    }).then((d) => {
+      alertResponse(d);
+      setLinks((l) => ({ ...l, binder: d.binder_path }));
+    });
+  };
+
+  const exportZip = () => {
+    fetchJSON("/api/exhibits/zip", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ case_id: caseId }),
+    }).then((d) => {
+      alertResponse(d);
+      setLinks((l) => ({ ...l, zip: d.zip_path }));
+    });
+  };
+
+  return (
+    <section className="card">
+      <h2>Exhibits</h2>
+      <div className="mb-2 flex gap-2">
+        <input
+          type="number"
+          value={caseId}
+          onChange={(e) => setCaseId(Number(e.target.value))}
+          className="w-24 p-2 rounded"
+          placeholder="Case"
+        />
+        <input
+          type="number"
+          value={docId}
+          onChange={(e) => setDocId(e.target.value)}
+          className="w-24 p-2 rounded"
+          placeholder="Doc ID"
+        />
+        <input
+          type="text"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          className="flex-1 p-2 rounded"
+          placeholder="Title"
+        />
+        <button className="button-secondary" onClick={assign}>
+          <i className="fa fa-tag mr-1"></i>
+          Assign
+        </button>
+      </div>
+      <table className="w-full exhibit-table text-sm">
+        <thead>
+          <tr>
+            <th>No.</th>
+            <th>Title</th>
+            <th>Bates</th>
+            <th>Pages</th>
+            <th>Priv</th>
+          </tr>
+        </thead>
+        <tbody>
+          {exhibits.map((ex) => (
+            <tr key={ex.id}>
+              <td>{ex.exhibit_number}</td>
+              <td>{ex.title}</td>
+              <td>{ex.bates_number || ""}</td>
+              <td>{ex.page_count}</td>
+              <td>{ex.privileged ? "Y" : "N"}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <div className="mt-2 flex gap-2">
+        <button className="button-secondary" onClick={exportBinder}>
+          <i className="fa fa-book mr-1"></i>
+          Binder
+        </button>
+        <button className="button-secondary" onClick={exportZip}>
+          <i className="fa fa-file-archive mr-1"></i>
+          ZIP
+        </button>
+      </div>
+      <div className="mt-2 text-xs">
+        {links.binder && (
+          <p>
+            Binder: <a href={links.binder}>{links.binder}</a>
+          </p>
+        )}
+        {links.zip && (
+          <p>
+            ZIP: <a href={links.zip}>{links.zip}</a>
+          </p>
+        )}
+      </div>
+    </section>
+  );
+}
+
+export default ExhibitSection;

--- a/apps/legal_discovery/static/style.css
+++ b/apps/legal_discovery/static/style.css
@@ -95,6 +95,13 @@ nav a:hover {
     text-shadow: 0 0 8px var(--color-accent-glow);
 }
 
+nav a:focus,
+nav a:focus-visible {
+    outline: 2px solid var(--color-accent);
+    outline-offset: 2px;
+    box-shadow: 0 0 4px var(--color-accent-glow);
+}
+
 header h1 {
     margin: 0;
     font-size: 2.2em;
@@ -569,4 +576,20 @@ progress::-webkit-progress-value {
 .theory-supported {
     color: var(--primary-color);
     text-shadow: 0 0 6px var(--color-accent-glow);
+}
+
+/* Exhibit table styling */
+.exhibit-table th {
+    background: var(--nav-bg);
+    color: var(--primary-color);
+    text-align: left;
+    padding: 6px;
+}
+
+.exhibit-table td {
+    padding: 6px;
+}
+
+.exhibit-table tr:hover {
+    background: rgba(255,255,255,0.05);
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ pyvis>=0.3.2
 schedule>=1.1.0
 Flask-SQLAlchemy>=2.5.1
 pandas>=1.3.5
+reportlab
 
 # We separate out requirements that are specific to the build, but not
 # necessary for operation to minimize the size of containers

--- a/tests/coded_tools/legal_discovery/test_exhibit_api.py
+++ b/tests/coded_tools/legal_discovery/test_exhibit_api.py
@@ -1,0 +1,66 @@
+import os
+import zipfile
+from flask import Flask
+from reportlab.pdfgen import canvas
+
+from apps.legal_discovery.database import db
+from apps.legal_discovery.models import Case, Document
+from apps.legal_discovery.exhibit_routes import exhibits_bp
+
+def _create_pdf(path):
+    c = canvas.Canvas(str(path))
+    c.drawString(100, 750, "Test")
+    c.save()
+
+
+def _setup(tmp_path):
+    app = Flask(__name__)
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite://"
+    app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
+    app.config["UPLOAD_FOLDER"] = str(tmp_path)
+    db.init_app(app)
+    app.register_blueprint(exhibits_bp)
+    with app.app_context():
+        db.create_all()
+        case = Case(name="Test Case")
+        db.session.add(case)
+        db.session.commit()
+        case_id = case.id
+        pdf_path = tmp_path / "doc.pdf"
+        _create_pdf(pdf_path)
+        doc = Document(
+            case_id=case_id,
+            name="Doc",
+            file_path=str(pdf_path),
+            content_hash="hash1",
+            bates_number="B1",
+        )
+        db.session.add(doc)
+        db.session.commit()
+        doc_id = doc.id
+    return app, case_id, doc_id
+
+
+def test_assign_list_and_exports(tmp_path):
+    app, case_id, doc_id = _setup(tmp_path)
+    client = app.test_client()
+
+    res = client.post("/api/exhibits/assign", json={"document_id": doc_id, "title": "Title"})
+    assert res.status_code == 200
+    assert res.json["exhibit_number"] == "EX_0001"
+
+    res = client.get(f"/api/exhibits?case_id={case_id}")
+    assert res.status_code == 200
+    assert res.json[0]["exhibit_number"] == "EX_0001"
+
+    res = client.post("/api/exhibits/binder", json={"case_id": case_id})
+    assert res.status_code == 200
+    binder_path = tmp_path / "case_{}_binder.pdf".format(case_id)
+    assert binder_path.exists()
+
+    res = client.post("/api/exhibits/zip", json={"case_id": case_id})
+    assert res.status_code == 200
+    zip_path = tmp_path / "case_{}_exhibits.zip".format(case_id)
+    assert zip_path.exists()
+    with zipfile.ZipFile(zip_path) as z:
+        assert "manifest.json" in z.namelist()

--- a/tests/coded_tools/legal_discovery/test_exhibit_manager.py
+++ b/tests/coded_tools/legal_discovery/test_exhibit_manager.py
@@ -1,0 +1,61 @@
+import os
+import zipfile
+from flask import Flask
+from reportlab.pdfgen import canvas
+
+from apps.legal_discovery.database import db
+from apps.legal_discovery.models import Case, Document
+from apps.legal_discovery.exhibit_manager import assign_exhibit_number, generate_binder, export_zip
+
+
+def _create_pdf(path):
+    c = canvas.Canvas(str(path))
+    c.drawString(100, 750, "Test")
+    c.save()
+
+
+def _setup_app(tmp_path):
+    app = Flask(__name__)
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite://"
+    app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
+    db.init_app(app)
+    with app.app_context():
+        db.create_all()
+        case = Case(name="Test Case")
+        db.session.add(case)
+        db.session.commit()
+        pdf_path = tmp_path / "doc.pdf"
+        _create_pdf(pdf_path)
+        doc = Document(
+            case_id=case.id,
+            name="Doc",
+            file_path=str(pdf_path),
+            content_hash="hash1",
+            bates_number="BATES1",
+        )
+        db.session.add(doc)
+        db.session.commit()
+        return app, case.id, doc.id
+
+
+def test_assign_and_generate_binder(tmp_path):
+    app, case_id, doc_id = _setup_app(tmp_path)
+    with app.app_context():
+        num = assign_exhibit_number(doc_id, "Title")
+        assert num == "EX_0001"
+        binder_path = tmp_path / "binder.pdf"
+        result = generate_binder(case_id, binder_path)
+        assert result == str(binder_path)
+        assert os.path.exists(result)
+
+
+def test_export_zip(tmp_path):
+    app, case_id, doc_id = _setup_app(tmp_path)
+    with app.app_context():
+        assign_exhibit_number(doc_id, "Title")
+        zip_path = tmp_path / "exhibits.zip"
+        result = export_zip(case_id, zip_path)
+        assert result == str(zip_path)
+        assert os.path.exists(result)
+        with zipfile.ZipFile(zip_path) as z:
+            assert "manifest.json" in z.namelist()


### PR DESCRIPTION
## Summary
- expose exhibit list, assignment, binder, and ZIP export routes via a dedicated Flask blueprint and register it with the app
- add a React Exhibits tab with assignment controls and export buttons, styled for the neon theme
- cover exhibit API flows with tests

## Testing
- `pip install reportlab`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68906b5936ac8333a7c636f838a12ead