### PR TITLE
feat: add exhibit tab with ordering and filters

### DIFF
--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -628,3 +628,8 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 - Added Gemini auto-drafter with motion templates and DOCX/PDF export.
 - Added React Auto Draft panel with manual review before export.
 - Next: expand motion templates and integrate deeper opposition metrics.
+
+## Update 2025-08-06T19:00Z
+- Added React ExhibitTab with drag-and-drop ordering plus privilege and source filters; entries show linked theories and timeline dates.
+- Extended exhibit API with source filter and links endpoint; updated tests to cover ordering, filtering, and link retrieval.
+- Next: connect exhibit links to detailed timeline view and broaden source options.

--- a/apps/legal_discovery/src/Dashboard.jsx
+++ b/apps/legal_discovery/src/Dashboard.jsx
@@ -19,7 +19,7 @@ import PresentationSection from "./components/PresentationSection";
 import AgentNetworkSection from "./components/AgentNetworkSection";
 import SettingsModal from "./components/SettingsModal";
 import LegalTheorySection from "./components/LegalTheorySection";
-import ExhibitSection from "./components/ExhibitSection";
+import ExhibitTab from "./components/ExhibitTab";
 import DepositionPrepSection from "./components/DepositionPrepSection";
 import ChainLogSection from "./components/ChainLogSection";
 const TABS = [
@@ -87,7 +87,7 @@ function Dashboard() {
       <div className="tab-content" style={{display: tab==='research'?'block':'none'}} id="tab-research"><ResearchSection/></div>
       <div className="tab-content" style={{display: tab==='subpoena'?'block':'none'}} id="tab-subpoena"><SubpoenaSection/></div>
       <div className="tab-content" style={{display: tab==='presentation'?'block':'none'}} id="tab-presentation"><PresentationSection/></div>
-      <div className="tab-content" style={{display: tab==='exhibits'?'block':'none'}} id="tab-exhibits"><ExhibitSection/></div>
+      <div className="tab-content" style={{display: tab==='exhibits'?'block':'none'}} id="tab-exhibits"><ExhibitTab/></div>
       <div className="tab-content" style={{display: tab==='deposition'?'block':'none'}} id="tab-deposition"><DepositionPrepSection/></div>
       <div className="tab-content" style={{display: tab==='chain'?'block':'none'}} id="tab-chain"><ChainLogSection/></div>
       <SettingsModal open={showSettings} onClose={()=>setShowSettings(false)}/>

--- a/apps/legal_discovery/src/components/ExhibitTab.jsx
+++ b/apps/legal_discovery/src/components/ExhibitTab.jsx
@@ -1,0 +1,116 @@
+import React, { useState, useEffect } from "react";
+import { fetchJSON, alertResponse } from "../utils";
+
+function ExhibitTab() {
+  const [caseId, setCaseId] = useState(1);
+  const [includePriv, setIncludePriv] = useState(false);
+  const [source, setSource] = useState("");
+  const [exhibits, setExhibits] = useState([]);
+
+  const load = () => {
+    const params = new URLSearchParams({ case_id: caseId });
+    if (includePriv) params.set("include_privileged", "true");
+    if (source) params.set("source", source);
+    fetchJSON(`/api/exhibits?${params.toString()}`).then(async (items) => {
+      const detailed = await Promise.all(
+        items.map(async (ex) => {
+          const links = await fetchJSON(`/api/exhibits/${ex.id}/links`);
+          return { ...ex, ...links };
+        })
+      );
+      setExhibits(detailed);
+    });
+  };
+
+  useEffect(() => {
+    load();
+  }, [caseId, includePriv, source]);
+
+  const onDragStart = (e, idx) => {
+    e.dataTransfer.setData("text/plain", idx);
+  };
+
+  const onDrop = (e, idx) => {
+    e.preventDefault();
+    const from = e.dataTransfer.getData("text/plain");
+    if (from === "") return;
+    const list = [...exhibits];
+    const [moved] = list.splice(Number(from), 1);
+    list.splice(idx, 0, moved);
+    setExhibits(list);
+    fetchJSON("/api/exhibits/reorder", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ case_id: caseId, order: list.map((e) => e.id) }),
+    }).then(alertResponse);
+  };
+
+  const allowDrop = (e) => e.preventDefault();
+
+  return (
+    <section className="card">
+      <h2>Exhibits</h2>
+      <div className="mb-2 flex gap-2 items-center">
+        <input
+          type="number"
+          value={caseId}
+          onChange={(e) => setCaseId(Number(e.target.value))}
+          className="w-24 p-2 rounded"
+        />
+        <label className="flex items-center gap-1 text-sm">
+          <input
+            type="checkbox"
+            checked={includePriv}
+            onChange={(e) => setIncludePriv(e.target.checked)}
+          />
+          Include Privileged
+        </label>
+        <select
+          value={source}
+          onChange={(e) => setSource(e.target.value)}
+          className="p-2 rounded"
+        >
+          <option value="">All Sources</option>
+          <option value="user">User</option>
+          <option value="opp_counsel">Opposing Counsel</option>
+          <option value="court">Court</option>
+        </select>
+        <button className="button-secondary" onClick={load}>
+          <i className="fa fa-sync mr-1"></i>Refresh
+        </button>
+      </div>
+      <ul>
+        {exhibits.map((ex, idx) => (
+          <li
+            key={ex.id}
+            draggable
+            onDragStart={(e) => onDragStart(e, idx)}
+            onDragOver={allowDrop}
+            onDrop={(e) => onDrop(e, idx)}
+            className={`p-2 mb-1 border rounded ${ex.privileged ? "privileged" : ""}`}
+          >
+            <div className="flex justify-between">
+              <span>
+                {ex.exhibit_number} - {ex.title}
+              </span>
+              <span className="text-xs">{ex.source}</span>
+            </div>
+            {ex.theories && ex.theories.length > 0 && (
+              <div className="text-xs mt-1">
+                <strong>Theories:</strong> {ex.theories.join(", ")}
+              </div>
+            )}
+            {ex.timeline && ex.timeline.length > 0 && (
+              <div className="text-xs mt-1">
+                <strong>Timeline:</strong> {ex.timeline.map((t) => t.date).join(", ")}
+              </div>
+            )}
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+export default ExhibitTab;
+


### PR DESCRIPTION
## Summary
- add drag-and-drop ExhibitTab with privilege and source filters
- extend exhibit API with source filter and links endpoint
- cover exhibit ordering and filters with tests

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'neuro_san')*
- `pytest tests/coded_tools/legal_discovery/test_exhibit_api.py`

------
https://chatgpt.com/codex/tasks/task_e_689317e297048333a32ce557f7888b59