### PR TITLE
feat: add pretrial export with Gemini

### DIFF
--- a/agents--features and memory/condensed_agents.md
+++ b/agents--features and memory/condensed_agents.md
@@ -227,3 +227,8 @@ WE STARTED ON #3, INSTEAD OF #1. DEAL WITH IT, FINISH IMPLEMENTING #3, AND THEN 
 - Added unit tests for fact–element linking, theory scoring, and `/api/theories/suggest` endpoint
 - Documented usage examples in legal_discovery README
 - Next: expand endpoint coverage and refine theory docs
+
+## Update 2025-08-08T16:00Z
+- Built Gemini-driven pretrial generator aggregating stipulations, contested issues and witnesses.
+- Export creates editable DOCX and triggers timeline and binder updates with unit tests.
+- Next: surface pretrial export controls in dashboard and expand coverage.

--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -698,3 +698,9 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 - Tests cover ingest, redaction, stamping and export logging end-to-end.
 - Next: extend chain log filters and add report export options.
 
+## Update 2025-08-08T16:00Z
+- Aggregated stipulations, contested issues and witness lists from approved theories.
+- Gemini-powered pretrial export saves editable DOCX and hooks timeline/binder modules.
+- Added unit test for export to verify timeline and binder integration.
+- Next: expose pretrial export endpoint in dashboard UI.
+

--- a/apps/legal_discovery/interface_flask.py
+++ b/apps/legal_discovery/interface_flask.py
@@ -1747,6 +1747,22 @@ def accept_theory():
         engine.close()
 
 
+@app.route("/api/pretrial/export", methods=["POST"])
+def export_pretrial_statement():
+    """Generate a pretrial statement document and update timeline/binder."""
+
+    data = request.get_json() or {}
+    case_id = data.get("case_id", type=int)
+    if not case_id:
+        return jsonify({"error": "Missing case_id"}), 400
+
+    os.makedirs("exports", exist_ok=True)
+    path = os.path.join("exports", f"pretrial_{case_id}.docx")
+    generator = PretrialGenerator()
+    generator.export(case_id, path)
+    return jsonify({"status": "ok", "path": path})
+
+
 @app.route("/api/theories/reject", methods=["POST"])
 def reject_theory():
     data = request.get_json() or {}

--- a/coded_tools/legal_discovery/pretrial_generator.py
+++ b/coded_tools/legal_discovery/pretrial_generator.py
@@ -1,16 +1,124 @@
+from __future__ import annotations
+
+"""Pretrial statement generation and export utilities."""
+
+from pathlib import Path
+
+import google.generativeai as genai
 from neuro_san.interfaces.coded_tool import CodedTool
+
+from .document_drafter import DocumentDrafter
+from .timeline_manager import TimelineManager
+
+try:  # pragma: no cover - optional import in some environments
+    from apps.legal_discovery.exhibit_manager import generate_binder
+except Exception:  # pragma: no cover - binder not available
+    generate_binder = None
+
+try:  # pragma: no cover - optional import of ORM models
+    from apps.legal_discovery.models import Fact, FactConflict, LegalTheory, Witness
+except Exception:  # pragma: no cover - test environments may not load app modules
+    Fact = FactConflict = LegalTheory = Witness = None
 
 
 class PretrialGenerator(CodedTool):
-    """Generate simple pretrial statements for accepted theories."""
+    """Generate pretrial statements from approved theories and evidence."""
 
-    def __init__(self, **kwargs):
+    def __init__(self, model_name: str = "gemini-1.5-flash", temperature: float = 0.2, **kwargs):
         super().__init__(**kwargs)
+        self.model_name = model_name
+        self.temperature = temperature
 
-    def generate_statement(self, cause: str, elements: list[str]) -> str:
-        """Return a pretrial statement summarising the elements for a cause."""
+    # ------------------------------------------------------------------
+    # Data aggregation
+    # ------------------------------------------------------------------
+    def aggregate(self, case_id: int) -> dict:
+        """Collect stipulations, contested issues and witnesses for a case."""
 
-        lines = [f"Pretrial Statement for {cause}", ""]
-        for el in elements:
-            lines.append(f"- {el}")
-        return "\n".join(lines)
+        if LegalTheory is None:  # pragma: no cover - safety check
+            return {"stipulations": [], "contested": [], "witnesses": [], "timeline": []}
+
+        theories = LegalTheory.query.filter_by(case_id=case_id, status="approved").all()
+
+        stipulations: list[str] = []
+        contested: list[str] = []
+        witness_ids: set[int] = set()
+        timeline: list[dict] = []
+
+        for theory in theories:
+            facts = Fact.query.filter_by(legal_theory_id=theory.id).all()
+            for fact in facts:
+                if fact.witness_id:
+                    witness_ids.add(fact.witness_id)
+                if fact.dates:
+                    for d in fact.dates:
+                        timeline.append({"date": d, "description": fact.text})
+
+                conflict = FactConflict.query.filter(
+                    (FactConflict.fact1_id == fact.id)
+                    | (FactConflict.fact2_id == fact.id)
+                ).first()
+                if conflict:
+                    contested.append(conflict.description)
+                else:
+                    stipulations.append(fact.text)
+
+        witnesses = []
+        for wid in witness_ids:
+            w = Witness.query.get(wid)
+            if w:
+                witnesses.append(w.name)
+
+        return {
+            "stipulations": stipulations,
+            "contested": contested,
+            "witnesses": witnesses,
+            "timeline": timeline,
+        }
+
+    # ------------------------------------------------------------------
+    # Drafting utilities
+    # ------------------------------------------------------------------
+    def draft(self, case_id: int) -> tuple[str, dict]:
+        """Use Gemini to draft a pretrial statement for the case."""
+
+        data = self.aggregate(case_id)
+        lines = ["Prepare a concise pretrial statement using the data below.", ""]
+        lines.append("Stipulations:")
+        lines.extend(f"- {s}" for s in data["stipulations"] or ["None"])
+        lines.append("\nContested Issues:")
+        lines.extend(f"- {c}" for c in data["contested"] or ["None"])
+        lines.append("\nWitnesses:")
+        lines.extend(f"- {w}" for w in data["witnesses"] or ["None"])
+
+        prompt = "\n".join(lines)
+        model = genai.GenerativeModel(self.model_name)
+        response = model.generate_content(
+            prompt,
+            generation_config=genai.types.GenerationConfig(temperature=self.temperature),
+        )
+        return response.text, data
+
+    # ------------------------------------------------------------------
+    # Export
+    # ------------------------------------------------------------------
+    def export(self, case_id: int, file_path: str) -> str:
+        """Generate and export a DOCX pretrial statement."""
+
+        text, data = self.draft(case_id)
+        path = Path(file_path)
+        drafter = DocumentDrafter()
+        drafter.create_document(str(path), text)
+
+        tm = TimelineManager()
+        if data["timeline"]:
+            tm.create_timeline(f"case_{case_id}_pretrial", data["timeline"])
+
+        if generate_binder is not None:
+            generate_binder(case_id)
+
+        return str(path)
+
+
+__all__ = ["PretrialGenerator"]
+

--- a/tests/coded_tools/legal_discovery/test_pretrial_generator.py
+++ b/tests/coded_tools/legal_discovery/test_pretrial_generator.py
@@ -1,0 +1,118 @@
+import os
+import sys
+from types import SimpleNamespace
+
+import pytest
+from flask import Flask
+
+sys.path.insert(0, os.path.abspath("."))
+
+from apps.legal_discovery.database import db
+from apps.legal_discovery.models import (
+    Case,
+    Document,
+    DocumentWitnessLink,
+    Fact,
+    FactConflict,
+    LegalTheory,
+    Witness,
+)
+from coded_tools.legal_discovery.pretrial_generator import PretrialGenerator
+
+
+def setup_app():
+    app = Flask(__name__)
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    db.init_app(app)
+    with app.app_context():
+        db.create_all()
+    return app
+
+
+def mock_genai():
+    class MockModel:
+        def __init__(self, _name):
+            pass
+
+        def generate_content(self, prompt, generation_config=None):
+            return SimpleNamespace(text="mock statement")
+
+    class MockTypes:
+        @staticmethod
+        def GenerationConfig(**kwargs):
+            return None
+
+    return SimpleNamespace(GenerativeModel=MockModel, types=MockTypes)
+
+
+def test_export_generates_doc_and_integrates(monkeypatch, tmp_path):
+    app = setup_app()
+    with app.app_context():
+        case = Case(name="C1", description="")
+        db.session.add(case)
+        db.session.commit()
+
+        doc = Document(
+            case_id=case.id,
+            name="Doc1",
+            bates_number="B1",
+            file_path="/tmp/doc1",
+            sha256="h1",
+        )
+        witness = Witness(name="Jane", role="Witness", associated_case=case.id)
+        theory = LegalTheory(case_id=case.id, theory_name="Theory", status="approved")
+        db.session.add_all([doc, witness, theory])
+        db.session.commit()
+
+        link = DocumentWitnessLink(document_id=doc.id, witness_id=witness.id)
+        db.session.add(link)
+
+        fact1 = Fact(
+            case_id=case.id,
+            document_id=doc.id,
+            legal_theory_id=theory.id,
+            text="A fact",
+            dates=["2024-01-01"],
+            witness_id=witness.id,
+        )
+        fact2 = Fact(
+            case_id=case.id,
+            document_id=doc.id,
+            legal_theory_id=theory.id,
+            text="Another fact",
+            witness_id=witness.id,
+        )
+        db.session.add_all([fact1, fact2])
+        db.session.commit()
+
+        conflict = FactConflict(
+            witness_id=witness.id,
+            fact1_id=fact1.id,
+            fact2_id=fact1.id,
+            score=0.9,
+            description="Conflict on A fact",
+        )
+        db.session.add(conflict)
+        db.session.commit()
+
+        pretrial_module = sys.modules[PretrialGenerator.__module__]
+        monkeypatch.setattr(pretrial_module, "genai", mock_genai())
+
+        calls = {}
+
+        def fake_create_timeline(self, timeline_id, items):
+            calls["timeline"] = (timeline_id, items)
+
+        monkeypatch.setattr(pretrial_module.TimelineManager, "create_timeline", fake_create_timeline)
+
+        def fake_binder(cid):
+            calls["binder"] = cid
+
+        monkeypatch.setattr(pretrial_module, "generate_binder", fake_binder)
+
+        generator = PretrialGenerator()
+        out_path = tmp_path / "pretrial.docx"
+        generator.export(case.id, str(out_path))
+        assert out_path.exists()
+        assert "timeline" in calls
+        assert "binder" in calls


### PR DESCRIPTION
## Summary
- aggregate stipulations, contested issues, witnesses from approved theories
- generate Gemini pretrial statement and export editable docx
- add tests for pretrial export integration with timeline and binder

## Testing
- `pytest tests/coded_tools/legal_discovery/test_pretrial_generator.py`

------
https://chatgpt.com/codex/tasks/task_e_68938175b0148333a579de328cfe291d