### PR TITLE
Remove export side effects from deposition review

### DIFF
--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -543,3 +543,7 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 - Upgraded privilege detection with legal spaCy model support and textcat scoring
 - Logged redaction snippets and added privilege override API/UI controls
 - Next: polish reviewer workflow and monitor classifier performance
+
+## Update 2025-08-05T22:30Z
+- Removed outdated deposition export from review endpoint to enforce reviewer IDs and avoid undefined variables
+- Next: add unit tests covering deposition review logging

--- a/apps/legal_discovery/interface_flask.py
+++ b/apps/legal_discovery/interface_flask.py
@@ -1094,12 +1094,6 @@ def review_deposition():
     return jsonify({"status": "ok"})
 
 
-    os.makedirs("exports", exist_ok=True)
-    path = os.path.join("exports", f"deposition_{witness_id}.{fmt}")
-    DepositionPrep.export_questions(witness_id, path)
-    return send_file(path, as_attachment=True)
-
-
 @app.route("/api/subpoena/draft", methods=["POST"])
 def draft_subpoena():
     """Draft a subpoena document using SubpoenaManager."""


### PR DESCRIPTION
## Summary
- remove leftover export logic from `/api/deposition/review` to return status only
- log this change in legal discovery module notes

## Testing
- `pytest` *(fails: TestKnowledgeGraphManager::test_link_fact_to_element_creates_relationships)*

------
https://chatgpt.com/codex/tasks/task_e_6891d71b5bcc8333bc68769e9c445c94