### PR TITLE
Enhance theory evaluation and routing

### DIFF
--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -604,3 +604,7 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 - Added `TheoryConfidence` model and migration linking facts to theories with source provenance.
 - Upgraded fact extractor for NER tagging, relationship extraction and confidence scoring.
 - Next: surface theory confidence metrics in API responses and dashboard graphs.
+
+## Update 2025-08-06T12:30Z
+- Added confidence-weighted SUPPORTS/CONTRADICTS edges and theory acceptance routing to drafter, pretrial and timeline APIs.
+- Next: surface accepted theory outputs in dashboard UI.

--- a/coded_tools/legal_discovery/__init__.py
+++ b/coded_tools/legal_discovery/__init__.py
@@ -10,6 +10,7 @@ from .file_manager import FileManager
 from .forensic_tools import ForensicTools
 from .knowledge_graph_manager import KnowledgeGraphManager
 from .presentation_generator import PresentationGenerator
+from .pretrial_generator import PretrialGenerator
 from .research_tools import ResearchTools
 from .subpoena_manager import SubpoenaManager
 from .task_tracker import TaskTracker
@@ -36,6 +37,7 @@ __all__ = [
     "ForensicTools",
     "KnowledgeGraphManager",
     "PresentationGenerator",
+    "PretrialGenerator",
     "ResearchTools",
     "SubpoenaManager",
     "TaskTracker",

--- a/coded_tools/legal_discovery/pretrial_generator.py
+++ b/coded_tools/legal_discovery/pretrial_generator.py
@@ -1,0 +1,16 @@
+from neuro_san.interfaces.coded_tool import CodedTool
+
+
+class PretrialGenerator(CodedTool):
+    """Generate simple pretrial statements for accepted theories."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+    def generate_statement(self, cause: str, elements: list[str]) -> str:
+        """Return a pretrial statement summarising the elements for a cause."""
+
+        lines = [f"Pretrial Statement for {cause}", ""]
+        for el in elements:
+            lines.append(f"- {el}")
+        return "\n".join(lines)

--- a/tests/coded_tools/legal_discovery/test_legal_theory_engine.py
+++ b/tests/coded_tools/legal_discovery/test_legal_theory_engine.py
@@ -15,7 +15,13 @@ class DummyKG:
     def run_query(self, query, params):  # pragma: no cover - simple stub
         element = params["element"]
         if element == "Existence of a contract":
-            return [{"text": "Contract between A and B", "weight": 0.9}]
+            return [
+                {
+                    "text": "Contract between A and B",
+                    "weight": 0.9,
+                    "dates": ["2024-01-01"],
+                }
+            ]
         return []
 
     def get_cause_subgraph(self, cause):  # pragma: no cover - simple stub
@@ -32,9 +38,21 @@ class ScoringKG:
     def run_query(self, query, params):
         element = params["element"]
         if element == "Existence of a contract":
-            return [{"text": "Contract exists", "weight": 0.9}]
+            return [
+                {
+                    "text": "Contract exists",
+                    "weight": 0.9,
+                    "dates": ["2024-01-01"],
+                }
+            ]
         if element == "Plaintiff's performance or excuse":
-            return [{"text": "Performance", "weight": 0.8}]
+            return [
+                {
+                    "text": "Performance",
+                    "weight": 0.8,
+                    "dates": ["2024-02-01"],
+                }
+            ]
         return []
 
     def get_cause_subgraph(self, cause):
@@ -55,12 +73,12 @@ class TestLegalTheoryEngine(unittest.TestCase):
 
         elements = {e["name"]: e for e in breach["elements"]}
         self.assertAlmostEqual(elements["Existence of a contract"]["weight"], 0.9)
-        self.assertEqual(
-            elements["Existence of a contract"]["facts"][0]["weight"], 0.9
-        )
+        self.assertEqual(elements["Existence of a contract"]["facts"][0]["weight"], 0.9)
         self.assertTrue(elements["Existence of a contract"]["facts"])
         self.assertIn("defenses", breach)
         self.assertIn("indicators", breach)
+        self.assertIn("missing_elements", breach)
+        self.assertTrue(breach["missing_elements"])
         engine.close()
 
     def test_suggestion_scoring(self):
@@ -70,9 +88,7 @@ class TestLegalTheoryEngine(unittest.TestCase):
         self.assertEqual(top["cause"], "Breach of Contract")
         self.assertAlmostEqual(top["score"], 0.4625)
         elements = {e["name"]: e for e in top["elements"]}
-        self.assertAlmostEqual(
-            elements["Plaintiff's performance or excuse"]["weight"], 0.8
-        )
+        self.assertAlmostEqual(elements["Plaintiff's performance or excuse"]["weight"], 0.8)
         engine.close()
 
     def test_get_theory_subgraph(self):
@@ -85,4 +101,3 @@ class TestLegalTheoryEngine(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-


### PR DESCRIPTION
## Summary
- Allow KnowledgeGraphManager to create weighted SUPPORTS/CONTRADICTS edges and surface them in cause subgraphs
- Extend LegalTheoryEngine with date-aware fact retrieval, missing element detection, and theory ranking
- Add PretrialGenerator and `/api/theories/accept` endpoint to route accepted theories to drafter, pretrial, and timeline services

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'neuro_san')*


------
https://chatgpt.com/codex/tasks/task_e_6892ff6844088333a32107f927843b75