### PR TITLE
Refactor deposition export and add tests

### DIFF
--- a/coded_tools/legal_discovery/deposition_prep.py
+++ b/coded_tools/legal_discovery/deposition_prep.py
@@ -165,11 +165,15 @@ class DepositionPrep:
         }
 
     @staticmethod
-    def export_questions(witness_id: int, file_path: str, reviewer_id: int) -> str:
+    def export_questions(
+        witness_id: int, file_path: str, reviewer_id: int
+    ) -> str:
+        """Export deposition questions to PDF or DOCX for an authorized reviewer."""
+
         reviewer = Agent.query.get(reviewer_id)
         if not reviewer or reviewer.role not in {"attorney", "case_admin"}:
             raise PermissionError("Reviewer lacks permission")
-    def export_questions(witness_id: int, file_path: str) -> str:
+
         witness = Witness.query.get_or_404(witness_id)
         questions = (
             DepositionQuestion.query.filter_by(witness_id=witness_id)
@@ -217,6 +221,7 @@ class DepositionPrep:
                 for i, src in enumerate(sources, 1):
                     doc.add_paragraph(f"[{i}] {src}")
             doc.save(file_path)
+
         return file_path
 
     @staticmethod


### PR DESCRIPTION
## Summary
- Merge duplicate `export_questions` methods into a single static method requiring `reviewer_id`
- Check reviewer permission before exporting deposition questions
- Add tests covering PDF and DOCX exports for authorized reviewers

## Testing
- `pytest tests/coded_tools/legal_discovery/test_deposition_prep.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6891c359e2f483338ed4481b84a702e6