### PR TITLE
Add chain-of-custody log model

### DIFF
--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -579,3 +579,8 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 ## Update 2025-08-06T02:40Z
 - Cleaned up RAG docstrings to reference Gemini embeddings
 - Next: confirm documentation aligns with new defaults
+
+## Update 2025-08-06T04:45Z
+- Implemented ChainOfCustodyLog model with immutable append-only records
+- Wired logging utility into ingest, redaction, stamping, and export flows with retrieval API and dashboard panel
+- Next: extend chain log filters and add report export options


### PR DESCRIPTION
## Summary
- introduce ChainEventType enum and ChainOfCustodyLog model for immutable chain-of-custody tracking
- wire log_event utility across ingestion, redaction, stamping and export flows
- expose `/api/chain` retrieval endpoint and React ChainLogSection to view chain-of-custody entries

## Testing
- `pytest` *(fails: AttributeError in deposition prep mock and Neo4j connection failure)*

------
https://chatgpt.com/codex/tasks/task_e_6892dfbcd7148333ba003ece12f789c5