### PR TITLE
Link facts to elements and score case theories

### DIFF
--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -513,3 +513,18 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 - Added tests for fact-element linking, theory scoring, and API endpoint coverage
 - Documented `/api/theories/suggest` usage in README
 - Next: broaden graph visualisations and extend endpoint coverage
+
+## Update 2025-08-05T15:00Z
+- Linked facts to supporting elements with `SUPPORTS` edges and tallied satisfied elements in `LegalTheoryEngine`
+- Exposed `/api/theories/suggest` endpoint returning ranked theories with supporting facts
+- Next: expand graph visualisation and refine element weighting metrics
+
+## Update 2025-08-05T18:00Z
+- Added weighted edge data to `get_cause_subgraph` and exposed `/api/theories/graph`
+- Refined theory scoring to average element weights for ranking
+- Next: surface graph visuals in dashboard and tune weighting heuristics
+
+## Update 2025-08-05T20:00Z
+- Surfaced cause-of-action graphs in the dashboard via event dispatch
+- Scoring now blends element weights with coverage ratio
+- Next: tune weighting thresholds and annotate graph nodes with fact counts

--- a/apps/legal_discovery/index.html
+++ b/apps/legal_discovery/index.html
@@ -5,6 +5,7 @@
     <title>Legal Discovery Dashboard</title>
     <link href="https://fonts.googleapis.com/css2?family=Rajdhani:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="./static/style.css">
+    <script src="https://cdn.jsdelivr.net/npm/cytoscape@3.26.0/dist/cytoscape.min.js"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/apps/legal_discovery/interface_flask.py
+++ b/apps/legal_discovery/interface_flask.py
@@ -361,19 +361,6 @@ def match_elements(text: str, ontology: dict) -> list[tuple[str, str, float]]:
     return matches
 
 
-def build_file_tree(directory: str, root_length: int) -> list:
-def match_elements(text: str, ontology: dict) -> list[tuple[str, str]]:
-    """Return (cause, element) pairs whose keywords appear in ``text``."""
-    matches: list[tuple[str, str]] = []
-    lower = text.lower()
-    for cause, data in ontology.get("causes_of_action", {}).items():
-        for element in data.get("elements", []):
-            tokens = [t for t in element.lower().split() if len(t) > 3]
-            if any(tok in lower for tok in tokens):
-                matches.append((cause, element))
-    return matches
-
-
 def build_file_tree(directory: str, root_length: int, docs: dict[str, Document]) -> list:
     """Recursively build a file tree structure."""
     tree = []
@@ -1292,6 +1279,18 @@ def suggest_theories():
     theories = engine.suggest_theories()
     engine.close()
     return jsonify({"status": "ok", "theories": theories})
+
+
+@app.route("/api/theories/graph", methods=["GET"])
+def theory_graph():
+    """Return graph data for a specific cause of action."""
+    cause = request.args.get("cause")
+    if not cause:
+        return jsonify({"status": "error", "error": "cause required"}), 400
+    engine = LegalTheoryEngine()
+    nodes, edges = engine.get_theory_subgraph(cause)
+    engine.close()
+    return jsonify({"status": "ok", "nodes": nodes, "edges": edges})
 
 
 @app.route("/api/query", methods=["POST"])

--- a/apps/legal_discovery/src/components/GraphSection.jsx
+++ b/apps/legal_discovery/src/components/GraphSection.jsx
@@ -21,6 +21,19 @@ function GraphSection() {
     window.addEventListener('graphRefresh', handler);
     return () => window.removeEventListener('graphRefresh', handler);
   }, [load]);
+
+  useEffect(() => {
+    const handler = (e) => {
+      const cause = e.detail && e.detail.cause;
+      if (!cause) return;
+      fetchJSON(`/api/theories/graph?cause=${encodeURIComponent(cause)}`).then(d => {
+        setNodes(d.nodes || []);
+        setEdges(d.edges || []);
+      });
+    };
+    window.addEventListener('loadTheoryGraph', handler);
+    return () => window.removeEventListener('loadTheoryGraph', handler);
+  }, []);
   useEffect(() => {
     if(!nodes.length && !edges.length) return;
     const cy = cytoscape({

--- a/apps/legal_discovery/src/components/LegalTheorySection.jsx
+++ b/apps/legal_discovery/src/components/LegalTheorySection.jsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from "react";
 function LegalTheorySection() {
   const [theories, setTheories] = useState([]);
   const [loading, setLoading] = useState(false);
+
   const load = () => {
     setLoading(true);
     fetch("/api/theories/suggest").then(r => r.json()).then(d => {
@@ -10,7 +11,13 @@ function LegalTheorySection() {
       setLoading(false);
     });
   };
+
+  const showGraph = (cause) => {
+    window.dispatchEvent(new CustomEvent('loadTheoryGraph', { detail: { cause } }));
+  };
+
   useEffect(() => { load(); }, []);
+
   return (
     <section className="card">
       <h2>Case Theory</h2>
@@ -19,7 +26,12 @@ function LegalTheorySection() {
       </button>
       {theories.map(t => (
         <div key={t.cause} className="mb-2">
-          <h3 className="font-bold">{t.cause} - {(t.score*100).toFixed(0)}%</h3>
+          <div className="flex items-center justify-between">
+            <h3 className="font-bold">{t.cause} - {(t.score*100).toFixed(0)}%</h3>
+            <button className="button-secondary" onClick={() => showGraph(t.cause)}>
+              <i className="fa fa-project-diagram mr-1"></i>Graph
+            </button>
+          </div>
           <ul className="list-disc list-inside text-sm">
             {t.elements.map(e => (
               <li key={e.name} className={e.weight > 0 ? "theory-supported" : ""}>
@@ -30,9 +42,6 @@ function LegalTheorySection() {
                 <div className="element-bar mt-1">
                   <div className="element-bar-fill" style={{width: `${e.weight*100}%`}}></div>
                 </div>
-              <li key={e.name} className={e.facts.length ? "theory-supported" : ""}>
-                {e.name}
-                {e.facts.length ? <span className="text-xs text-gray-400 ml-1">({e.facts.length})</span> : null}
               </li>
             ))}
           </ul>

--- a/coded_tools/legal_discovery/knowledge_graph_manager.py
+++ b/coded_tools/legal_discovery/knowledge_graph_manager.py
@@ -91,19 +91,21 @@ class KnowledgeGraphManager(CodedTool):
         return self.create_node(label, {"name": name})
 
     def link_fact_to_element(
-        self, fact_id: int, cause: str, element: str, weight: float = 1.0
+        self, fact_id: int, cause: str, element: str, weight: float | None = None
     ) -> None:
-        """Link an existing fact to an element and cause with a weighted relationship."""
+        """Link an existing fact to an element and cause of action.
+
+        A ``SUPPORTS`` edge is created from the ``Fact`` to the ``Element`` and
+        a ``BELONGS_TO`` edge from the ``Element`` to the ``CauseOfAction``.  If
+        ``weight`` is provided it is stored on the ``SUPPORTS`` relationship so
+        later scoring can take it into account.
+        """
+
         cause_id = self._get_or_create_by_name("CauseOfAction", cause)
         element_id = self._get_or_create_by_name("Element", element)
         self.create_relationship(element_id, cause_id, "BELONGS_TO")
-        self.create_relationship(fact_id, element_id, "SUPPORTS", {"weight": weight})
-    def link_fact_to_element(self, fact_id: int, cause: str, element: str) -> None:
-        """Link an existing fact to an element and cause of action."""
-        cause_id = self._get_or_create_by_name("CauseOfAction", cause)
-        element_id = self._get_or_create_by_name("Element", element)
-        self.create_relationship(element_id, cause_id, "BELONGS_TO")
-        self.create_relationship(fact_id, element_id, "SUPPORTS")
+        props = {"weight": weight} if weight is not None else None
+        self.create_relationship(fact_id, element_id, "SUPPORTS", props)
 
     def link_document_dispute(self, fact_id: int, document_node_id: int) -> None:
         """Link a fact to a document that disputes it."""
@@ -185,19 +187,19 @@ class KnowledgeGraphManager(CodedTool):
         )
 
         edges_query = (
-            "MATCH (e:Element)-[:BELONGS_TO]->(c:CauseOfAction {name:$cause}) "
-            "RETURN id(e) as source, id(c) as target, 'BELONGS_TO' as type "
+            "MATCH (e:Element)-[r:BELONGS_TO]->(c:CauseOfAction {name:$cause}) "
+            "RETURN id(e) as source, id(c) as target, 'BELONGS_TO' as type, properties(r) as properties "
             "UNION "
-            "MATCH (f:Fact)-[:SUPPORTS]->(e:Element)-[:BELONGS_TO]->(c:CauseOfAction {name:$cause}) "
-            "RETURN id(f) as source, id(e) as target, 'SUPPORTS' as type "
+            "MATCH (f:Fact)-[r:SUPPORTS]->(e:Element)-[:BELONGS_TO]->(c:CauseOfAction {name:$cause}) "
+            "RETURN id(f) as source, id(e) as target, 'SUPPORTS' as type, properties(r) as properties "
             "UNION "
-            "MATCH (f:Fact)-[:SUPPORTS]->(e:Element)-[:BELONGS_TO]->(c:CauseOfAction {name:$cause}), "
-            "(f)-[:DISPUTED_BY]->(d:Document) "
-            "RETURN id(f) as source, id(d) as target, 'DISPUTED_BY' as type "
+            "MATCH (f:Fact)-[s:SUPPORTS]->(e:Element)-[:BELONGS_TO]->(c:CauseOfAction {name:$cause}), "
+            "(f)-[r:DISPUTED_BY]->(d:Document) "
+            "RETURN id(f) as source, id(d) as target, 'DISPUTED_BY' as type, properties(r) as properties "
             "UNION "
-            "MATCH (f:Fact)-[:SUPPORTS]->(e:Element)-[:BELONGS_TO]->(c:CauseOfAction {name:$cause}), "
-            "(f)-[:ORIGINATED_IN]->(o) "
-            "RETURN id(f) as source, id(o) as target, 'ORIGINATED_IN' as type"
+            "MATCH (f:Fact)-[s:SUPPORTS]->(e:Element)-[:BELONGS_TO]->(c:CauseOfAction {name:$cause}), "
+            "(f)-[r:ORIGINATED_IN]->(o) "
+            "RETURN id(f) as source, id(o) as target, 'ORIGINATED_IN' as type, properties(r) as properties"
         )
 
         nodes = [
@@ -214,6 +216,7 @@ class KnowledgeGraphManager(CodedTool):
                 "source": record["source"],
                 "target": record["target"],
                 "type": record["type"],
+                "properties": record.get("properties", {}),
             }
             for record in self.run_query(edges_query, {"cause": cause})
         ]

--- a/tests/coded_tools/legal_discovery/test_api_endpoints.py
+++ b/tests/coded_tools/legal_discovery/test_api_endpoints.py
@@ -1,5 +1,5 @@
 import unittest
-from flask import Flask, jsonify
+from flask import Flask, jsonify, request
 from coded_tools.legal_discovery.legal_theory_engine import LegalTheoryEngine
 
 
@@ -25,6 +25,11 @@ class TestAPIEndpoints(unittest.TestCase):
         def suggest():
             return jsonify(self.engine.suggest_theories())
 
+        @app.route("/api/theories/graph")
+        def graph():
+            nodes, edges = self.engine.get_theory_subgraph(request.args.get("cause", ""))
+            return jsonify({"nodes": nodes, "edges": edges})
+
         self.client = app.test_client()
 
     def tearDown(self):
@@ -36,6 +41,13 @@ class TestAPIEndpoints(unittest.TestCase):
         data = resp.get_json()
         self.assertIsInstance(data, list)
         self.assertTrue(any(t["cause"] == "Breach of Contract" for t in data))
+
+    def test_theories_graph_endpoint(self):
+        resp = self.client.get("/api/theories/graph?cause=Fraud")
+        self.assertEqual(resp.status_code, 200)
+        data = resp.get_json()
+        self.assertIn("nodes", data)
+        self.assertIn("edges", data)
 
 
 if __name__ == "__main__":

--- a/tests/coded_tools/legal_discovery/test_knowledge_graph_manager.py
+++ b/tests/coded_tools/legal_discovery/test_knowledge_graph_manager.py
@@ -55,7 +55,7 @@ class TestKnowledgeGraphManager(unittest.TestCase):
             self.skipTest(str(exc))
 
         self.kg_manager.link_fact_to_element(
-            fact_id, "Fraud", "Misrepresentation"
+            fact_id, "Fraud", "Misrepresentation", weight=0.7
         )
         self.kg_manager.link_document_dispute(fact_id, doc_id)
         self.kg_manager.link_fact_origin(fact_id, "Email", "Email1")
@@ -67,6 +67,8 @@ class TestKnowledgeGraphManager(unittest.TestCase):
         self.assertIn("BELONGS_TO", edge_types)
         self.assertIn("DISPUTED_BY", edge_types)
         self.assertIn("ORIGINATED_IN", edge_types)
+        support_edge = next(e for e in edges if e["type"] == "SUPPORTS")
+        self.assertAlmostEqual(support_edge.get("properties", {}).get("weight"), 0.7)
         self.kg_manager.delete_node(fact_id)
         self.kg_manager.delete_node(doc_id)
         self.kg_manager.run_query("MATCH (n:Email {name:'Email1'}) DETACH DELETE n")

--- a/tests/coded_tools/legal_discovery/test_legal_theory_engine.py
+++ b/tests/coded_tools/legal_discovery/test_legal_theory_engine.py
@@ -50,8 +50,8 @@ class TestLegalTheoryEngine(unittest.TestCase):
         theories = engine.suggest_theories()
 
         breach = next(t for t in theories if t["cause"] == "Breach of Contract")
-        # One of four elements is supported by the dummy graph
-        self.assertAlmostEqual(breach["score"], 0.25)
+        # Score blends element weights with coverage ratio
+        self.assertAlmostEqual(breach["score"], 0.2375)
 
         elements = {e["name"]: e for e in breach["elements"]}
         self.assertAlmostEqual(elements["Existence of a contract"]["weight"], 0.9)
@@ -68,7 +68,7 @@ class TestLegalTheoryEngine(unittest.TestCase):
         theories = engine.suggest_theories()
         top = theories[0]
         self.assertEqual(top["cause"], "Breach of Contract")
-        self.assertAlmostEqual(top["score"], 0.5)
+        self.assertAlmostEqual(top["score"], 0.4625)
         elements = {e["name"]: e for e in top["elements"]}
         self.assertAlmostEqual(
             elements["Plaintiff's performance or excuse"]["weight"], 0.8


### PR DESCRIPTION
## Summary
- ensure facts connect to ontology elements through `SUPPORTS` edges with optional weights
- rank legal theories by averaging element weights and return supporting facts
- expose `/api/theories/suggest` and `/api/theories/graph` endpoints for retrieving ranked case theories and visualisation data
- surface cause-of-action graphs in dashboard and blend theory scores with coverage ratio

## Testing
- `pytest tests/coded_tools/legal_discovery/test_legal_theory_engine.py tests/coded_tools/legal_discovery/test_knowledge_graph_manager.py tests/coded_tools/legal_discovery/test_api_endpoints.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689183680ca88333b1442e21453bb1c3