### PR TITLE
test: stub weasyprint and expand deposition prep assertions

### DIFF
--- a/condensed AGENTS.md
+++ b/condensed AGENTS.md
@@ -95,3 +95,7 @@ we are now working on implementing a major feature, so stand by, this is  A GDDM
 - Consolidated deposition question export into a single authorized method returning the generated file path
 - Added unit tests covering PDF and DOCX exports with reviewer authorization
 - Next: extend export tests to handle edge cases and additional formats
+
+## Update 2025-08-06T04:18Z
+- Added weasyprint stub for tests and expanded deposition prep assertions for contradiction detection and review logs
+- Next: cover additional deposition prep edge cases

--- a/tests/coded_tools/legal_discovery/conftest.py
+++ b/tests/coded_tools/legal_discovery/conftest.py
@@ -19,11 +19,13 @@ if importlib.util.find_spec("weasyprint") is None:  # pragma: no cover - environ
     weasyprint = types.ModuleType("weasyprint")
 
     class HTML:  # type: ignore
+        """Minimal stand-in for :class:`weasyprint.HTML`."""
+
         def __init__(self, string: str | None = None, *_, **__):
             self.string = string
 
-        def write_pdf(self, target: str) -> None:
-            # Write a tiny PDF header so tests can confirm output file creation
+        def write_pdf(self, target: str, *_args, **_kwargs) -> None:
+            """Create a tiny PDF so tests can confirm file output."""
             with open(target, "wb") as fh:
                 fh.write(b"%PDF-1.4\n%stub")
 

--- a/tests/coded_tools/legal_discovery/test_deposition_prep.py
+++ b/tests/coded_tools/legal_discovery/test_deposition_prep.py
@@ -26,6 +26,7 @@ class DummyResponse:
             self.message = type("obj", (), {"content": content})
 
     def __init__(self, content):
+        self.content = content
         self.choices = [DummyResponse.Choice(content)]
 
 
@@ -144,6 +145,7 @@ def test_detect_contradictions_and_export(monkeypatch, tmp_path):
         assert conflict.score == pytest.approx(0.95)
         assert "present on Monday" in conflict.description
         assert "absent on Monday" in conflict.description
+        assert conflict.created_at is not None
         pdf_path = tmp_path / "out.pdf"
         docx_path = tmp_path / "out.docx"
         returned_pdf = DepositionPrep.export_questions(witness.id, str(pdf_path), reviewer.id)
@@ -186,10 +188,12 @@ def test_review_logging_and_permissions(tmp_path):
         assert result["notes"] == "looks good"
         assert DepositionReviewLog.query.count() == 1
         log = DepositionReviewLog.query.first()
+        assert result["id"] == log.id
         assert log.reviewer_id == attorney.id
         assert log.witness_id == witness.id
         assert log.approved is True
         assert log.notes == "looks good"
+        assert log.timestamp is not None
         with pytest.raises(PermissionError):
             DepositionPrep.log_review(witness.id, paralegal.id, True)
         assert DepositionReviewLog.query.count() == 1


### PR DESCRIPTION
## Summary
- mock `weasyprint` in tests to allow deposition prep suite to run without the real dependency
- add coverage for contradiction detection and review logging in deposition prep tests

## Testing
- `pytest tests/coded_tools/legal_discovery/test_deposition_prep.py`


------
https://chatgpt.com/codex/tasks/task_e_6892d5ccc4748333ba3c40014a561782