### PR TITLE
Expand motion templates and refine Auto Draft review

### DIFF
--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -667,3 +667,8 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 - Added NarrativeDiscrepancy model, Gemini-powered analysis pipeline, and REST endpoints.
 - Introduced React OppositionTrackerSection with color-coded flags and export options.
 - Next: auto-link discrepancies to timeline and expand batch processing.
+
+## Update 2025-08-06T12:32Z
+- Added motions to compel and protective order templates sourcing facts, theories and conflicts.
+- Enhanced Auto Draft panel with visual review status and disabled actions until approval.
+- Next: surface opposition metrics within prompts and polish export styles.

--- a/apps/legal_discovery/src/components/AutoDraftSection.jsx
+++ b/apps/legal_discovery/src/components/AutoDraftSection.jsx
@@ -44,13 +44,20 @@ function AutoDraftSection() {
         {types.map(t => <option key={t} value={t}>{t.replace(/_/g, " ")}</option>)}
       </select>
       <div className="flex flex-wrap gap-2 mb-2">
-        <button className="button-secondary" onClick={generate}><i className="fa fa-magic mr-1"></i>Generate</button>
+        <button className="button-secondary" onClick={generate} disabled={!motion}><i className="fa fa-magic mr-1"></i>Generate</button>
         <button className="button-secondary" onClick={() => { setDraft(""); setReviewed(false); }}><i className="fa fa-eraser mr-1"></i>Clear</button>
-        <button className="button-secondary" onClick={() => setReviewed(true)}><i className="fa fa-check mr-1"></i>Mark Reviewed</button>
+        <button className="button-secondary" onClick={() => setReviewed(true)} disabled={!draft}><i className="fa fa-check mr-1"></i>Mark Reviewed</button>
         <button className="button-secondary" onClick={() => exportFile('docx')} disabled={!reviewed}><i className="fa fa-file-word mr-1"></i>Export DOCX</button>
         <button className="button-secondary" onClick={() => exportFile('pdf')} disabled={!reviewed}><i className="fa fa-file-pdf mr-1"></i>Export PDF</button>
       </div>
-      <textarea rows="10" value={draft} onChange={e=>{ setDraft(e.target.value); setReviewed(false); }} className="w-full p-2 rounded" placeholder="Draft output for review..." />
+      <p className="text-sm mb-1">{reviewed ? "Draft reviewed" : "Review required before export"}</p>
+      <textarea
+        rows="10"
+        value={draft}
+        onChange={e=>{ setDraft(e.target.value); setReviewed(false); }}
+        className={`w-full p-2 rounded border ${reviewed ? 'border-green-500' : 'border-red-500'}`}
+        placeholder="Draft output for review..."
+      />
       {output && <p className="text-sm">Output: <a href={'/uploads/'+output} target="_blank" rel="noopener noreferrer">{output}</a></p>}
     </section>
   );

--- a/coded_tools/legal_discovery/template_library.py
+++ b/coded_tools/legal_discovery/template_library.py
@@ -26,6 +26,14 @@ class TemplateLibrary(CodedTool):
             "Draft a Motion in Limine considering these facts:\n{facts}\n"
             "Accepted theories:\n{theories}\nOpposition:\n{conflicts}"
         ),
+        "motion_to_compel": (
+            "Draft a Motion to Compel discovery using these facts:\n{facts}\n"
+            "Accepted theories:\n{theories}\nOpposition:\n{conflicts}"
+        ),
+        "motion_for_protective_order": (
+            "Prepare a Motion for Protective Order grounded on these facts:\n{facts}\n"
+            "Accepted theories:\n{theories}\nOpposition:\n{conflicts}"
+        ),
     }
 
     def available(self) -> list[str]:

--- a/condensed AGENTS.md
+++ b/condensed AGENTS.md
@@ -125,3 +125,8 @@ we are now working on implementing a major feature, so stand by, this is  A GDDM
 - Added Gemini NLI-based narrative discrepancy pipeline with database model and API endpoints.
 - Built React opposition tracker with filters and PDF/CSV export.
 - Next: link discrepancies directly to timeline events and enhance bulk analysis.
+
+## Update 2025-08-06T12:32Z
+- Expanded motion template library with motions to compel and protective order pulling facts, accepted theories and conflicts.
+- Refined Auto Draft UI with clear review status, disabled actions until approval and accent borders for edit state.
+- Next: integrate opposition metrics into prompts and enhance export formatting.

--- a/tests/coded_tools/legal_discovery/test_auto_drafter.py
+++ b/tests/coded_tools/legal_discovery/test_auto_drafter.py
@@ -19,6 +19,8 @@ def test_template_library_available():
     available = lib.available()
     assert "motion_to_dismiss" in available
     assert "motion_in_limine" in available
+    assert "motion_to_compel" in available
+    assert "motion_for_protective_order" in available
 
 
 def test_auto_drafter_generate(monkeypatch):


### PR DESCRIPTION
## Summary
- extend auto drafter template library with motions to compel and protective order
- refine Auto Draft React panel with review status indicator and disabled buttons
- broaden tests to cover new motion types

## Testing
- `pytest` *(fails: ModuleNotFoundError for apps and other dependencies)*
- `pytest tests/coded_tools/legal_discovery/test_auto_drafter.py -q`

------
https://chatgpt.com/codex/tasks/task_e_689349b785388333aadaa5d8d7e31cf6