### PR TITLE
Integrate opposition tracker into motion templates

### DIFF
--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -698,3 +698,8 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 - Tests cover ingest, redaction, stamping and export logging end-to-end.
 - Next: extend chain log filters and add report export options.
 
+
+## Update 2025-08-06T16:29Z
+- TemplateLibrary now pulls opposition discrepancies for motion prompts.
+- Next: expand discrepancy formatting and link deeper opposition metrics into drafts.
+

--- a/apps/legal_discovery/interface_flask.py
+++ b/apps/legal_discovery/interface_flask.py
@@ -1252,7 +1252,7 @@ def auto_draft_export():
     path = os.path.join(app.config["UPLOAD_FOLDER"], filename)
     drafter = AutoDrafter()
     try:
-        drafter.export(content, path)
+        drafter.export(content, path, fmt)
     except Exception as exc:  # pragma: no cover - file errors
         return jsonify({"error": str(exc)}), 500
     return jsonify({"status": "ok", "output": filename})

--- a/coded_tools/legal_discovery/auto_drafter.py
+++ b/coded_tools/legal_discovery/auto_drafter.py
@@ -41,14 +41,31 @@ class AutoDrafter(CodedTool):
         )
         return response.text
 
-    def export(self, content: str, file_path: str) -> str:
-        """Export reviewed content to DOCX or PDF."""
+    def export(self, content: str, file_path: str, fmt: str | None = None) -> str:
+        """Export reviewed content to DOCX or PDF.
+
+        Parameters
+        ----------
+        content:
+            The draft text that has been manually reviewed.
+        file_path:
+            Desired output path. The directory will be created if missing.
+        fmt:
+            Optional explicit format (``"docx"`` or ``"pdf"``). When omitted, the
+            format is inferred from ``file_path``'s extension.
+        """
+
         path = Path(file_path)
         path.parent.mkdir(parents=True, exist_ok=True)
-        if path.suffix.lower() == ".pdf":
+        format_ext = (fmt or path.suffix.lstrip(".")).lower()
+        if format_ext == "pdf":
+            if path.suffix.lower() != ".pdf":
+                path = path.with_suffix(".pdf")
             html = f"<pre>{content}</pre>"
             HTML(string=html).write_pdf(str(path))
         else:
+            if path.suffix.lower() != ".docx":
+                path = path.with_suffix(".docx")
             doc = DocxDocument()
             for line in content.splitlines():
                 doc.add_paragraph(line)

--- a/coded_tools/legal_discovery/template_library.py
+++ b/coded_tools/legal_discovery/template_library.py
@@ -5,9 +5,13 @@ from __future__ import annotations
 from neuro_san.interfaces.coded_tool import CodedTool
 
 try:  # optional imports for runtime
-    from apps.legal_discovery.models import Fact, LegalTheory, FactConflict
+    from apps.legal_discovery.models import (
+        Fact,
+        LegalTheory,
+        NarrativeDiscrepancy,
+    )
 except Exception:  # pragma: no cover - used when app context missing
-    Fact = LegalTheory = FactConflict = None  # type: ignore
+    Fact = LegalTheory = NarrativeDiscrepancy = None  # type: ignore
 
 
 class TemplateLibrary(CodedTool):
@@ -48,7 +52,7 @@ class TemplateLibrary(CodedTool):
 
         facts_text = "No facts available."
         theories_text = "No accepted theories."
-        conflicts_text = "No conflicts recorded."
+        opposition_text = "No opposition recorded."
         try:
             if Fact is not None:
                 facts = Fact.query.order_by(Fact.id).all()
@@ -60,13 +64,18 @@ class TemplateLibrary(CodedTool):
                     theories_text = "\n".join(
                         f"- {t.theory_name}: {t.description or ''}" for t in theories
                     )
-            if FactConflict is not None:
-                conflicts = FactConflict.query.order_by(FactConflict.id).all()
-                if conflicts:
-                    conflicts_text = "\n".join(c.description for c in conflicts)
+            if NarrativeDiscrepancy is not None:
+                opp = NarrativeDiscrepancy.query.order_by(
+                    NarrativeDiscrepancy.id
+                ).all()
+                if opp:
+                    opposition_text = "\n".join(
+                        f"- {d.conflicting_claim} vs {d.evidence_excerpt}"
+                        for d in opp
+                    )
         except Exception:  # pragma: no cover - missing DB/app context
             pass
 
         return template.format(
-            facts=facts_text, theories=theories_text, conflicts=conflicts_text
+            facts=facts_text, theories=theories_text, conflicts=opposition_text
         )


### PR DESCRIPTION
## Summary
- enrich motion templates with opposition discrepancies
- refine drafter export with explicit format handling
- wire export route to pass format

## Testing
- `pytest tests/coded_tools/legal_discovery/test_auto_drafter.py -q --no-cov`

------
https://chatgpt.com/codex/tasks/task_e_689381803b708333a10962c3c2f2545a