### PR TITLE
Add theory confidence model and enhanced fact extraction

### DIFF
--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -598,3 +598,9 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 - Added Redis-backed message bus and listener module.
 - Chain-of-custody logs now record `source_team` for provenance.
 - Next: persist research insights received via message bus.
+
+## Update 2025-08-06T10:30Z
+- Extended ontology with new causes, defenses and jurisdiction mapping.
+- Added `TheoryConfidence` model and migration linking facts to theories with source provenance.
+- Upgraded fact extractor for NER tagging, relationship extraction and confidence scoring.
+- Next: surface theory confidence metrics in API responses and dashboard graphs.

--- a/apps/legal_discovery/migrations/003_add_theory_confidence.py
+++ b/apps/legal_discovery/migrations/003_add_theory_confidence.py
@@ -1,0 +1,26 @@
+from alembic import op
+import sqlalchemy as sa
+
+revision = "003_add_theory_confidence"
+down_revision = "002_add_chat_tables"
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    op.create_table(
+        "theory_confidence",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("legal_theory_id", sa.Integer(), sa.ForeignKey("legal_theory.id"), nullable=False),
+        sa.Column("fact_id", sa.Integer(), sa.ForeignKey("fact.id"), nullable=False),
+        sa.Column("confidence", sa.Float(), nullable=False),
+        sa.Column("source_team", sa.String(length=100), nullable=False, server_default="unknown"),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now()),
+        sa.CheckConstraint("confidence >= 0 AND confidence <= 1", name="ck_theory_confidence_range"),
+    )
+    op.alter_column("theory_confidence", "source_team", server_default=None)
+    op.create_index("ix_theory_confidence_theory_fact", "theory_confidence", ["legal_theory_id", "fact_id"], unique=True)
+
+
+def downgrade():
+    op.drop_index("ix_theory_confidence_theory_fact", table_name="theory_confidence")
+    op.drop_table("theory_confidence")

--- a/apps/legal_discovery/models.py
+++ b/apps/legal_discovery/models.py
@@ -356,6 +356,27 @@ class Fact(db.Model):
     witness = db.relationship("Witness", backref=db.backref("facts", lazy=True))
 
 
+class TheoryConfidence(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    legal_theory_id = db.Column(db.Integer, db.ForeignKey("legal_theory.id"), nullable=False)
+    fact_id = db.Column(db.Integer, db.ForeignKey("fact.id"), nullable=False)
+    confidence = db.Column(db.Float, nullable=False)
+    source_team = db.Column(db.String(100), nullable=False, default="unknown")
+    created_at = db.Column(db.DateTime, server_default=db.func.now())
+    __table_args__ = (
+        db.CheckConstraint("confidence >= 0 AND confidence <= 1", name="ck_theory_confidence_range"),
+    )
+
+    legal_theory = db.relationship(
+        "LegalTheory",
+        backref=db.backref("confidence_links", lazy=True, cascade="all, delete-orphan"),
+    )
+    fact = db.relationship(
+        "Fact",
+        backref=db.backref("theory_links", lazy=True, cascade="all, delete-orphan"),
+    )
+
+
 class DepositionQuestion(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     witness_id = db.Column(db.Integer, db.ForeignKey("witness.id"), nullable=False)

--- a/coded_tools/legal_discovery/fact_extractor.py
+++ b/coded_tools/legal_discovery/fact_extractor.py
@@ -2,30 +2,79 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional, Tuple
 
 import spacy
 from spacy.cli import download as spacy_download
+
+from .ontology_loader import OntologyLoader
 
 
 class FactExtractor:
     """Identify facts, parties, actions and dates using spaCy."""
 
-    def __init__(self, model: str = "en_core_web_sm") -> None:
-        """Load a spaCy pipeline, downloading the model if necessary."""
+    def __init__(self, model: str = "en_core_web_sm", loader: Optional[OntologyLoader] = None) -> None:
+        """Load a spaCy pipeline and ontology data.
+
+        Parameters
+        ----------
+        model: str
+            spaCy model name to load. The model will be downloaded if missing.
+        loader: OntologyLoader, optional
+            Loader instance providing ontology elements for similarity scoring.
+        """
         try:
             self.nlp = spacy.load(model)
         except OSError:
             spacy_download(model)
             self.nlp = spacy.load(model)
+        self.loader = loader or OntologyLoader()
 
-    def extract(self, text: str) -> List[Dict[str, Any]]:
-        """Return a list of facts with parties, actions and dates.
+    def _match_element(self, sent: spacy.tokens.Span) -> Tuple[Optional[str], float]:
+        """Return the most similar ontology element for the sentence."""
+        ontology = self.loader.load()["causes_of_action"]
+        best_element: Optional[str] = None
+        best_score = 0.0
+        sent_doc = sent.as_doc()
+        for data in ontology.values():
+            for element in data.get("elements", []):
+                elem_doc = self.nlp(element)
+                score = sent_doc.similarity(elem_doc)
+                if score > best_score:
+                    best_score = score
+                    best_element = element
+        return best_element, best_score
+
+    def _extract_relationships(self, sent: spacy.tokens.Span) -> List[Dict[str, Optional[str]]]:
+        """Extract simple subject-verb-object relationships from a sentence."""
+        relationships: List[Dict[str, Optional[str]]] = []
+        for token in sent:
+            if token.dep_ == "ROOT" and token.pos_ == "VERB":
+                subj = [w.text for w in token.lefts if w.dep_ in {"nsubj", "nsubjpass"}]
+                obj = [w.text for w in token.rights if w.dep_ in {"dobj", "pobj", "attr", "dative"}]
+                if subj or obj:
+                    relationships.append(
+                        {
+                            "subject": " ".join(subj) if subj else None,
+                            "verb": token.lemma_,
+                            "object": " ".join(obj) if obj else None,
+                        }
+                    )
+        return relationships
+
+    def extract(self, text: str, source_reliability: float = 1.0) -> List[Dict[str, Any]]:
+        """Return a list of facts with entity tags and confidence scores.
+
+        Confidence is computed as ``similarity * source_reliability`` where
+        similarity is the cosine similarity between the sentence and the
+        closest matching ontology element.
 
         Parameters
         ----------
         text: str
             Raw document text.
+        source_reliability: float, optional
+            Multiplier in [0,1] representing the trustworthiness of the source.
         """
         doc = self.nlp(text)
         facts: List[Dict[str, Any]] = []
@@ -39,12 +88,18 @@ class FactExtractor:
                     dates.append(ent.text)
             actions = [token.lemma_ for token in sent if token.pos_ == "VERB"]
             if parties or dates or actions:
+                relationships = self._extract_relationships(sent)
+                element, similarity = self._match_element(sent)
+                confidence = max(min(similarity * source_reliability, 1.0), 0.0)
                 facts.append(
                     {
                         "text": sent.text.strip(),
                         "parties": parties,
                         "dates": dates,
                         "actions": actions,
+                        "relationships": relationships,
+                        "element": element,
+                        "confidence": confidence,
                     }
                 )
         return facts

--- a/coded_tools/legal_discovery/legal_theory_ontology.json
+++ b/coded_tools/legal_discovery/legal_theory_ontology.json
@@ -9,7 +9,8 @@
       ],
       "defenses": [
         "Lack of Consideration",
-        "Statute of Frauds"
+        "Statute of Frauds",
+        "Statute of Limitations"
       ],
       "indicators": [
         "signed agreement",
@@ -44,7 +45,8 @@
       ],
       "defenses": [
         "Comparative negligence",
-        "Assumption of risk"
+        "Assumption of risk",
+        "Statute of Limitations"
       ],
       "indicators": [
         "accident report",
@@ -112,13 +114,73 @@
       ],
       "defenses": [
         "Product misuse",
-        "Assumption of risk"
+        "Assumption of risk",
+        "Contributory negligence"
       ],
       "indicators": [
         "product recall",
         "design schematics",
         "injury reports"
       ]
+    },
+    "Battery": {
+      "elements": [
+        "Intentional act",
+        "Harmful or offensive contact",
+        "Causation"
+      ],
+      "defenses": [
+        "Consent",
+        "Self-defense"
+      ],
+      "indicators": [
+        "medical report",
+        "witness statement",
+        "photographs of injury"
+      ]
+    },
+    "Conversion": {
+      "elements": [
+        "Plaintiff's ownership",
+        "Defendant's wrongful dominion",
+        "Damages"
+      ],
+      "defenses": [
+        "Consent",
+        "Authority of law"
+      ],
+      "indicators": [
+        "property records",
+        "demand letters",
+        "police reports"
+      ]
+    },
+    "Trespass to Land": {
+      "elements": [
+        "Ownership or possessory interest",
+        "Intentional entry",
+        "Without consent",
+        "Damages"
+      ],
+      "defenses": [
+        "Necessity",
+        "Consent"
+      ],
+      "indicators": [
+        "boundary surveys",
+        "photographs of entry",
+        "land records"
+      ]
+    }
+  },
+  "jurisdictions": {
+    "California": {
+      "Breach of Contract": "Cal. Civ. Proc. Code § 337",
+      "Fraud": "Cal. Civ. Code § 1572"
+    },
+    "New York": {
+      "Breach of Contract": "N.Y. C.P.L.R. 213(2)",
+      "Fraud": "N.Y. Gen. Bus. Law § 349"
     }
   }
 }

--- a/condensed AGENTS.md
+++ b/condensed AGENTS.md
@@ -99,3 +99,9 @@ we are now working on implementing a major feature, so stand by, this is  A GDDM
 ## Update 2025-08-06T04:18Z
 - Added weasyprint stub for tests and expanded deposition prep assertions for contradiction detection and review logs
 - Next: cover additional deposition prep edge cases
+
+## Update 2025-08-06T10:30Z
+- Expanded legal theory ontology with additional causes, defenses and jurisdiction data.
+- Introduced `TheoryConfidence` model with migration linking facts to theories with scored confidence.
+- Enhanced fact extractor to tag relationships and compute confidence from similarity and source reliability.
+- Next: expose confidence metrics through API and UI visualisations.

--- a/tests/apps/test_theory_confidence.py
+++ b/tests/apps/test_theory_confidence.py
@@ -1,0 +1,42 @@
+from flask import Flask
+from apps.legal_discovery.database import db
+from apps.legal_discovery.models import (
+    Case,
+    Document,
+    LegalTheory,
+    Fact,
+    TheoryConfidence,
+)
+
+
+def _setup_app():
+    app = Flask(__name__)
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite://"
+    app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
+    db.init_app(app)
+    return app
+
+
+def test_theory_confidence_model():
+    app = _setup_app()
+    with app.app_context():
+        db.create_all()
+        case = Case(name="Test Case")
+        db.session.add(case)
+        db.session.commit()
+        doc = Document(
+            case_id=case.id,
+            name="Doc",
+            file_path="/tmp/doc.txt",
+            content_hash="hash",
+        )
+        theory = LegalTheory(case_id=case.id, theory_name="Breach of Contract")
+        fact = Fact(case_id=case.id, document=doc, legal_theory=theory, text="Alice signed", parties=[], dates=[], actions=[])
+        db.session.add_all([doc, theory, fact])
+        db.session.commit()
+        tc = TheoryConfidence(legal_theory=theory, fact=fact, confidence=0.8, source_team="team1")
+        db.session.add(tc)
+        db.session.commit()
+        assert tc.id is not None
+        assert 0 <= tc.confidence <= 1
+        assert tc.source_team == "team1"

--- a/tests/coded_tools/legal_discovery/test_fact_extractor.py
+++ b/tests/coded_tools/legal_discovery/test_fact_extractor.py
@@ -7,10 +7,13 @@ from coded_tools.legal_discovery.fact_extractor import FactExtractor
 def test_fact_extraction_basic():
     extractor = FactExtractor()
     text = "On May 5, 2024, Alice signed a contract with Bob."
-    facts = extractor.extract(text)
+    facts = extractor.extract(text, source_reliability=0.9)
     assert len(facts) == 1
     fact = facts[0]
     assert "Alice" in fact["parties"]
     assert "Bob" in fact["parties"]
     assert any("May" in d for d in fact["dates"])
     assert "sign" in fact["actions"]
+    assert 0.0 <= fact["confidence"] <= 1.0
+    assert isinstance(fact.get("element"), (str, type(None)))
+    assert fact["relationships"]


### PR DESCRIPTION
## Summary
- extend legal theory ontology with new causes of action, defenses, and jurisdiction metadata
- introduce TheoryConfidence model/migration linking facts to theories with scored confidence
- upgrade FactExtractor for NER-based relationship tagging and confidence = similarity × source reliability

## Testing
- `pytest tests/coded_tools/legal_discovery/test_fact_extractor.py tests/apps/test_theory_confidence.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6892fc2521e8833399ce3b45a3157080