### PR TITLE
feat: enhance privilege detection logging and overrides

### DIFF
--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -584,3 +584,8 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 - Implemented ChainOfCustodyLog model with immutable append-only records
 - Wired logging utility into ingest, redaction, stamping, and export flows with retrieval API and dashboard panel
 - Next: extend chain log filters and add report export options
+
+## Update 2025-08-06T05:30Z
+- Enhanced privilege detector with legal-model fallback and optional classifier
+- Recorded span scores in `RedactionLog` and exposed manual privilege override API/UI
+- Next: refine reviewer workflow and monitor classifier accuracy

--- a/apps/legal_discovery/src/components/UploadSection.jsx
+++ b/apps/legal_discovery/src/components/UploadSection.jsx
@@ -10,10 +10,12 @@ function UploadSection() {
   const [source,setSource] = useState('user');
   const [filter,setFilter] = useState('all');
   const togglePrivilege = (id, privileged) => {
+    const reviewer = prompt('Reviewer (optional):') || '';
+    const reason = prompt('Reason (optional):') || '';
     fetch(`/api/privilege/${id}`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ privileged })
+      body: JSON.stringify({ privileged, reviewer, reason })
     }).then(fetchFiles);
   };
   const upload = async () => {


### PR DESCRIPTION
## Summary
- expand privilege detector with legal-model fallback and optional classifier
- log redaction span scores and add privilege override event logging
- allow reviewer override from upload UI

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'neo4j'; ModuleNotFoundError: No module named 'flask_sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6892e922ad3c8333abf8032817d6b2a0