### PR TITLE
feat: add WebRTC voice chat with audit logging

### DIFF
--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -648,3 +648,8 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 - Expanded motion template library with Motion in Limine and configurable Gemini temperature.
 - Added review gating to Auto Draft UI requiring explicit approval before export.
 - Next: incorporate opposition metrics into prompts and support additional export formats.
+
+## Update 2025-08-07T12:00Z
+- Added WebRTC-enabled ChatSection with selectable voice models and Socket.IO streaming.
+- Logged chat messages and voice transcripts to MessageAuditLog with migration and integration tests.
+- Next: enhance audio quality and broaden language model support.

--- a/apps/legal_discovery/migrations/007_add_message_audit_log.py
+++ b/apps/legal_discovery/migrations/007_add_message_audit_log.py
@@ -1,0 +1,25 @@
+"""Add message audit log"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "007_add_message_audit_log"
+down_revision = "006_add_conversation_vector"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "message_audit_log",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("message_id", sa.String(length=36), sa.ForeignKey("message.id"), nullable=False),
+        sa.Column("sender", sa.String(length=50), nullable=False),
+        sa.Column("transcript", sa.Text(), nullable=False),
+        sa.Column("voice_model", sa.String(length=50), nullable=True),
+        sa.Column("timestamp", sa.DateTime(), server_default=sa.func.now()),
+    )
+
+
+def downgrade():
+    op.drop_table("message_audit_log")

--- a/apps/legal_discovery/models.py
+++ b/apps/legal_discovery/models.py
@@ -70,6 +70,17 @@ class Message(db.Model):
     reply_to = db.relationship("Message", remote_side=[id])
 
 
+class MessageAuditLog(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    message_id = db.Column(db.String(36), db.ForeignKey("message.id"), nullable=False)
+    sender = db.Column(db.String(50), nullable=False)
+    transcript = db.Column(db.Text, nullable=False)
+    voice_model = db.Column(db.String(50), nullable=True)
+    timestamp = db.Column(db.DateTime, server_default=db.func.now())
+
+    message = db.relationship("Message", backref=db.backref("audit_logs", lazy=True))
+
+
 class DocumentSource(enum.Enum):
     USER = "user"
     OPP_COUNSEL = "opp_counsel"

--- a/apps/legal_discovery/requirements.txt
+++ b/apps/legal_discovery/requirements.txt
@@ -27,6 +27,7 @@ spacy
 weasyprint
 reportlab
 pygraphviz
+gTTS
 
 en-core-web-sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.7.1/en_core_web_sm-3.7.1-py3-none-any.whl
 

--- a/tests/apps/test_chat_audit.py
+++ b/tests/apps/test_chat_audit.py
@@ -1,0 +1,39 @@
+import base64
+import os
+import pytest
+
+os.environ["DATABASE_URL"] = "sqlite://"
+
+from apps.legal_discovery.interface_flask import app, db, MessageAuditLog
+
+
+@pytest.fixture
+def client():
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+    return app.test_client()
+
+
+def test_query_logs_message(client):
+    resp = client.post("/api/query", json={"text": "hello"})
+    assert resp.status_code == 200
+    with app.app_context():
+        logs = MessageAuditLog.query.all()
+        assert any(l.sender == "user" and l.transcript == "hello" for l in logs)
+
+
+def test_voice_query_logs_message(client, monkeypatch):
+    monkeypatch.setattr(
+        "apps.legal_discovery.interface_flask.synthesize_voice", lambda text, model: ""
+    )
+    audio = base64.b64encode(b"test").decode()
+    resp = client.post(
+        "/api/voice_query",
+        json={"audio": audio, "transcript": "hi", "voice_model": "en-US"},
+    )
+    assert resp.status_code == 200
+    with app.app_context():
+        log = MessageAuditLog.query.filter_by(transcript="hi").first()
+        assert log is not None
+        assert log.voice_model == "en-US"


### PR DESCRIPTION
## Summary
- add WebRTC-enabled ChatSection with socket-based audio streaming
- log chat messages and voice transcripts to MessageAuditLog with migration
- cover auditing with integration tests

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'spacy')*

------
https://chatgpt.com/codex/tasks/task_e_68932f5725408333804acb07879d6ef3