### PR TITLE
Add chain of custody logging

### DIFF
--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -547,3 +547,9 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 ## Update 2025-08-05T22:30Z
 - Removed outdated deposition export from review endpoint to enforce reviewer IDs and avoid undefined variables
 - Next: add unit tests covering deposition review logging
+
+## Update 2025-08-05T10:56Z
+- Added chain-of-custody logging model and event triggers
+- Integrated logging utility across ingest, redaction, stamping, and export flows
+- Exposed retrieval API and React dashboard panel for chain logs
+- Next: extend filtering and export options for audit reports

--- a/apps/legal_discovery/chain_logger.py
+++ b/apps/legal_discovery/chain_logger.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from .database import db
+from .models import ChainOfCustodyLog, ChainEventType
+
+
+def log_event(
+    document_id: int,
+    event_type: ChainEventType | str,
+    user_id: Optional[int] = None,
+    metadata: Optional[dict[str, Any]] = None,
+) -> str:
+    """Persist a chain-of-custody event."""
+    etype = ChainEventType(event_type) if isinstance(event_type, str) else event_type
+    entry = ChainOfCustodyLog(
+        document_id=document_id,
+        event_type=etype,
+        user_id=user_id,
+        event_metadata=metadata or {},
+    )
+    db.session.add(entry)
+    db.session.commit()
+    return entry.id

--- a/apps/legal_discovery/src/Dashboard.jsx
+++ b/apps/legal_discovery/src/Dashboard.jsx
@@ -20,6 +20,7 @@ import SettingsModal from "./components/SettingsModal";
 import LegalTheorySection from "./components/LegalTheorySection";
 import ExhibitSection from "./components/ExhibitSection";
 import DepositionPrepSection from "./components/DepositionPrepSection";
+import ChainLogSection from "./components/ChainLogSection";
 const TABS = [
   {id:'network', label:'Agent Network', icon:'fa-sitemap'},
   {id:'overview', label:'Overview', icon:'fa-home'},
@@ -39,7 +40,8 @@ const TABS = [
   {id:'subpoena', label:'Subpoena', icon:'fa-gavel'},
   {id:'presentation', label:'Trial Prep', icon:'fa-slideshare'},
   {id:'exhibits', label:'Exhibits', icon:'fa-book'},
-  {id:'deposition', label:'Deposition Prep', icon:'fa-user-tie'}
+  {id:'deposition', label:'Deposition Prep', icon:'fa-user-tie'},
+  {id:'chain', label:'Chain Log', icon:'fa-link'}
 ];
 
 function Dashboard() {
@@ -85,6 +87,7 @@ function Dashboard() {
       <div className="tab-content" style={{display: tab==='presentation'?'block':'none'}} id="tab-presentation"><PresentationSection/></div>
       <div className="tab-content" style={{display: tab==='exhibits'?'block':'none'}} id="tab-exhibits"><ExhibitSection/></div>
       <div className="tab-content" style={{display: tab==='deposition'?'block':'none'}} id="tab-deposition"><DepositionPrepSection/></div>
+      <div className="tab-content" style={{display: tab==='chain'?'block':'none'}} id="tab-chain"><ChainLogSection/></div>
       <SettingsModal open={showSettings} onClose={()=>setShowSettings(false)}/>
     </div>
   );

--- a/apps/legal_discovery/src/components/ChainLogSection.jsx
+++ b/apps/legal_discovery/src/components/ChainLogSection.jsx
@@ -1,0 +1,36 @@
+import React, { useState } from "react";
+
+function ChainLogSection() {
+  const [docId, setDocId] = useState("");
+  const [events, setEvents] = useState([]);
+  const load = () => {
+    if (!docId) return;
+    fetch(`/api/chain?document_id=${docId}`)
+      .then((r) => r.json())
+      .then((d) => setEvents(d.events || []));
+  };
+  return (
+    <section className="card">
+      <h2>Chain of Custody</h2>
+      <input
+        type="text"
+        value={docId}
+        onChange={(e) => setDocId(e.target.value)}
+        className="w-full mb-2 p-2 rounded"
+        placeholder="Document ID"
+      />
+      <button className="button-secondary mb-2" onClick={load}>
+        <i className="fa fa-search mr-1"></i>Load
+      </button>
+      <ul className="text-sm">
+        {events.map((e, i) => (
+          <li key={i} className="mb-1">
+            <span className="font-bold">{e.type}</span> {e.timestamp}
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+export default ChainLogSection;


### PR DESCRIPTION
## Summary
- Add ChainOfCustodyLog model and enum to record ingest, redaction, stamping, export events
- Implement chain_logger utility and integrate logging across document pipeline
- Expose `/api/chain` retrieval endpoint and new dashboard tab to view chain of custody

## Testing
- `pytest` *(fails: TestKnowledgeGraphManager::test_link_fact_to_element_creates_relationships)*

------
https://chatgpt.com/codex/tasks/task_e_6891e0847974833398cdff8721ecb550