### PR TITLE
refactor: modularize legal discovery interface

### DIFF
--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -733,3 +733,8 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 - Enabled chat-driven timeline updates with cross-links to depositions, exhibits and theories, plus summary endpoint and blur styling.
 - Next: broaden natural language date parsing and display linked events in dashboard.
 
+
+## Update 2025-08-09T15:00Z
+- Refactored Flask app into feature blueprints for theories, binder and chat with feature toggles.
+- Updated chat UI and routing tests to use blueprint paths.
+- Next: expand binder capabilities and modularise remaining routes.

--- a/apps/legal_discovery/binder_routes.py
+++ b/apps/legal_discovery/binder_routes.py
@@ -1,0 +1,25 @@
+import os
+from flask import Blueprint, jsonify, request
+
+from coded_tools.legal_discovery.pretrial_generator import PretrialGenerator
+
+binder_bp = Blueprint("binder", __name__, url_prefix="/api/binder")
+
+
+@binder_bp.post("/pretrial/export")
+def export_pretrial_statement():
+    """Generate a pretrial statement document and update timeline/binder."""
+
+    data = request.get_json() or {}
+    case_id = data.get("case_id", type=int)
+    if not case_id:
+        return jsonify({"error": "Missing case_id"}), 400
+
+    os.makedirs("exports", exist_ok=True)
+    path = os.path.join("exports", f"pretrial_{case_id}.docx")
+    generator = PretrialGenerator()
+    generator.export(case_id, path)
+    return jsonify({"status": "ok", "path": path})
+
+
+__all__ = ["binder_bp"]

--- a/apps/legal_discovery/chat_state.py
+++ b/apps/legal_discovery/chat_state.py
@@ -1,0 +1,5 @@
+import queue
+
+user_input_queue = queue.Queue()
+
+__all__ = ["user_input_queue"]

--- a/apps/legal_discovery/extensions.py
+++ b/apps/legal_discovery/extensions.py
@@ -1,0 +1,5 @@
+from flask_socketio import SocketIO
+
+socketio = SocketIO()
+
+__all__ = ["socketio"]

--- a/apps/legal_discovery/feature_flags.py
+++ b/apps/legal_discovery/feature_flags.py
@@ -1,0 +1,9 @@
+import os
+
+FEATURE_FLAGS = {
+    "theories": os.getenv("ENABLE_THEORIES", "1") == "1",
+    "binder": os.getenv("ENABLE_BINDER", "1") == "1",
+    "chat": os.getenv("ENABLE_CHAT", "1") == "1",
+}
+
+__all__ = ["FEATURE_FLAGS"]

--- a/apps/legal_discovery/src/components/ChatSection.jsx
+++ b/apps/legal_discovery/src/components/ChatSection.jsx
@@ -35,7 +35,7 @@ function ChatSection() {
 
   const send = () => {
     if (!input.trim()) return;
-    fetch("/api/query", {
+    fetch("/api/chat/query", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ text: input, voice_model: voiceModel }),
@@ -85,7 +85,7 @@ function ChatSection() {
   };
 
   const sendVoice = (audio, transcript) => {
-    fetch("/api/voice_query", {
+    fetch("/api/chat/voice", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ audio, transcript, voice_model: voiceModel }),

--- a/apps/legal_discovery/theory_routes.py
+++ b/apps/legal_discovery/theory_routes.py
@@ -1,0 +1,127 @@
+import os
+from flask import Blueprint, jsonify, request, current_app
+
+from coded_tools.legal_discovery.document_drafter import DocumentDrafter
+from coded_tools.legal_discovery.pretrial_generator import PretrialGenerator
+from coded_tools.legal_discovery.timeline_manager import TimelineManager
+from coded_tools.legal_discovery.legal_theory_engine import LegalTheoryEngine
+
+from .database import db
+from .models import LegalTheory
+
+
+theories_bp = Blueprint("theories", __name__, url_prefix="/api/theories")
+
+
+@theories_bp.get("/suggest")
+def suggest_theories():
+    """Return ranked legal theory candidates."""
+    engine = LegalTheoryEngine()
+    theories = engine.suggest_theories()
+    engine.close()
+    return jsonify({"status": "ok", "theories": theories})
+
+
+@theories_bp.get("/graph")
+def theory_graph():
+    """Return graph data for a specific cause of action."""
+    cause = request.args.get("cause")
+    if not cause:
+        return jsonify({"status": "error", "error": "cause required"}), 400
+    engine = LegalTheoryEngine()
+    nodes, edges = engine.get_theory_subgraph(cause)
+    engine.close()
+    return jsonify({"status": "ok", "nodes": nodes, "edges": edges})
+
+
+@theories_bp.post("/accept")
+def accept_theory():
+    """Pipe an accepted theory to drafting, pretrial and timeline tools."""
+
+    data = request.get_json() or {}
+    cause = data.get("cause")
+    if not cause:
+        return jsonify({"status": "error", "error": "cause required"}), 400
+
+    engine = LegalTheoryEngine()
+    try:
+        theories = engine.suggest_theories()
+        theory = next((t for t in theories if t["cause"] == cause), None)
+        if theory is None:
+            return jsonify({"status": "error", "error": "unknown cause"}), 404
+
+        drafter = DocumentDrafter()
+        upload_dir = current_app.config.get("UPLOAD_FOLDER", "uploads")
+        doc_path = os.path.join(upload_dir, f"{cause.replace(' ', '_')}_theory.docx")
+        drafter.create_document(doc_path, f"Accepted theory: {cause}")
+
+        pretrial = PretrialGenerator()
+        statement = pretrial.generate_statement(cause, [e["name"] for e in theory["elements"]])
+
+        timeline_items: list[dict] = []
+        for element in theory["elements"]:
+            for fact in element["facts"]:
+                for date in fact.get("dates", []):
+                    timeline_items.append({"date": date, "description": fact["text"]})
+
+        timeline_manager = TimelineManager()
+        if timeline_items:
+            timeline_manager.create_timeline(cause, timeline_items)
+
+        lt = LegalTheory.query.filter_by(theory_name=cause, case_id=1).first()
+        if lt is None:
+            lt = LegalTheory(case_id=1, theory_name=cause)
+            db.session.add(lt)
+        lt.status = "approved"
+        if data.get("comment"):
+            lt.review_comment = data.get("comment")
+        db.session.commit()
+
+        return jsonify(
+            {
+                "status": "ok",
+                "document": doc_path,
+                "pretrial": statement,
+                "timeline_items": timeline_items,
+            }
+        )
+    finally:
+        engine.close()
+
+
+@theories_bp.post("/reject")
+def reject_theory():
+    data = request.get_json() or {}
+    cause = data.get("cause")
+    if not cause:
+        return jsonify({"status": "error", "error": "cause required"}), 400
+
+    lt = LegalTheory.query.filter_by(theory_name=cause, case_id=1).first()
+    if lt is None:
+        lt = LegalTheory(case_id=1, theory_name=cause)
+        db.session.add(lt)
+    lt.status = "rejected"
+    if data.get("comment"):
+        lt.review_comment = data.get("comment")
+    db.session.commit()
+    return jsonify({"status": "ok"})
+
+
+@theories_bp.post("/comment")
+def comment_theory():
+    data = request.get_json() or {}
+    cause = data.get("cause")
+    comment = data.get("comment")
+    if not cause or comment is None:
+        return jsonify({"status": "error", "error": "cause and comment required"}), 400
+
+    lt = LegalTheory.query.filter_by(theory_name=cause, case_id=1).first()
+    if lt is None:
+        lt = LegalTheory(case_id=1, theory_name=cause)
+        db.session.add(lt)
+    lt.review_comment = comment
+    db.session.commit()
+    return jsonify({"status": "ok"})
+
+
+__all__ = ["theories_bp"]

--- a/apps/legal_discovery/voice.py
+++ b/apps/legal_discovery/voice.py
@@ -1,0 +1,18 @@
+import base64
+from io import BytesIO
+
+
+def synthesize_voice(text: str, model: str) -> str:
+    """Generate base64-encoded audio from text using gTTS."""
+    try:  # pragma: no cover - best effort
+        from gtts import gTTS
+
+        audio_io = BytesIO()
+        gTTS(text=text, lang=model).write_to_fp(audio_io)
+        audio_io.seek(0)
+        return base64.b64encode(audio_io.read()).decode("utf-8")
+    except Exception:  # pragma: no cover
+        return ""
+
+
+__all__ = ["synthesize_voice"]

--- a/tests/apps/test_chat_audit.py
+++ b/tests/apps/test_chat_audit.py
@@ -16,7 +16,7 @@ def client():
 
 
 def test_query_logs_message(client):
-    resp = client.post("/api/query", json={"text": "hello"})
+    resp = client.post("/api/chat/query", json={"text": "hello"})
     assert resp.status_code == 200
     with app.app_context():
         logs = MessageAuditLog.query.all()
@@ -25,11 +25,11 @@ def test_query_logs_message(client):
 
 def test_voice_query_logs_message(client, monkeypatch):
     monkeypatch.setattr(
-        "apps.legal_discovery.interface_flask.synthesize_voice", lambda text, model: ""
+        "apps.legal_discovery.voice.synthesize_voice", lambda text, model: ""
     )
     audio = base64.b64encode(b"test").decode()
     resp = client.post(
-        "/api/voice_query",
+        "/api/chat/voice",
         json={"audio": audio, "transcript": "hi", "voice_model": "en-US"},
     )
     assert resp.status_code == 200

--- a/tests/apps/test_pretrial_export.py
+++ b/tests/apps/test_pretrial_export.py
@@ -1,0 +1,25 @@
+import os
+import pytest
+from pathlib import Path
+
+os.environ["DATABASE_URL"] = "sqlite://"
+
+from apps.legal_discovery.interface_flask import app, db
+
+
+@pytest.fixture
+def client(monkeypatch):
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+    def fake_export(case_id, path):
+        Path(path).write_text("test")
+        return path
+    monkeypatch.setattr("apps.legal_discovery.binder_routes.PretrialGenerator.export", fake_export)
+    return app.test_client()
+
+
+def test_pretrial_export(client):
+    resp = client.post("/api/binder/pretrial/export", json={"case_id": 1})
+    assert resp.status_code == 200
+    assert "path" in resp.json

--- a/tests/apps/test_timeline_chat.py
+++ b/tests/apps/test_timeline_chat.py
@@ -22,7 +22,7 @@ def client():
 
 def test_chat_creates_timeline_event(client):
     resp = client.post(
-        "/api/query",
+        "/api/chat/query",
         json={"text": "case:1 2024-01-01 Filing made [dep:1] [ex:2] [theory:3]"},
     )
     assert resp.status_code == 200
@@ -36,7 +36,7 @@ def test_chat_creates_timeline_event(client):
 
 
 def test_timeline_summary(client):
-    client.post("/api/query", json={"text": "case:1 2024-02-02 Hearing"})
+    client.post("/api/chat/query", json={"text": "case:1 2024-02-02 Hearing"})
     resp = client.get("/api/timeline/summary", query_string={"case_id": 1})
     assert resp.status_code == 200
     assert "2024-02-02" in resp.json["summary"]


### PR DESCRIPTION
## Summary
- break monolithic legal_discovery interface into feature blueprints for theories, binder, and chat
- add feature flag configuration to enable or disable modules
- update chat client and tests for new blueprint paths

## Testing
- `npm --prefix apps/legal_discovery run build --silent`
- `pytest tests/apps/test_chat_audit.py tests/apps/test_timeline_chat.py tests/apps/test_pretrial_export.py tests/coded_tools/legal_discovery/test_api_endpoints.py tests/coded_tools/legal_discovery/test_exhibit_api.py -q` *(fails: Failed to connect to Neo4j at bolt://localhost:7687)*

------
https://chatgpt.com/codex/tasks/task_e_68939dbabd60833393d82e33646ef4fb