### PR TITLE
feat: add shared message bus and listeners

### DIFF
--- a/apps/conscious_assistant/listener.py
+++ b/apps/conscious_assistant/listener.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from apps.message_bus import (
+    FORENSIC_HASH_TOPIC,
+    RESEARCH_INSIGHT_TOPIC,
+    MessageBus,
+    TeamMessage,
+)
+
+
+bus = MessageBus()
+
+
+def _handle_forensic(message: TeamMessage) -> None:
+    print(
+        f"[conscious_assistant] Forensic hash from {message.source_team}: {message.payload}"
+    )
+
+
+def _handle_research(message: TeamMessage) -> None:
+    print(
+        f"[conscious_assistant] Research insight from {message.source_team}: {message.payload}"
+    )
+
+
+def start_listening() -> None:
+    bus.subscribe(FORENSIC_HASH_TOPIC, _handle_forensic)
+    bus.subscribe(RESEARCH_INSIGHT_TOPIC, _handle_research)

--- a/apps/cruse/listener.py
+++ b/apps/cruse/listener.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from apps.message_bus import (
+    FORENSIC_HASH_TOPIC,
+    RESEARCH_INSIGHT_TOPIC,
+    MessageBus,
+    TeamMessage,
+)
+
+
+bus = MessageBus()
+
+
+def _handle_forensic(message: TeamMessage) -> None:
+    print(f"[cruse] Forensic hash from {message.source_team}: {message.payload}")
+
+
+def _handle_research(message: TeamMessage) -> None:
+    print(f"[cruse] Research insight from {message.source_team}: {message.payload}")
+
+
+def start_listening() -> None:
+    bus.subscribe(FORENSIC_HASH_TOPIC, _handle_forensic)
+    bus.subscribe(RESEARCH_INSIGHT_TOPIC, _handle_research)

--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -594,3 +594,7 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 - Added migration for conversation and message tables with visibility enum.
 - Verified retrieval chat agent wiring with privilege filtering and audit logging.
 - Next: expand chat tests and support multi-conversation management.
+## Update 2025-08-06T09:00Z
+- Added Redis-backed message bus and listener module.
+- Chain-of-custody logs now record `source_team` for provenance.
+- Next: persist research insights received via message bus.

--- a/apps/legal_discovery/chain_logger.py
+++ b/apps/legal_discovery/chain_logger.py
@@ -11,6 +11,7 @@ def log_event(
     event_type: ChainEventType | str,
     user_id: Optional[int] = None,
     metadata: Optional[dict[str, Any]] = None,
+    source_team: str = "unknown",
 ) -> str:
     """Persist a chain-of-custody event."""
     etype = ChainEventType(event_type) if isinstance(event_type, str) else event_type
@@ -18,6 +19,7 @@ def log_event(
         document_id=document_id,
         event_type=etype,
         user_id=user_id,
+        source_team=source_team,
         event_metadata=metadata or {},
     )
     db.session.add(entry)

--- a/apps/legal_discovery/interface_flask.py
+++ b/apps/legal_discovery/interface_flask.py
@@ -449,6 +449,7 @@ def override_privilege(doc_id: int):
         doc.id,
         ChainEventType.REDACTED,
         metadata={"override": True, "privileged": doc.is_privileged},
+        source_team="legal_discovery",
     )
     db.session.commit()
     return jsonify({"status": "ok", "privileged": doc.is_privileged})
@@ -652,6 +653,7 @@ def ingest_document(
             doc_id,
             ChainEventType.REDACTED,
             metadata={"spans": [(s.start, s.end) for s in spans]},
+            source_team="legal_discovery",
         )
     else:
         shutil.copy(original_path, redacted_path)
@@ -705,7 +707,12 @@ def ingest_document(
                 kg.link_fact_to_element(fact_id, cause, element, weight)
 
     kg.close()
-    log_event(doc_id, ChainEventType.INGESTED, metadata={"path": redacted_path})
+    log_event(
+        doc_id,
+        ChainEventType.INGESTED,
+        metadata={"path": redacted_path},
+        source_team="legal_discovery",
+    )
 
 
 MAX_FILE_SIZE = 50 * 1024 * 1024  # 50MB
@@ -875,7 +882,12 @@ def export_files():
     archive = "processed_files.zip"
     shutil.make_archive("processed_files", "zip", UPLOAD_FOLDER)
     for doc in Document.query.all():
-        log_event(doc.id, ChainEventType.EXPORTED, metadata={"archive": archive})
+        log_event(
+            doc.id,
+            ChainEventType.EXPORTED,
+            metadata={"archive": archive},
+            source_team="legal_discovery",
+        )
     return send_from_directory(".", archive, as_attachment=True)
 
 
@@ -953,7 +965,12 @@ def redact_document():
         return jsonify({"error": str(exc)}), 500
     doc = Document.query.filter_by(file_path=file_path).first()
     if doc:
-        log_event(doc.id, ChainEventType.REDACTED, metadata={"text": text})
+        log_event(
+            doc.id,
+            ChainEventType.REDACTED,
+            metadata={"text": text},
+            source_team="legal_discovery",
+        )
     return jsonify({"message": "File redacted", "output": f"{file_path}_redacted.pdf"})
 
 
@@ -972,7 +989,12 @@ def bates_stamp_document():
         return jsonify({"error": str(exc)}), 500
     doc = Document.query.filter_by(file_path=file_path).first()
     if doc:
-        log_event(doc.id, ChainEventType.STAMPED, metadata={"prefix": prefix})
+        log_event(
+            doc.id,
+            ChainEventType.STAMPED,
+            metadata={"prefix": prefix},
+            source_team="legal_discovery",
+        )
     return jsonify({"message": "File stamped", "output": f"{file_path}_stamped.pdf"})
 
 

--- a/apps/legal_discovery/listener.py
+++ b/apps/legal_discovery/listener.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from apps.message_bus import (
+    FORENSIC_HASH_TOPIC,
+    RESEARCH_INSIGHT_TOPIC,
+    MessageBus,
+    TeamMessage,
+)
+
+
+bus = MessageBus()
+
+
+def _handle_forensic(message: TeamMessage) -> None:
+    print(
+        f"[legal_discovery] Forensic hash from {message.source_team}: {message.payload}"
+    )
+
+
+def _handle_research(message: TeamMessage) -> None:
+    print(
+        f"[legal_discovery] Research insight from {message.source_team}: {message.payload}"
+    )
+
+
+def start_listening() -> None:
+    bus.subscribe(FORENSIC_HASH_TOPIC, _handle_forensic)
+    bus.subscribe(RESEARCH_INSIGHT_TOPIC, _handle_research)

--- a/apps/legal_discovery/models.py
+++ b/apps/legal_discovery/models.py
@@ -138,6 +138,7 @@ class ChainOfCustodyLog(db.Model):
     event_type = db.Column(db.Enum(ChainEventType), nullable=False)
     timestamp = db.Column(db.DateTime, server_default=db.func.now())
     user_id = db.Column(db.Integer, db.ForeignKey("agent.id"), nullable=True)
+    source_team = db.Column(db.String(100), nullable=False, default="unknown")
     event_metadata = db.Column(db.JSON, nullable=True)
 
     user = db.relationship("Agent", backref=db.backref("chain_logs", lazy=True))

--- a/apps/log_analyzer/listener.py
+++ b/apps/log_analyzer/listener.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from apps.message_bus import (
+    FORENSIC_HASH_TOPIC,
+    RESEARCH_INSIGHT_TOPIC,
+    MessageBus,
+    TeamMessage,
+)
+
+
+bus = MessageBus()
+
+
+def _handle_forensic(message: TeamMessage) -> None:
+    print(f"[log_analyzer] Forensic hash from {message.source_team}: {message.payload}")
+
+
+def _handle_research(message: TeamMessage) -> None:
+    print(f"[log_analyzer] Research insight from {message.source_team}: {message.payload}")
+
+
+def start_listening() -> None:
+    bus.subscribe(FORENSIC_HASH_TOPIC, _handle_forensic)
+    bus.subscribe(RESEARCH_INSIGHT_TOPIC, _handle_research)

--- a/apps/message_bus.py
+++ b/apps/message_bus.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Callable, Dict
+
+import redis
+
+# Topic names shared across features
+FORENSIC_HASH_TOPIC = "team.forensic.hashes"
+RESEARCH_INSIGHT_TOPIC = "team.research.insights"
+
+
+@dataclass
+class TeamMessage:
+    """Message payload with provenance metadata."""
+
+    source_team: str
+    payload: Dict[str, Any]
+
+
+class MessageBus:
+    """Simple Redis pub/sub wrapper for team communication."""
+
+    def __init__(self, url: str = "redis://localhost:6379/0") -> None:
+        self._client = redis.Redis.from_url(url)
+
+    def publish(self, topic: str, message: TeamMessage) -> None:
+        data = json.dumps({"source_team": message.source_team, "payload": message.payload})
+        self._client.publish(topic, data)
+
+    def subscribe(self, topic: str, handler: Callable[[TeamMessage], None]) -> None:
+        pubsub = self._client.pubsub()
+
+        def _callback(msg: Dict[str, Any]) -> None:
+            data = json.loads(msg["data"]) if isinstance(msg["data"], bytes) else {}
+            handler(
+                TeamMessage(source_team=data.get("source_team", "unknown"), payload=data.get("payload", {}))
+            )
+
+        pubsub.subscribe(**{topic: _callback})
+        pubsub.run_in_thread(sleep_time=0.001, daemon=True)

--- a/apps/wwaw/listener.py
+++ b/apps/wwaw/listener.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from apps.message_bus import (
+    FORENSIC_HASH_TOPIC,
+    RESEARCH_INSIGHT_TOPIC,
+    MessageBus,
+    TeamMessage,
+)
+
+
+bus = MessageBus()
+
+
+def _handle_forensic(message: TeamMessage) -> None:
+    print(f"[wwaw] Forensic hash from {message.source_team}: {message.payload}")
+
+
+def _handle_research(message: TeamMessage) -> None:
+    print(f"[wwaw] Research insight from {message.source_team}: {message.payload}")
+
+
+def start_listening() -> None:
+    bus.subscribe(FORENSIC_HASH_TOPIC, _handle_forensic)
+    bus.subscribe(RESEARCH_INSIGHT_TOPIC, _handle_research)

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ schedule>=1.1.0
 Flask-SQLAlchemy>=2.5.1
 pandas>=1.3.5
 reportlab
+redis>=5.0.0
 
 # We separate out requirements that are specific to the build, but not
 # necessary for operation to minimize the size of containers


### PR DESCRIPTION
## Summary
- establish Redis-backed message bus with forensic hash and research insight topics
- add listener modules to each feature subscribing to shared topics
- record source team metadata in legal discovery chain-of-custody logs

## Testing
- `pip install redis`
- `pip install pytest-cov pytest-asyncio pytest-timer coverage`
- `pip install neuro-san`
- `pip install pymupdf`
- `pytest` *(fails: ModuleNotFoundError: No module named 'fitz')*

------
https://chatgpt.com/codex/tasks/task_e_6892f8dfaa6c83338097b369688af42e