### PR TITLE
Add document versioning with Bates history and diff

### DIFF
--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -682,3 +682,12 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 - Logged privilege detection spans and override actions.
 - Added tests for detector true/false positives and dashboard override flow.
 - Next: evaluate detector accuracy on larger corpora.
+
+## Update 2025-08-06T14:58Z
+- Introduced DocumentVersion model with stamping hook and diffable history UI.
+- Added API endpoints and React components to browse versions and compare changes.
+- Next: extend diffing to support binary comparisons and pagination.
+
+## Update 2025-08-06T15:02Z
+- Finalized migration and unit tests for sequential versioning.
+- Next: run full integration suite once remaining dependencies are installed.

--- a/apps/legal_discovery/interface_flask.py
+++ b/apps/legal_discovery/interface_flask.py
@@ -77,6 +77,7 @@ from apps.legal_discovery.models import (
     DocumentSource,
     MessageAuditLog,
     NarrativeDiscrepancy,
+    DocumentVersion,
 )
 from coded_tools.legal_discovery.deposition_prep import DepositionPrep
 from coded_tools.legal_discovery.legal_crawler import LegalCrawler
@@ -85,6 +86,12 @@ from coded_tools.legal_discovery.narrative_discrepancy_detector import (
 )
 from .exhibit_routes import exhibits_bp
 from .chain_logger import ChainEventType, log_event
+from coded_tools.legal_discovery.bates_numbering import (
+    BatesNumberingService,
+    stamp_pdf,
+)
+import difflib
+import fitz
 
 # Configure logging before any other setup so early steps are captured
 logging.basicConfig(level=os.environ.get("LOG_LEVEL", "INFO"))
@@ -126,6 +133,7 @@ app.register_blueprint(exhibits_bp)
 executor = ThreadPoolExecutor(max_workers=int(os.environ.get("INGESTION_WORKERS", "4")))
 atexit.register(executor.shutdown)
 thread_started = False  # pylint: disable=invalid-name
+bates_service = BatesNumberingService()
 
 # Shared crawler instance for legal references
 def synthesize_voice(text: str, model: str) -> str:
@@ -1077,26 +1085,104 @@ def redact_document():
 
 @app.route("/api/document/stamp", methods=["POST"])
 def bates_stamp_document():
-    """Apply Bates numbering to a PDF."""
+    """Apply Bates numbering to a PDF and record a new version."""
     data = request.get_json() or {}
     file_path = data.get("file_path")
     prefix = data.get("prefix", "BATES")
+    user_id = data.get("user_id")
     if not file_path:
         return jsonify({"error": "Missing file_path"}), 400
-    modifier = DocumentModifier()
+    doc = Document.query.filter_by(file_path=file_path).first()
+    if doc is None:
+        return jsonify({"error": "Document not found"}), 404
+    # Determine next Bates number and stamp the PDF
+    start = bates_service.get_next_bates_number(prefix)
+    start_num = int(start.split("_")[-1])
+    # Advance counter for remaining pages
+    page_total = fitz.open(file_path).page_count
+    for _ in range(page_total - 1):
+        bates_service.get_next_bates_number(prefix)
+    output_path = f"{file_path}_v{start}.pdf"
     try:
-        modifier.bates_stamp(file_path, prefix)
+        stamp_pdf(file_path, output_path, start_num, prefix=prefix)
     except Exception as exc:  # pragma: no cover - filesystem errors
         return jsonify({"error": str(exc)}), 500
+    doc.bates_number = start
+    version = DocumentVersion(
+        document_id=doc.id,
+        bates_number=start,
+        user_id=user_id,
+        file_path=output_path,
+    )
+    db.session.add(version)
+    db.session.commit()
+    log_event(
+        doc.id,
+        ChainEventType.STAMPED,
+        metadata={"prefix": prefix},
+        source_team="legal_discovery",
+    )
+    log_event(
+        doc.id,
+        ChainEventType.VERSIONED,
+        metadata={"version_id": version.id, "bates_number": start},
+        source_team="legal_discovery",
+    )
+    return jsonify({"message": "File stamped", "output": output_path, "bates_number": start})
+
+
+@app.route("/api/document/versions")
+def document_versions():
+    """Return version history for a document."""
+    file_path = request.args.get("file_path")
+    if not file_path:
+        return jsonify({"error": "Missing file_path"}), 400
     doc = Document.query.filter_by(file_path=file_path).first()
-    if doc:
-        log_event(
-            doc.id,
-            ChainEventType.STAMPED,
-            metadata={"prefix": prefix},
-            source_team="legal_discovery",
+    if doc is None:
+        return jsonify({"error": "Document not found"}), 404
+    versions = (
+        DocumentVersion.query.filter_by(document_id=doc.id)
+        .order_by(DocumentVersion.timestamp)
+        .all()
+    )
+    results = []
+    for v in versions:
+        user = Agent.query.get(v.user_id) if v.user_id else None
+        results.append(
+            {
+                "id": v.id,
+                "bates_number": v.bates_number,
+                "user": user.name if user else None,
+                "timestamp": v.timestamp.isoformat(),
+            }
         )
-    return jsonify({"message": "File stamped", "output": f"{file_path}_stamped.pdf"})
+    return jsonify(results)
+
+
+@app.route("/api/document/versions/diff")
+def document_versions_diff():
+    """Compute a unified diff between two document versions."""
+    v1_id = request.args.get("v1")
+    v2_id = request.args.get("v2")
+    if not v1_id or not v2_id:
+        return jsonify({"error": "Missing version ids"}), 400
+    v1 = DocumentVersion.query.get(v1_id)
+    v2 = DocumentVersion.query.get(v2_id)
+    if not v1 or not v2:
+        return jsonify({"error": "Version not found"}), 404
+    processor = DocumentProcessor()
+    text1 = processor.extract_text(v1.file_path)
+    text2 = processor.extract_text(v2.file_path)
+    diff = "\n".join(
+        difflib.unified_diff(
+            text1.splitlines(),
+            text2.splitlines(),
+            fromfile=v1.bates_number,
+            tofile=v2.bates_number,
+            lineterm="",
+        )
+    )
+    return jsonify({"diff": diff})
 
 
 @app.route("/api/document/draft", methods=["POST"])

--- a/apps/legal_discovery/migrations/009_add_document_version.py
+++ b/apps/legal_discovery/migrations/009_add_document_version.py
@@ -1,0 +1,23 @@
+from alembic import op
+import sqlalchemy as sa
+
+revision = "009_add_document_version"
+down_revision = "008_add_narrative_discrepancy"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "document_version",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("document_id", sa.Integer, sa.ForeignKey("document.id"), nullable=False),
+        sa.Column("bates_number", sa.String(100), nullable=False),
+        sa.Column("user_id", sa.Integer, sa.ForeignKey("agent.id"), nullable=True),
+        sa.Column("timestamp", sa.DateTime(), server_default=sa.func.now()),
+        sa.Column("file_path", sa.String(255), nullable=False),
+    )
+
+
+def downgrade():
+    op.drop_table("document_version")

--- a/apps/legal_discovery/models.py
+++ b/apps/legal_discovery/models.py
@@ -147,6 +147,23 @@ class Document(db.Model):
     )
 
 
+class DocumentVersion(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    document_id = db.Column(db.Integer, db.ForeignKey("document.id"), nullable=False)
+    bates_number = db.Column(db.String(100), nullable=False)
+    user_id = db.Column(db.Integer, db.ForeignKey("agent.id"), nullable=True)
+    timestamp = db.Column(db.DateTime, server_default=db.func.now())
+    file_path = db.Column(db.String(255), nullable=False)
+
+    document = db.relationship(
+        "Document",
+        backref=db.backref("versions", lazy=True, cascade="all, delete-orphan"),
+    )
+    user = db.relationship(
+        "Agent", backref=db.backref("document_versions", lazy=True)
+    )
+
+
 class ChainOfCustodyLog(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     document_id = db.Column(db.Integer, db.ForeignKey("document.id"), nullable=False)

--- a/apps/legal_discovery/src/components/DocToolsSection.jsx
+++ b/apps/legal_discovery/src/components/DocToolsSection.jsx
@@ -1,16 +1,25 @@
 import React, { useState } from "react";
 import { alertResponse } from "../utils";
+
 function DocToolsSection() {
   const [path,setPath] = useState('');
   const [redactText,setRedact] = useState('');
   const [prefix,setPrefix] = useState('');
   const [extracted,setExtracted] = useState('');
   const [output,setOutput] = useState('');
+  const [versions,setVersions] = useState([]);
+  const [v1,setV1] = useState('');
+  const [v2,setV2] = useState('');
+  const [diff,setDiff] = useState('');
   const call = (url,body) => fetch(url,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)})
       .then(r=>r.json()).then(d=>{setOutput(d.output||'');alertResponse(d);});
   const redact = () => call('/api/document/redact',{file_path:path,text:redactText});
   const stamp = () => call('/api/document/stamp',{file_path:path,prefix});
   const extract = () => fetch('/api/document/text',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({file_path:path})}).then(r=>r.json()).then(d=>setExtracted(d.data||''));
+  const loadVersions = () => fetch(`/api/document/versions?file_path=${encodeURIComponent(path)}`)
+        .then(r=>r.json()).then(setVersions);
+  const viewDiff = () => fetch(`/api/document/versions/diff?v1=${v1}&v2=${v2}`)
+        .then(r=>r.json()).then(d=>setDiff(d.diff||''));
   return (
     <section className="card">
       <h2>Document Tools</h2>
@@ -22,8 +31,25 @@ function DocToolsSection() {
       <input type="text" value={prefix} onChange={e=>setPrefix(e.target.value)} className="w-full mb-2 p-2 rounded" placeholder="Bates prefix" />
       <button className="button-secondary" onClick={stamp}><i className="fa fa-stamp mr-1"></i>Bates Stamp</button>
       <button className="button-secondary mt-2" onClick={extract}><i className="fa fa-file-lines mr-1"></i>Extract Text</button>
+      <button className="button-secondary mt-2" onClick={loadVersions}><i className="fa fa-clock-rotate-left mr-1"></i>Load Versions</button>
       {output && <p className="text-sm mb-2">Output: <a href={'/uploads/'+output} target="_blank" rel="noopener noreferrer">{output}</a></p>}
       <pre className="text-sm mt-2">{extracted}</pre>
+      {versions.length > 0 && (
+        <div className="mt-4">
+          <h3 className="mb-2">Version History</h3>
+          <ul className="mb-2">
+            {versions.map(v => (
+              <li key={v.id} className="flex items-center gap-2 text-sm">
+                <input type="radio" name="v1" value={v.id} onChange={e=>setV1(e.target.value)} />
+                <input type="radio" name="v2" value={v.id} onChange={e=>setV2(e.target.value)} />
+                <span>{v.bates_number} ({v.timestamp})</span>
+              </li>
+            ))}
+          </ul>
+          <button className="button-secondary" onClick={viewDiff} disabled={!v1 || !v2}><i className="fa fa-code-compare mr-1"></i>View Diff</button>
+          {diff && <pre className="text-xs mt-2 whitespace-pre-wrap">{diff}</pre>}
+        </div>
+      )}
     </section>
   );
 }

--- a/tests/apps/test_document_versioning.py
+++ b/tests/apps/test_document_versioning.py
@@ -1,0 +1,50 @@
+import hashlib
+import os
+import fitz
+import pytest
+
+os.environ["DATABASE_URL"] = "sqlite://"
+
+from apps.legal_discovery.interface_flask import app, db, Document, Agent, Case, DocumentVersion, DocumentSource
+
+
+def _create_pdf(path: str):
+    doc = fitz.open()
+    doc.new_page()
+    doc.save(path)
+
+
+@pytest.fixture
+def client(tmp_path):
+    pdf_path = tmp_path / "sample.pdf"
+    _create_pdf(str(pdf_path))
+    sha = hashlib.sha256(pdf_path.read_bytes()).hexdigest()
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+        case = Case(name="c1", description="d1")
+        db.session.add(case)
+        agent = Agent(name="tester", role="user")
+        db.session.add(agent)
+        db.session.flush()
+        doc = Document(
+            case_id=case.id,
+            name="sample",
+            file_path=str(pdf_path),
+            sha256=sha,
+            source=DocumentSource.USER,
+        )
+        db.session.add(doc)
+        db.session.commit()
+    return app.test_client()
+
+
+def test_sequential_versions(client, tmp_path):
+    file_path = str(tmp_path / "sample.pdf")
+    resp1 = client.post("/api/document/stamp", json={"file_path": file_path, "prefix": "CASE", "user_id": 1})
+    assert resp1.status_code == 200
+    resp2 = client.post("/api/document/stamp", json={"file_path": file_path, "prefix": "CASE", "user_id": 1})
+    assert resp2.status_code == 200
+    with app.app_context():
+        versions = DocumentVersion.query.order_by(DocumentVersion.id).all()
+        assert [v.bates_number for v in versions] == ["CASE_000001", "CASE_000002"]


### PR DESCRIPTION
## Summary
- add `DocumentVersion` model and migration for Bates-stamped versions
- update stamping API to log versions and expose history/diff endpoints
- show document version history with diff view in dashboard
- add sequential numbering unit test

## Testing
- `pip install pytest-cov`
- `pip install PyMuPDF`
- `pip install spacy`
- `pip install weasyprint`
- `pip install more-itertools`
- `PYTHONPATH=$(pwd) pytest tests/apps/test_document_versioning.py` *(fails: ModuleNotFoundError: No module named 'pyhocon')*

------
https://chatgpt.com/codex/tasks/task_e_68936b4ad8b48333811fa5830695d050