### PR TITLE
Add document source tracking and upload filters

### DIFF
--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -553,3 +553,12 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 - Integrated logging utility across ingest, redaction, stamping, and export flows
 - Exposed retrieval API and React dashboard panel for chain logs
 - Next: extend filtering and export options for audit reports
+## Update 2025-08-05T11:12Z
+- Added `DocumentSource` enum and `source` field with migration
+- Upload pipeline records source and returns it in file APIs
+- Vector database now skips duplicate/similar documents
+- React upload panel offers source selection, filtering, and color coding
+- Next: fix failing KnowledgeGraphManager relationship test
+## Update 2025-08-05T11:13Z
+- Removed duplicate logging import in vector database manager
+- Next: none

--- a/apps/legal_discovery/migrations/001_add_document_source.py
+++ b/apps/legal_discovery/migrations/001_add_document_source.py
@@ -1,0 +1,24 @@
+"""Add source field to Document"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "001_add_document_source"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    doc_source = sa.Enum("user", "opp_counsel", "court", name="documentsource")
+    doc_source.create(op.get_bind(), checkfirst=True)
+    op.add_column(
+        "document",
+        sa.Column("source", doc_source, nullable=False, server_default="user"),
+    )
+    op.alter_column("document", "source", server_default=None)
+
+
+def downgrade():
+    op.drop_column("document", "source")
+    sa.Enum(name="documentsource").drop(op.get_bind(), checkfirst=True)

--- a/apps/legal_discovery/models.py
+++ b/apps/legal_discovery/models.py
@@ -34,6 +34,12 @@ class TaskDependency(db.Model):
     depends_on_id = db.Column(db.Integer, db.ForeignKey("task.id"), nullable=False)
 
 
+class DocumentSource(enum.Enum):
+    USER = "user"
+    OPP_COUNSEL = "opp_counsel"
+    COURT = "court"
+
+
 class Document(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     case_id = db.Column(db.Integer, db.ForeignKey("case.id"), nullable=False)
@@ -42,6 +48,7 @@ class Document(db.Model):
     file_path = db.Column(db.String(255), nullable=False)
     content_hash = db.Column(db.String(64), nullable=False, unique=True)
     created_at = db.Column(db.DateTime, server_default=db.func.now())
+    source = db.Column(db.Enum(DocumentSource), nullable=False, default=DocumentSource.USER)
     is_privileged = db.Column(db.Boolean, nullable=False, default=False)
     is_redacted = db.Column(db.Boolean, nullable=False, default=False)
     needs_review = db.Column(db.Boolean, nullable=False, default=False)

--- a/apps/legal_discovery/src/components/UploadSection.jsx
+++ b/apps/legal_discovery/src/components/UploadSection.jsx
@@ -7,6 +7,8 @@ function UploadSection() {
   const [kgProg,setKgProg] = useState(0);
   const [neoProg,setNeoProg] = useState(0);
   const [current,setCurrent] = useState('');
+  const [source,setSource] = useState('user');
+  const [filter,setFilter] = useState('all');
   const togglePrivilege = (id, privileged) => {
     fetch(`/api/privilege/${id}`, {
       method: 'POST',
@@ -23,6 +25,7 @@ function UploadSection() {
       setCurrent(batch[0]?.name || '');
       const fd = new FormData();
       batch.forEach(f => fd.append('files', f, f.webkitRelativePath || f.name));
+      fd.append('source', source);
       await new Promise(res => {
         const xhr = new XMLHttpRequest();
         xhr.open('POST','/api/upload');
@@ -52,30 +55,56 @@ function UploadSection() {
     fetch('/api/organized-files').then(r=>r.json()).then(d=>setTree(d.data||[]));
   };
   useEffect(fetchFiles, []);
-  const renderNodes = nodes => nodes.map((n,i)=> n.children ? (
-    <li key={i} className="folder">
-      <div className="folder-header" onClick={e=>e.currentTarget.parentNode.classList.toggle('open')}><i className="folder-icon fa fa-caret-right"></i>{n.name}</div>
-      <div className="folder-contents"><ul>{renderNodes(n.children)}</ul></div>
-    </li>
-  ) : (
-    <li key={i} className={`file ${n.privileged ? 'privileged' : ''}`} onClick={() => window.open('/uploads/'+n.path,'_blank')}>
-      {n.name}
-      {n.privileged && <i className="fa fa-user-secret ml-1" />}
-      {n.id && (
-        <button
-          className="button-secondary ml-2 text-xs"
-          onClick={e => {e.stopPropagation(); togglePrivilege(n.id, !n.privileged);}}
-        >
-          {n.privileged ? 'Mark Public' : 'Mark Privileged'}
-        </button>
-      )}
-    </li>
-  ));
+  const sourceClass = s => {
+    switch (s) {
+      case 'opp_counsel': return 'text-red-400';
+      case 'court': return 'text-yellow-400';
+      default: return 'text-blue-400';
+    }
+  };
+  const renderNodes = nodes => nodes.map((n,i)=> {
+    if (n.children) {
+      const kids = renderNodes(n.children).filter(Boolean);
+      if (!kids.length) return null;
+      return (
+        <li key={i} className="folder">
+          <div className="folder-header" onClick={e=>e.currentTarget.parentNode.classList.toggle('open')}><i className="folder-icon fa fa-caret-right"></i>{n.name}</div>
+          <div className="folder-contents"><ul>{kids}</ul></div>
+        </li>
+      );
+    }
+    if (filter !== 'all' && n.source !== filter) return null;
+    return (
+      <li key={i} className={`file ${n.privileged ? 'privileged' : ''} ${sourceClass(n.source)}`} onClick={() => window.open('/uploads/'+n.path,'_blank')}>
+        {n.name}
+        {n.privileged && <i className="fa fa-user-secret ml-1" />}
+        {n.id && (
+          <button
+            className="button-secondary ml-2 text-xs"
+            onClick={e => {e.stopPropagation(); togglePrivilege(n.id, !n.privileged);}}
+          >
+            {n.privileged ? 'Mark Public' : 'Mark Privileged'}
+          </button>
+        )}
+      </li>
+    );
+  });
   return (
     <section className="card">
       <h2>Upload</h2>
       <input type="file" ref={inputRef} className="mb-3" webkitdirectory="" directory="" multiple />
       <div className="flex flex-wrap gap-2 mb-3">
+        <select value={source} onChange={e=>setSource(e.target.value)} className="px-2 py-1 bg-gray-800 border border-gray-600 rounded">
+          <option value="user">User</option>
+          <option value="opp_counsel">Opposing Counsel</option>
+          <option value="court">Court</option>
+        </select>
+        <select value={filter} onChange={e=>setFilter(e.target.value)} className="px-2 py-1 bg-gray-800 border border-gray-600 rounded">
+          <option value="all">All Sources</option>
+          <option value="user">User</option>
+          <option value="opp_counsel">Opposing Counsel</option>
+          <option value="court">Court</option>
+        </select>
         <button className="button-primary" onClick={upload}><i className="fa fa-upload mr-1"></i>Upload</button>
         <button className="button-secondary" onClick={exportAll}><i className="fa fa-file-export mr-1"></i>Export All</button>
         <button className="button-secondary" onClick={organize}><i className="fa fa-folder-tree mr-1"></i>Organize</button>


### PR DESCRIPTION
## Summary
- track document provenance with new `DocumentSource` enum and migration
- accept and persist upload `source` in Flask API, file tree, and vector DB
- filter and color-code uploads in React panel
- deduplicate and similarity-check documents before vector addition

## Testing
- `pytest` *(fails: TestKnowledgeGraphManager::test_link_fact_to_element_creates_relationships)*


------
https://chatgpt.com/codex/tasks/task_e_6891e441b6488333877d89239580246f