### PR TITLE
feat: enrich exhibit export metadata

### DIFF
--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -633,3 +633,8 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 - Added React ExhibitTab with drag-and-drop ordering plus privilege and source filters; entries show linked theories and timeline dates.
 - Extended exhibit API with source filter and links endpoint; updated tests to cover ordering, filtering, and link retrieval.
 - Next: connect exhibit links to detailed timeline view and broaden source options.
+
+## Update 2025-08-06T20:30Z
+- Enhanced exhibit export to bundle deposition excerpts, theory references, scorecards, and sanctions notes into PDF/ZIP.
+- Added tests for exhibit numbering, cross-links, and privilege exclusions.
+- Next: enrich PDF export formatting for metadata pages.

--- a/apps/legal_discovery/exhibit_manager.py
+++ b/apps/legal_discovery/exhibit_manager.py
@@ -93,6 +93,23 @@ def create_cover_sheet(exhibit: Document) -> BytesIO:
     return buffer
 
 
+def _text_page(title: str, text: str) -> BytesIO:
+    """Create a simple PDF page with a title and body text."""
+    buf = BytesIO()
+    c = canvas.Canvas(buf)
+    c.setFont("Helvetica-Bold", 16)
+    c.drawString(80, 760, title)
+    c.setFont("Helvetica", 12)
+    text_obj = c.beginText(80, 740)
+    for line in text.splitlines():
+        text_obj.textLine(line)
+    c.drawText(text_obj)
+    c.showPage()
+    c.save()
+    buf.seek(0)
+    return buf
+
+
 def merge_pdf(cover: BytesIO, exhibit_path: str, writer: PdfWriter) -> None:
     """Append a cover sheet and exhibit file to the provided PDF writer."""
     if not Path(exhibit_path).exists():
@@ -123,6 +140,11 @@ def generate_binder(case_id: int, output_path: str | None = None) -> str:
     for exhibit in exhibits:
         cover = create_cover_sheet(exhibit)
         merge_pdf(cover, exhibit.file_path, writer)
+        meta = {m.schema: m.data for m in exhibit.metadata_entries}
+        if (dep := meta.get("deposition_excerpt")) and dep.get("text"):
+            writer.append(PdfReader(_text_page("Deposition Excerpt", dep["text"])))
+        if (theory := meta.get("theory_reference")) and theory.get("text"):
+            writer.append(PdfReader(_text_page("Theory Reference", theory["text"])))
     if output_path is None:
         output_path = Path(tempfile.gettempdir()) / f"case_{case_id}_binder.pdf"
     with open(output_path, "wb") as f:
@@ -146,14 +168,26 @@ def export_zip(case_id: int, output_path: str | None = None) -> str:
         for ex in exhibits:
             name = f"{ex.exhibit_number}_{(ex.exhibit_title or '').replace(' ', '_')}.pdf"
             z.write(ex.file_path, name)
-            manifest.append(
-                {
-                    "exhibit_number": ex.exhibit_number,
-                    "title": ex.exhibit_title,
-                    "path": name,
-                    "bates_number": ex.bates_number,
-                }
-            )
+            meta = {m.schema: m.data for m in ex.metadata_entries}
+            entry = {
+                "exhibit_number": ex.exhibit_number,
+                "title": ex.exhibit_title,
+                "path": name,
+                "bates_number": ex.bates_number,
+            }
+            if (dep := meta.get("deposition_excerpt")) and dep.get("text"):
+                dep_name = f"{ex.exhibit_number}_deposition.txt"
+                z.writestr(dep_name, dep["text"])
+                entry["deposition_excerpt"] = dep_name
+            if (theory := meta.get("theory_reference")) and theory.get("text"):
+                theory_name = f"{ex.exhibit_number}_theory.txt"
+                z.writestr(theory_name, theory["text"])
+                entry["theory_reference"] = theory_name
+            if score := meta.get("evidence_scorecard"):
+                entry["evidence_scorecard"] = score
+            if sanctions := meta.get("sanctions_risk"):
+                entry["sanctions_risk"] = sanctions
+            manifest.append(entry)
         z.writestr("manifest.json", json.dumps(manifest, indent=2))
     log_action(case_id, None, "EXPORT_ZIP", details={"path": str(output_path)})
     return str(output_path)

--- a/tests/coded_tools/legal_discovery/test_exhibit_manager.py
+++ b/tests/coded_tools/legal_discovery/test_exhibit_manager.py
@@ -1,11 +1,19 @@
 import os
+import json
 import zipfile
+
+import pytest
 from flask import Flask
 from reportlab.pdfgen import canvas
 
 from apps.legal_discovery.database import db
-from apps.legal_discovery.models import Case, Document
-from apps.legal_discovery.exhibit_manager import assign_exhibit_number, generate_binder, export_zip
+from apps.legal_discovery.models import Case, Document, DocumentMetadata
+from apps.legal_discovery.exhibit_manager import (
+    ExhibitExportError,
+    assign_exhibit_number,
+    export_zip,
+    generate_binder,
+)
 
 
 def _create_pdf(path):
@@ -24,23 +32,29 @@ def _setup_app(tmp_path):
         case = Case(name="Test Case")
         db.session.add(case)
         db.session.commit()
-        pdf_path = tmp_path / "doc.pdf"
-        _create_pdf(pdf_path)
-        doc = Document(
-            case_id=case.id,
-            name="Doc",
-            file_path=str(pdf_path),
-            content_hash="hash1",
-            bates_number="BATES1",
-        )
-        db.session.add(doc)
-        db.session.commit()
-        return app, case.id, doc.id
+        return app, case.id
+
+
+def _create_doc(case_id, tmp_path, name, hash_, bates, privileged=False):
+    pdf_path = tmp_path / f"{name}.pdf"
+    _create_pdf(pdf_path)
+    doc = Document(
+        case_id=case_id,
+        name=name,
+        file_path=str(pdf_path),
+        content_hash=hash_,
+        bates_number=bates,
+        is_privileged=privileged,
+    )
+    db.session.add(doc)
+    db.session.commit()
+    return doc.id
 
 
 def test_assign_and_generate_binder(tmp_path):
-    app, case_id, doc_id = _setup_app(tmp_path)
+    app, case_id = _setup_app(tmp_path)
     with app.app_context():
+        doc_id = _create_doc(case_id, tmp_path, "Doc", "hash1", "BATES1")
         num = assign_exhibit_number(doc_id, "Title")
         assert num == "EX_0001"
         assert Document.query.get(doc_id).exhibit_order == 1
@@ -50,14 +64,43 @@ def test_assign_and_generate_binder(tmp_path):
         assert os.path.exists(result)
 
 
-def test_export_zip(tmp_path):
-    app, case_id, doc_id = _setup_app(tmp_path)
+def test_export_metadata_and_crosslinks(tmp_path):
+    app, case_id = _setup_app(tmp_path)
     with app.app_context():
-        assign_exhibit_number(doc_id, "Title")
-        assert Document.query.get(doc_id).exhibit_order == 1
+        doc1 = _create_doc(case_id, tmp_path, "Doc1", "hash1", "B1")
+        doc2 = _create_doc(case_id, tmp_path, "Doc2", "hash2", "B2")
+        assign_exhibit_number(doc1, "Title1")
+        assign_exhibit_number(doc2, "Title2")
+        db.session.add_all(
+            [
+                DocumentMetadata(document_id=doc1, schema="deposition_excerpt", data={"text": "dep"}),
+                DocumentMetadata(document_id=doc1, schema="theory_reference", data={"text": "ref"}),
+                DocumentMetadata(document_id=doc1, schema="evidence_scorecard", data={"score": 5}),
+                DocumentMetadata(document_id=doc1, schema="sanctions_risk", data={"note": "low"}),
+            ]
+        )
+        db.session.commit()
         zip_path = tmp_path / "exhibits.zip"
-        result = export_zip(case_id, zip_path)
-        assert result == str(zip_path)
-        assert os.path.exists(result)
+        export_zip(case_id, zip_path)
         with zipfile.ZipFile(zip_path) as z:
-            assert "manifest.json" in z.namelist()
+            manifest = json.load(z.open("manifest.json"))
+            assert manifest[0]["exhibit_number"] == "EX_0001"
+            assert manifest[1]["exhibit_number"] == "EX_0002"
+            assert manifest[0]["deposition_excerpt"] == "EX_0001_deposition.txt"
+            assert manifest[0]["theory_reference"] == "EX_0001_theory.txt"
+            assert "evidence_scorecard" in manifest[0]
+            assert "sanctions_risk" in manifest[0]
+            assert "EX_0001_deposition.txt" in z.namelist()
+            assert "EX_0001_theory.txt" in z.namelist()
+
+
+def test_export_skips_privileged(tmp_path):
+    app, case_id = _setup_app(tmp_path)
+    with app.app_context():
+        doc1 = _create_doc(case_id, tmp_path, "Doc1", "hash1", "B1")
+        doc2 = _create_doc(case_id, tmp_path, "Doc2", "hash2", "B2", privileged=True)
+        assign_exhibit_number(doc1)
+        assign_exhibit_number(doc2)
+        zip_path = tmp_path / "exhibits.zip"
+        with pytest.raises(ExhibitExportError):
+            export_zip(case_id, zip_path)


### PR DESCRIPTION
## Summary
- expand exhibit ZIP/PDF export with deposition excerpts, theory references, evidence scorecards, and sanctions-risk notes
- add tests for exhibit numbering, cross-links, and privilege exclusions

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'apps', 'dotenv', 'neuro_san', 'google', 'fitz', 'flask_sqlalchemy', 'reportlab', 'spacy', 'neo4j', ...)*
- `pytest tests/coded_tools/legal_discovery/test_exhibit_manager.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68931bdfcb248333a8a2436149260595