### PR TITLE
feat: add legal crawler and search API

### DIFF
--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -613,3 +613,7 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 - Implemented approval, rejection and comment endpoints with UI controls and confidence bar.
 - Graph and timeline auto-refresh on theory decisions and Cypress tests cover the workflow.
 - Next: capture reviewer identity and expose theory review history.
+## Update 2025-08-06T16:00Z
+- Added legal crawler for bench cards, jury instructions, statutes and case law with Neo4j storage.
+- Exposed CoCounsel and auto-drafter search APIs and scheduled daily crawler updates.
+- Next: expand source-specific parsing and connect search results to dashboard UI.

--- a/coded_tools/legal_discovery/legal_crawler.py
+++ b/coded_tools/legal_discovery/legal_crawler.py
@@ -1,0 +1,74 @@
+import datetime
+import os
+from typing import Dict, List, Optional
+
+import requests
+from bs4 import BeautifulSoup
+
+from neuro_san.interfaces.coded_tool import CodedTool
+
+from .knowledge_graph_manager import KnowledgeGraphManager
+
+
+class LegalCrawler(CodedTool):
+    """Crawl legal resources and store them in Neo4j."""
+
+    def __init__(self, kg: Optional[KnowledgeGraphManager] = None, **kwargs):
+        super().__init__(**kwargs)
+        self.kg = kg or KnowledgeGraphManager()
+        self.sources: Dict[str, Optional[str]] = {
+            "bench_cards": os.environ.get("BENCH_CARDS_URL"),
+            "jury_instructions": os.environ.get("JURY_INSTRUCTIONS_URL"),
+            "statutes": os.environ.get("STATUTES_URL"),
+            "case_law": os.environ.get("CASE_LAW_URL"),
+        }
+
+    def _fetch_text(self, url: str) -> str:
+        """Return normalized text content for a URL."""
+        response = requests.get(url, timeout=30)
+        response.raise_for_status()
+        soup = BeautifulSoup(response.content, "html.parser")
+        return soup.get_text(" ", strip=True)
+
+    def crawl_category(self, category: str) -> List[Dict[str, str]]:
+        """Crawl a configured category and return references."""
+        base_url = self.sources.get(category)
+        if not base_url:
+            raise RuntimeError(f"{category} URL not configured")
+        text = self._fetch_text(base_url)
+        retrieved = datetime.datetime.utcnow().isoformat()
+        return [
+            {
+                "category": category,
+                "title": base_url,
+                "url": base_url,
+                "text": text,
+                "retrieved_at": retrieved,
+            }
+        ]
+
+    def crawl_all(self) -> List[Dict[str, str]]:
+        """Crawl all configured categories."""
+        results: List[Dict[str, str]] = []
+        for category in self.sources:
+            try:
+                results.extend(self.crawl_category(category))
+            except Exception as exc:  # pragma: no cover - network issues
+                results.append({"category": category, "error": str(exc)})
+        return results
+
+    def store(self, references: List[Dict[str, str]], theories: Optional[List[str]] = None) -> None:
+        """Store crawled references in the knowledge graph."""
+        for ref in references:
+            if ref.get("error"):
+                continue
+            self.kg.add_legal_reference(
+                category=ref["category"],
+                title=ref["title"],
+                text=ref["text"],
+                url=ref["url"],
+                retrieved_at=ref["retrieved_at"],
+                theories=theories or [],
+            )
+
+__all__ = ["LegalCrawler"]

--- a/tests/coded_tools/legal_discovery/test_knowledge_graph_manager.py
+++ b/tests/coded_tools/legal_discovery/test_knowledge_graph_manager.py
@@ -112,37 +112,3 @@ class TestKnowledgeGraphManager(unittest.TestCase):
         self.kg_manager.delete_node(b_id)
 
 
-import unittest
-
-
-class TestKnowledgeGraphManager(unittest.TestCase):
-    def setUp(self):
-        from your_module import KnowledgeGraphManager
-
-        self.kg_manager = KnowledgeGraphManager()
-
-    def test_link_fact_to_element_creates_relationships(self):
-        try:
-            fact_id = self.kg_manager.create_node("Fact", {"text": "Link fact"})
-        except RuntimeError as exc:
-            self.skipTest(str(exc))
-
-        self.kg_manager.link_fact_to_element(fact_id, "Fraud", "Intent to induce reliance")
-
-        rel = self.kg_manager.run_query(
-            (
-                "MATCH (f:Fact)-[:SUPPORTS]->(e:Element)-[:BELONGS_TO]->"
-                "(c:CauseOfAction {name:$cause}) WHERE id(f)=$f AND e.name=$element RETURN e"
-            ),
-            {"f": fact_id, "cause": "Fraud", "element": "Intent to induce reliance"},
-        )
-
-        self.assertTrue(rel)
-
-        self.kg_manager.delete_node(fact_id)
-        self.kg_manager.run_query("MATCH (n:Element {name:$e}) DETACH DELETE n", {"e": "Intent to induce reliance"})
-        self.kg_manager.run_query("MATCH (n:CauseOfAction {name:$c}) DETACH DELETE n", {"c": "Fraud"})
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/coded_tools/legal_discovery/test_legal_crawler.py
+++ b/tests/coded_tools/legal_discovery/test_legal_crawler.py
@@ -1,0 +1,40 @@
+import unittest
+
+from coded_tools.legal_discovery.knowledge_graph_manager import KnowledgeGraphManager
+
+
+class TestLegalCrawlerIntegration(unittest.TestCase):
+    def setUp(self):
+        try:
+            self.kg = KnowledgeGraphManager()
+        except RuntimeError as exc:  # Neo4j not running
+            self.skipTest(str(exc))
+
+    def tearDown(self):
+        self.kg.close()
+
+    def test_add_and_search_legal_reference(self):
+        ref_id = self.kg.add_legal_reference(
+            category="statute",
+            title="Test Statute",
+            text="Example statute text about contracts",
+            url="http://example.com/statute",
+            retrieved_at="2025-01-01",
+            theories=["Contracts"],
+        )
+        results = self.kg.search_legal_references("statute")
+        self.assertTrue(any(r["title"] == "Test Statute" for r in results))
+        self.kg.delete_node(ref_id)
+        # Clean up related nodes
+        self.kg.run_query(
+            "MATCH (n:LegalTheory {name:$name}) DETACH DELETE n",
+            {"name": "Contracts"},
+        )
+        self.kg.run_query(
+            "MATCH (n:TimelineEvent {description:$d}) DETACH DELETE n",
+            {"d": "Test Statute"},
+        )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- add legal crawler for bench cards, jury instructions, statutes and case law
- store legal references in Neo4j and expose CoCounsel/auto-drafter search APIs
- schedule daily crawls and document in AGENTS log

## Testing
- `pytest --override-ini="addopts=" tests/coded_tools/legal_discovery/test_legal_crawler.py tests/coded_tools/legal_discovery/test_knowledge_graph_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_689308dd8ff88333841d1d7860bd9009