### PR TITLE
Add retrieval-augmented chat pipeline

### DIFF
--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -562,3 +562,8 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 ## Update 2025-08-05T11:13Z
 - Removed duplicate logging import in vector database manager
 - Next: none
+## Update 2025-08-06T00:00Z
+- Added conversation and message tables for chat memory with privilege-aware visibility
+- Implemented retrieval chat agent querying vector/graph stores with audit logging
+- React chat panel now uses Socket.IO client for real-time updates
+- Next: expand chat tests and manage multi-conversation UI

--- a/apps/legal_discovery/package-lock.json
+++ b/apps/legal_discovery/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "react": "^18.2.0",
         "react-calendar": "^6.0.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "socket.io-client": "^4.8.1"
       },
       "devDependencies": {
         "@vitejs/plugin-react": "^4.2.0",
@@ -733,6 +734,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -902,6 +909,45 @@
       "integrity": "sha512-xcwe9ELcuxYLUFqZZxL19Z6HVKcvNkIwhbHUz7L3us6u12yR+7uY89dSl570f/IqNthx8dAw3tojG7i4Ni4tDA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/engine.io-client": {
+      "version": "6.6.3",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.3.tgz",
+      "integrity": "sha512-T0iLjnyNWahNyv/lcjS2y4oE358tVS/SYQNxYXGAJ9/GLgH4VCvOQ/mhTjqU88mLZCQgiG8RIegFHYCdVC+j5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.17.1",
+        "xmlhttprequest-ssl": "~2.1.1"
+      }
+    },
+    "node_modules/engine.io-client/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.18.20",
@@ -1073,7 +1119,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -1234,6 +1279,68 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/socket.io-client": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.1.tgz",
+      "integrity": "sha512-hJVXfu3E28NmzGk8o1sHhN3om52tRvwYeidbj7xKy2eIIse5IoKX3USlS6Tqt3BHAtflLIkCQBkzVrEEfWUyYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.2",
+        "engine.io-client": "~6.6.1",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-client/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
+      "integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-parser/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -1338,6 +1445,35 @@
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.0.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xmlhttprequest-ssl": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+      "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/yallist": {

--- a/apps/legal_discovery/package.json
+++ b/apps/legal_discovery/package.json
@@ -10,7 +10,8 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-calendar": "^6.0.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "socket.io-client": "^4.8.1"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.2.0",

--- a/apps/legal_discovery/src/components/ChatSection.jsx
+++ b/apps/legal_discovery/src/components/ChatSection.jsx
@@ -1,27 +1,68 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
+import { io } from "socket.io-client";
+
 function ChatSection() {
   const [messages, setMessages] = useState([]);
-  const [input, setInput] = useState('');
+  const [input, setInput] = useState("");
+  const boxRef = useRef(null);
+
   useEffect(() => {
-    const socket = io('/chat');
-    socket.on('update_speech', d => setMessages(m => [...m, {type:'speech', text:d.data}]));
-    socket.on('update_user_input', d => setMessages(m => [...m, {type:'user', text:d.data}]));
+    const socket = io("/chat");
+    socket.on("update_speech", (d) =>
+      setMessages((m) => [...m, { type: "assistant", text: d.data }])
+    );
+    socket.on("update_user_input", (d) =>
+      setMessages((m) => [...m, { type: "user", text: d.data }])
+    );
     return () => socket.disconnect();
   }, []);
+
+  useEffect(() => {
+    if (boxRef.current) {
+      boxRef.current.scrollTop = boxRef.current.scrollHeight;
+    }
+  }, [messages]);
+
   const send = () => {
     if (!input.trim()) return;
-    fetch('/api/query', {method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify({text: input})})
-      .then(() => setInput(''));
+    fetch("/api/query", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ text: input }),
+    }).then(() => setInput(""));
   };
+
   return (
     <section className="card">
       <h2>Chat</h2>
-      <div className="chat-box" style={{maxHeight:'160px'}}>
-        {messages.map((m,i) => <div key={i} className={m.type==='user'?'user-msg':'speech-msg'}>{m.text}</div>)}
+      <div
+        ref={boxRef}
+        className="chat-box overflow-y-auto" 
+        style={{ maxHeight: "200px" }}
+      >
+        {messages.map((m, i) => (
+          <div
+            key={i}
+            className={
+              m.type === "user" ? "text-right text-blue-400" : "text-left text-green-300"
+            }
+          >
+            {m.text}
+          </div>
+        ))}
       </div>
-      <textarea value={input} onChange={e=>setInput(e.target.value)} rows="2" className="w-full mb-2 p-2 rounded" placeholder="Ask the assistant..."></textarea>
-      <button className="button-primary" onClick={send}>Send</button>
+      <textarea
+        value={input}
+        onChange={(e) => setInput(e.target.value)}
+        rows="2"
+        className="w-full mb-2 p-2 rounded bg-gray-800 text-gray-100"
+        placeholder="Ask the assistant..."
+      ></textarea>
+      <button className="button-primary" onClick={send}>
+        Send
+      </button>
     </section>
   );
 }
+
 export default ChatSection;

--- a/coded_tools/legal_discovery/__init__.py
+++ b/coded_tools/legal_discovery/__init__.py
@@ -23,6 +23,7 @@ from .legal_theory_engine import LegalTheoryEngine
 from .privilege_detector import PrivilegeDetector
 from .bates_numbering import BatesNumberingService, stamp_pdf
 from .deposition_prep import DepositionPrep
+from .chat_agent import RetrievalChatAgent
 
 __all__ = [
     "CaseManagementTools",
@@ -49,4 +50,5 @@ __all__ = [
     "BatesNumberingService",
     "stamp_pdf",
     "DepositionPrep",
+    "RetrievalChatAgent",
 ]

--- a/coded_tools/legal_discovery/chat_agent.py
+++ b/coded_tools/legal_discovery/chat_agent.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional
+
+from neuro_san.interfaces.coded_tool import CodedTool
+
+from apps.legal_discovery.chain_logger import ChainEventType, log_event
+from apps.legal_discovery.database import db
+from apps.legal_discovery.models import (
+    Conversation,
+    Document,
+    Message,
+    MessageVisibility,
+)
+
+from .knowledge_graph_manager import KnowledgeGraphManager
+from .privilege_detector import PrivilegeDetector
+from .vector_database_manager import VectorDatabaseManager
+
+
+class RetrievalChatAgent(CodedTool):
+    """Query vector and graph stores with privilege filtering and audit logging."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.vector_db = VectorDatabaseManager(**kwargs)
+        self.graph_db = KnowledgeGraphManager(**kwargs)
+        self.detector = PrivilegeDetector()
+
+    def _ensure_conversation(self, conversation_id: Optional[str], sender_id: int) -> Conversation:
+        if conversation_id:
+            convo = Conversation.query.get(conversation_id)
+            if convo:
+                if sender_id not in convo.participants:
+                    convo.participants.append(sender_id)
+                    db.session.commit()
+                return convo
+        convo = Conversation(participants=[sender_id])
+        db.session.add(convo)
+        db.session.commit()
+        return convo
+
+    def store_message(
+        self,
+        conversation_id: Optional[str],
+        sender_id: int,
+        content: str,
+        document_ids: Optional[List[int]] = None,
+        reply_to: Optional[str] = None,
+    ) -> Message:
+        convo = self._ensure_conversation(conversation_id, sender_id)
+        privileged, spans = self.detector.detect(content)
+        visibility = MessageVisibility.ATTORNEY_ONLY if privileged else MessageVisibility.PUBLIC
+        text = self.detector.redact_text(content, spans) if privileged else content
+        message = Message(
+            conversation_id=convo.id,
+            sender_id=sender_id,
+            content=text,
+            document_ids=document_ids or [],
+            reply_to_id=reply_to,
+            visibility=visibility,
+        )
+        db.session.add(message)
+        db.session.commit()
+        return message
+
+    def query(
+        self,
+        question: str,
+        sender_id: int = 0,
+        conversation_id: Optional[str] = None,
+        top_k: int = 5,
+    ) -> Dict[str, Any]:
+        message = self.store_message(conversation_id, sender_id, question)
+        vec = self.vector_db.query([question], n_results=top_k)
+        documents: List[Dict[str, Any]] = []
+        for doc_id, meta in zip(vec.get("ids", [[]])[0], vec.get("metadatas", [[]])[0]):
+            doc = Document.query.filter_by(id=int(meta.get("id", doc_id))).first()
+            if not doc or doc.is_privileged:
+                continue
+            log_event(doc.id, ChainEventType.ACCESSED, metadata={"message_id": message.id})
+            documents.append({"id": doc.id, "name": doc.name})
+        try:
+            records = self.graph_db.run_query(
+                "MATCH (f:Fact) WHERE toLower(f.text) CONTAINS toLower($q) RETURN f.text AS text LIMIT $k",
+                {"q": question, "k": top_k},
+            )
+            facts = [r["text"] for r in records]
+        except Exception as exc:  # pragma: no cover - best effort
+            logging.warning("graph query failed: %s", exc)
+            facts = []
+        return {"message_id": message.id, "documents": documents, "facts": facts}
+
+
+__all__ = ["RetrievalChatAgent"]


### PR DESCRIPTION
## Summary
- extend legal discovery models with conversation and message tables plus chain-of-custody access events
- implement RetrievalChatAgent querying vector and graph stores with privilege filtering and audit logging
- enhance chat route and React component to use Socket.IO for real-time assistant responses

## Testing
- `pytest tests/coded_tools/legal_discovery -q` *(fails: Failed to connect to Neo4j at bolt://localhost:7687)*


------
https://chatgpt.com/codex/tasks/task_e_6891e863a9e48333a11b8182a245bbf1