### PR TITLE
Add legal theory engine for cause-of-action analysis

### DIFF
--- a/coded_tools/legal_discovery/legal_theory_engine.py
+++ b/coded_tools/legal_discovery/legal_theory_engine.py
@@ -1,82 +1,154 @@
+"""Evaluate legal theories by matching facts to ontology elements.
+
+The ``LegalTheoryEngine`` loads a cause-of-action ontology and then queries
+both a Neo4j knowledge graph and an optional SQL database to determine which
+theories have sufficient evidentiary support.  For each cause of action the
+engine gathers supporting facts for every element, computes a score based on
+how many elements are supported, and returns a structured summary.
+
+The Neo4j queries expect ``Fact`` nodes linked to ``Element`` nodes via the
+``SUPPORTS`` relationship and ``Element`` nodes linked to ``CauseOfAction``
+via ``BELONGS_TO``.  When a SQLAlchemy session is supplied the engine will
+also look for ``Fact`` records joined to ``Element`` and ``CauseOfAction``
+tables to collect additional supporting facts.
+"""
+
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Sequence
 
 from neuro_san.interfaces.coded_tool import CodedTool
 
 from .knowledge_graph_manager import KnowledgeGraphManager
 from .ontology_loader import OntologyLoader
 
+try:  # pragma: no cover - optional dependency for SQL lookups
+    from sqlalchemy.orm import Session
+    from apps.legal_discovery.models import CauseOfAction, Element, Fact
+except Exception:  # pragma: no cover - imports are optional for graph-only use
+    Session = Any  # type: ignore[assignment]
+    CauseOfAction = Element = Fact = None  # type: ignore[assignment]
+
 
 class LegalTheoryEngine(CodedTool):
     """Suggest legal theories by linking facts to ontology elements."""
 
-    def __init__(self, kg: Optional[KnowledgeGraphManager] = None, loader: Optional[OntologyLoader] = None, **kwargs: Any) -> None:
+    def __init__(
+        self,
+        kg: Optional[KnowledgeGraphManager] = None,
+        db_session: Optional[Session] = None,
+        loader: Optional[OntologyLoader] = None,
+        **kwargs: Any,
+    ) -> None:
         super().__init__(**kwargs)
         self.kg = kg or KnowledgeGraphManager()
+        self.db_session = db_session
         self.loader = loader or OntologyLoader()
 
+    # ------------------------------------------------------------------
+    # Internal helpers
+    def _facts_for_element(self, cause: str, element: str) -> List[Dict[str, Any]]:
+        """Return supporting facts for a cause/element pair.
+
+        Facts are collected from the Neo4j knowledge graph and, when available,
+        the SQL database.  Each fact is returned as a dictionary containing the
+        fact text and an optional weight.
+        """
+
+        facts: List[Dict[str, Any]] = []
+
+        # Neo4j query ---------------------------------------------------
+        query = (
+            "MATCH (f:Fact)-[r:SUPPORTS]->(e:Element {name:$element})"
+            "-[:BELONGS_TO]->(c:CauseOfAction {name:$cause}) "
+            "RETURN f.text AS text, r.weight AS weight"
+        )
+
+        try:
+            records = self.kg.run_query(query, {"element": element, "cause": cause})
+            for r in records:
+                facts.append(
+                    {
+                        "text": r.get("text", ""),
+                        "weight": r.get("weight", 0),
+                        "source": "graph",
+                    }
+                )
+        except Exception:  # pragma: no cover - graph may be unavailable
+            pass
+
+        # SQL query -----------------------------------------------------
+        if self.db_session and Fact is not None:
+            sql_records = (
+                self.db_session.query(Fact)
+                .join(Element)
+                .join(CauseOfAction)
+                .filter(Element.name == element, CauseOfAction.name == cause)
+                .all()
+            )
+            for f in sql_records:
+                facts.append(
+                    {
+                        "text": getattr(f, "text", ""),
+                        "weight": getattr(f, "weight", 0),
+                        "source": "sql",
+                    }
+                )
+
+        return facts
+
+    # ------------------------------------------------------------------
+    # Public API
     def suggest_theories(self) -> List[Dict[str, Any]]:
-        """Return ranked candidate theories based on graph support."""
+        """Return ranked candidate theories based on factual support."""
+
         ontology = self.loader.load()["causes_of_action"]
         suggestions: List[Dict[str, Any]] = []
-        for cause, data in ontology.items():
-            elements = data.get("elements", [])
-            element_results: List[Dict[str, Any]] = []
-            for element in elements:
-                query = (
-                    "MATCH (f:Fact)-[r:SUPPORTS]->(e:Element {name:$element})"
-                    "-[:BELONGS_TO]->(c:CauseOfAction {name:$cause}) "
-                    "RETURN f.text as text, r.weight as weight"
-                )
-                records = self.kg.run_query(query, {"element": element, "cause": cause})
-                facts = [
-                    {"text": r["text"], "weight": r.get("weight", 0)} for r in records
-                ]
-                element_weight = max((r.get("weight", 0) for r in records), default=0)
-                element_results.append(
-                    {"name": element, "facts": facts, "weight": element_weight}
-                )
-            score = (
-                sum(e["weight"] for e in element_results) / len(elements)
-                if elements
-                else 0
-            )
-            suggestions.append({"cause": cause, "score": score, "elements": element_results})
-        suggestions.sort(key=lambda s: s["score"], reverse=True)
-        return suggestions
 
+        for cause, data in ontology.items():
+            elements: Sequence[str] = data.get("elements", [])
             defenses = data.get("defenses", [])
             indicators = data.get("indicators", [])
+
             element_results: List[Dict[str, Any]] = []
             supported = 0
+            total_weight = 0.0
+
             for element in elements:
-                query = (
-                    "MATCH (f:Fact)-[:SUPPORTS]->(e:Element {name:$element})"
-                    "-[:BELONGS_TO]->(c:CauseOfAction {name:$cause}) "
-                    "RETURN f.text as text"
-                )
-                records = self.kg.run_query(query, {"element": element, "cause": cause})
-                facts = [r["text"] for r in records]
+                facts = self._facts_for_element(cause, element)
+                weight = max((f.get("weight", 0) for f in facts), default=0)
                 if facts:
                     supported += 1
-                element_results.append({"name": element, "facts": facts})
+                total_weight += weight
+                element_results.append({"name": element, "facts": facts, "weight": weight})
+
             score = supported / len(elements) if elements else 0
+            avg_weight = total_weight / len(elements) if elements else 0
+
             suggestions.append(
                 {
                     "cause": cause,
                     "score": score,
+                    "avg_weight": avg_weight,
                     "elements": element_results,
                     "defenses": defenses,
                     "indicators": indicators,
                 }
             )
-        suggestions.sort(key=lambda s: s["score"], reverse=True)
+
+        suggestions.sort(key=lambda s: (s["score"], s.get("avg_weight", 0)), reverse=True)
         return suggestions
 
     def get_theory_subgraph(self, cause: str):
         """Expose subgraph retrieval for a specific cause of action."""
+
         return self.kg.get_cause_subgraph(cause)
 
     def close(self) -> None:
+        """Clean up any external connections."""
+
         self.kg.close()
+
+
+__all__ = ["LegalTheoryEngine"]
+

--- a/registries/legal_discovery.hocon
+++ b/registries/legal_discovery.hocon
@@ -939,7 +939,7 @@ You will go through the compiled evidence and identify key facts, events, and pa
 You are the Case Theorist/Strategist agent.
 You will formulate the case strategy and theory based on the facts and the law.
             """,
-            "tools": []
+            "tools": ["legal_theory_engine"]
         },
         {
             "name": "investigator_lead_discovery",

--- a/tests/coded_tools/legal_discovery/test_legal_theory_engine.py
+++ b/tests/coded_tools/legal_discovery/test_legal_theory_engine.py
@@ -1,22 +1,27 @@
+"""Tests for the LegalTheoryEngine coded tool."""
+
+import os
+import sys
 import unittest
+
+sys.path.insert(0, os.path.abspath("."))
+
 from coded_tools.legal_discovery.legal_theory_engine import LegalTheoryEngine
 
 
 class DummyKG:
-    def run_query(self, query, params):
+    """Minimal stand-in for the Neo4j manager used in tests."""
+
+    def run_query(self, query, params):  # pragma: no cover - simple stub
         element = params["element"]
         if element == "Existence of a contract":
             return [{"text": "Contract between A and B", "weight": 0.9}]
         return []
 
-
-            return [{"text": "Contract between A and B"}]
-        return []
-
-    def get_cause_subgraph(self, cause):
+    def get_cause_subgraph(self, cause):  # pragma: no cover - simple stub
         return ["n"], ["e"]
 
-    def close(self):
+    def close(self):  # pragma: no cover - simple stub
         pass
 
 
@@ -24,15 +29,16 @@ class TestLegalTheoryEngine(unittest.TestCase):
     def test_suggest_theories(self):
         engine = LegalTheoryEngine(kg=DummyKG())
         theories = engine.suggest_theories()
+
         breach = next(t for t in theories if t["cause"] == "Breach of Contract")
-        self.assertAlmostEqual(breach["score"], 0.9 / 4, places=3)
+        # One of four elements is supported by the dummy graph
+        self.assertAlmostEqual(breach["score"], 0.25)
+
         elements = {e["name"]: e for e in breach["elements"]}
         self.assertAlmostEqual(elements["Existence of a contract"]["weight"], 0.9)
         self.assertEqual(
             elements["Existence of a contract"]["facts"][0]["weight"], 0.9
         )
-        self.assertAlmostEqual(breach["score"], 0.25)
-        elements = {e["name"]: e for e in breach["elements"]}
         self.assertTrue(elements["Existence of a contract"]["facts"])
         self.assertIn("defenses", breach)
         self.assertIn("indicators", breach)
@@ -48,3 +54,4 @@ class TestLegalTheoryEngine(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+


### PR DESCRIPTION
## Summary
- build LegalTheoryEngine to correlate ontology elements with facts from Neo4j/SQL and score causes of action
- register tool in legal discovery registry and wire to case_theorist agent
- cover engine with unit tests

## Testing
- `pytest tests/coded_tools/legal_discovery/test_legal_theory_engine.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689162ba53048333a9fb111eee078c33