### PR TITLE
Add Trial Prep Academy with resource lessons

### DIFF
--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -742,3 +742,7 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 ## Update 2025-08-09T16:30Z
 - Updated README to reference Gemini models and modern `docker compose` commands.
 - Next: review remaining docs for outdated OpenAI references.
+
+## Update 2025-08-10T00:00Z
+- Introduced Trial Prep Academy with resource ingestion, lesson APIs, and React curriculum tab.
+- Next: expand telemetry analysis and feed prioritisation.

--- a/apps/legal_discovery/interface_flask.py
+++ b/apps/legal_discovery/interface_flask.py
@@ -88,6 +88,7 @@ from coded_tools.legal_discovery.bates_numbering import (
     stamp_pdf,
 )
 from .exhibit_routes import exhibits_bp
+from .trial_prep_routes import trial_prep_bp
 from .chain_logger import ChainEventType, log_event
 from coded_tools.legal_discovery.bates_numbering import (
     BatesNumberingService,
@@ -138,6 +139,7 @@ app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
 db.init_app(app)
 socketio.init_app(app)
 app.register_blueprint(exhibits_bp)
+app.register_blueprint(trial_prep_bp)
 if FEATURE_FLAGS.get("theories"):
     from .theory_routes import theories_bp
 

--- a/apps/legal_discovery/src/Dashboard.jsx
+++ b/apps/legal_discovery/src/Dashboard.jsx
@@ -25,6 +25,7 @@ import DepositionPrepSection from "./components/DepositionPrepSection";
 import ChainLogSection from "./components/ChainLogSection";
 import OppositionTrackerSection from "./components/OppositionTrackerSection";
 import DocumentReviewSection from "./components/DocumentReviewSection";
+import TrialPrepSchoolSection from "./components/TrialPrepSchoolSection";
 const TABS = [
   {id:'network', label:'Agent Network', icon:'fa-sitemap'},
   {id:'overview', label:'Overview', icon:'fa-home'},
@@ -44,6 +45,7 @@ const TABS = [
   {id:'research', label:'Legal Research', icon:'fa-book-open'},
   {id:'subpoena', label:'Subpoena', icon:'fa-gavel'},
   {id:'presentation', label:'Trial Prep', icon:'fa-slideshare'},
+  {id:'academy', label:'Trial Prep School', icon:'fa-university'},
   {id:'exhibits', label:'Exhibits', icon:'fa-book'},
   {id:'deposition', label:'Deposition Prep', icon:'fa-user-tie'},
   {id:'opposition', label:'Opposition Tracker', icon:'fa-flag'},
@@ -94,6 +96,7 @@ function Dashboard() {
       <div className="tab-content" style={{display: tab==='research'?'block':'none'}} id="tab-research"><ResearchSection/></div>
       <div className="tab-content" style={{display: tab==='subpoena'?'block':'none'}} id="tab-subpoena"><SubpoenaSection/></div>
       <div className="tab-content" style={{display: tab==='presentation'?'block':'none'}} id="tab-presentation"><PresentationSection/></div>
+      <div className="tab-content" style={{display: tab==='academy'?'block':'none'}} id="tab-academy"><TrialPrepSchoolSection/></div>
       <div className="tab-content" style={{display: tab==='exhibits'?'block':'none'}} id="tab-exhibits"><ExhibitTab/></div>
       <div className="tab-content" style={{display: tab==='deposition'?'block':'none'}} id="tab-deposition"><DepositionPrepSection/></div>
       <div className="tab-content" style={{display: tab==='opposition'?'block':'none'}} id="tab-opposition"><OppositionTrackerSection/></div>

--- a/apps/legal_discovery/src/components/TrialPrepSchoolSection.jsx
+++ b/apps/legal_discovery/src/components/TrialPrepSchoolSection.jsx
@@ -1,0 +1,44 @@
+import React, { useEffect, useState } from "react";
+
+function TrialPrepSchoolSection() {
+  const [lessons, setLessons] = useState([]);
+
+  useEffect(() => {
+    fetch("/api/lessons")
+      .then((r) => r.json())
+      .then(setLessons)
+      .catch(() => setLessons([]));
+  }, []);
+
+  const markComplete = (id) => {
+    fetch(`/api/lessons/${id}/progress`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ completed: true }),
+    })
+      .then((r) => r.json())
+      .then((data) => {
+        setLessons((ls) =>
+          ls.map((l) => (l.id === id ? { ...l, progress: [data] } : l))
+        );
+      });
+  };
+
+  return (
+    <div className="card-grid">
+      {lessons.map((lesson) => (
+        <div key={lesson.id} className="card">
+          <h3>{lesson.title}</h3>
+          <p>{lesson.summary}</p>
+          {lesson.progress && lesson.progress[0] && lesson.progress[0].completed ? (
+            <span className="badge">Completed</span>
+          ) : (
+            <button onClick={() => markComplete(lesson.id)}>Mark Complete</button>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default TrialPrepSchoolSection;

--- a/apps/legal_discovery/trial_prep.py
+++ b/apps/legal_discovery/trial_prep.py
@@ -1,0 +1,312 @@
+"""Trial Prep Academy core modules."""
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import textwrap
+from dataclasses import dataclass
+from typing import Iterable, List
+
+import chromadb
+import requests
+import spacy
+from spacy.cli import download as spacy_download
+from bs4 import BeautifulSoup
+from chromadb.config import Settings
+from neo4j import GraphDatabase
+
+from .database import db
+from .models import LegalResource, Lesson, LessonProgress
+
+
+def _load_spacy_model():
+    try:
+        return spacy.load("en_core_web_sm")
+    except OSError:  # pragma: no cover - environment specific
+        spacy_download("en_core_web_sm")
+        return spacy.load("en_core_web_sm")
+
+
+@dataclass
+class CandidateResource:
+    """Simple container used by the scout and quality gate."""
+
+    url: str
+    title: str | None = None
+    jurisdiction: str | None = None
+
+
+class ResourceScout:
+    """Scans configured feeds for candidate legal materials."""
+
+    def __init__(self, feeds: Iterable[str] | None = None) -> None:
+        self.feeds = list(
+            feeds
+            or [
+                "https://www.courts.ca.gov/opinions-slip.htm",
+                "https://www.justice.gov/usao/resources",
+            ]
+        )
+
+    def scan(self) -> List[CandidateResource]:
+        candidates: List[CandidateResource] = []
+        for feed in self.feeds:
+            try:
+                resp = requests.get(feed, timeout=10)
+                resp.raise_for_status()
+            except Exception as exc:  # pragma: no cover - network failures
+                logging.warning("feed %s unreachable: %s", feed, exc)
+                continue
+            soup = BeautifulSoup(resp.text, "html.parser")
+            for link in soup.find_all("a", href=True):
+                href = requests.compat.urljoin(feed, link["href"])
+                if href.lower().endswith((".pdf", ".html", ".htm")):
+                    candidates.append(CandidateResource(url=href, title=link.text.strip()))
+        return candidates
+
+
+class ResourceScraper:
+    """Fetch and parse legal resources into raw text."""
+
+    def fetch(self, url: str) -> str:
+        resp = requests.get(url, timeout=20)
+        resp.raise_for_status()
+        content_type = resp.headers.get("content-type", "")
+        if "pdf" in content_type or url.lower().endswith(".pdf"):
+            return self._parse_pdf(resp.content)
+        return self._parse_html(resp.text)
+
+    @staticmethod
+    def _parse_pdf(data: bytes) -> str:
+        import fitz  # PyMuPDF
+
+        text = []
+        with fitz.open(stream=data, filetype="pdf") as doc:
+            for page in doc:
+                text.append(page.get_text())
+        return "\n".join(text)
+
+    @staticmethod
+    def _parse_html(text: str) -> str:
+        soup = BeautifulSoup(text, "html.parser")
+        for script in soup(["script", "style"]):
+            script.decompose()
+        return soup.get_text(" ")
+
+
+class QualityGate:
+    """Scores resources to determine indexing suitability."""
+
+    KEYWORDS = ["evidence", "motion", "trial", "rule"]
+
+    def score(self, text: str, jurisdiction: str | None = None) -> float:
+        score = 0.0
+        lowered = text.lower()
+        for kw in self.KEYWORDS:
+            if kw in lowered:
+                score += 1
+        if jurisdiction and jurisdiction.lower() in lowered:
+            score += 1
+        return score / (len(self.KEYWORDS) + 1)
+
+    def passes(self, score: float) -> bool:
+        return score >= 0.2
+
+
+class KnowledgeBase:
+    """Stores resource embeddings using ChromaDB with an in-memory fallback."""
+
+    def __init__(self) -> None:
+        self.nlp = _load_spacy_model()
+        try:
+            self.client = chromadb.Client(Settings(anonymized_telemetry=False))
+            self.collection = self.client.get_or_create_collection("trial_prep_resources")
+            self.use_chroma = True
+        except Exception:  # pragma: no cover - environment specific
+            self.client = None
+            self.collection = {}
+            self.use_chroma = False
+
+    def index(self, resource: LegalResource) -> None:
+        doc = self.nlp(resource.content)
+        if self.use_chroma:
+            self.collection.add(
+                ids=[str(resource.id)],
+                embeddings=[doc.vector.tolist()],
+                documents=[resource.content],
+                metadatas=[{"title": resource.title}],
+            )
+        else:
+            self.collection[str(resource.id)] = doc.vector
+
+    def search(self, query: str, limit: int = 5) -> List[int]:
+        doc = self.nlp(query)
+        if self.use_chroma:
+            result = self.collection.query(query_embeddings=[doc.vector.tolist()], n_results=limit)
+            return [int(rid) for rid in result.get("ids", [[]])[0]]
+        import numpy as np
+
+        q = doc.vector
+        scores = []
+        for rid, vec in self.collection.items():
+            denom = float(np.linalg.norm(q) * np.linalg.norm(vec)) or 1.0
+            scores.append((rid, float(np.dot(q, vec) / denom)))
+        scores.sort(key=lambda x: x[1], reverse=True)
+        return [int(rid) for rid, _ in scores[:limit]]
+
+
+class GraphManager:
+    """Links resources to topics and related materials in Neo4j."""
+
+    def __init__(self, uri: str | None = None, user: str | None = None, password: str | None = None) -> None:
+        uri = uri or os.environ.get("NEO4J_URL", "bolt://localhost:7687")
+        user = user or os.environ.get("NEO4J_USER", "neo4j")
+        password = password or os.environ.get("NEO4J_PASSWORD", "test")
+        try:
+            self.driver = GraphDatabase.driver(uri, auth=(user, password))
+            self.session = self.driver.session()
+        except Exception:  # pragma: no cover - external service
+            self.driver = None
+            self.session = None
+
+    def link(self, resource: LegalResource, topic: str) -> None:
+        if self.session is None:  # pragma: no cover - network path
+            return
+        try:
+            self.session.run(
+                "MERGE (r:Resource {id:$id, title:$title})"
+                " MERGE (t:Topic {name:$topic})"
+                " MERGE (r)-[:BELONGS_TO]->(t)",
+                id=resource.id,
+                title=resource.title,
+                topic=topic,
+            )
+        except Exception:  # pragma: no cover - external service
+            pass
+
+    def close(self) -> None:
+        if self.session:
+            self.session.close()
+        if self.driver:
+            self.driver.close()
+
+
+class LessonBuilder:
+    """Transforms resources into lessons with summaries and quizzes."""
+
+    def __init__(self) -> None:
+        self.nlp = _load_spacy_model()
+
+    def _summarize(self, text: str) -> str:
+        summary = textwrap.shorten(text, width=400, placeholder="...")
+        return summary
+
+    def _quiz(self, text: str) -> List[dict]:
+        doc = self.nlp(text)
+        questions = []
+        for sent in list(doc.sents)[:3]:
+            words = sent.text.split()
+            if len(words) < 6:
+                continue
+            idx = len(words) // 2
+            answer = words[idx]
+            question = " ".join(words[:idx] + ["____"] + words[idx + 1 :])
+            questions.append({"question": question, "answer": answer})
+        return questions
+
+    def build_from_resource(self, resource: LegalResource, topic: str) -> Lesson:
+        summary = self._summarize(resource.content)
+        quiz = self._quiz(resource.content)
+        lesson = Lesson(topic=topic, title=resource.title, resource_id=resource.id, summary=summary, quiz=quiz)
+        db.session.add(lesson)
+        db.session.commit()
+        return lesson
+
+
+class CurriculumManager:
+    """CRUD operations for lessons and progress tracking."""
+
+    def list_lessons(self, topic: str | None = None) -> List[Lesson]:
+        query = Lesson.query
+        if topic:
+            query = query.filter_by(topic=topic)
+        return query.all()
+
+    def record_progress(
+        self, lesson_id: int, completed: bool, quiz_score: float | None, thumbs_up: bool | None
+    ) -> LessonProgress:
+        progress = LessonProgress.query.filter_by(lesson_id=lesson_id, user_id="default").first()
+        if progress is None:
+            progress = LessonProgress(lesson_id=lesson_id, user_id="default")
+            db.session.add(progress)
+        progress.completed = completed
+        if quiz_score is not None:
+            progress.quiz_score = float(quiz_score)
+        progress.thumbs_up = thumbs_up
+        db.session.commit()
+        return progress
+
+
+class ResourceManager:
+    """Orchestrates resource acquisition and indexing."""
+
+    def __init__(self) -> None:
+        self.scout = ResourceScout()
+        self.scraper = ResourceScraper()
+        self.gate = QualityGate()
+        self.kb = KnowledgeBase()
+        self.graph = GraphManager()
+
+    def ingest(self) -> List[LegalResource]:  # pragma: no cover - network heavy
+        resources = []
+        for candidate in self.scout.scan():
+            try:
+                text = self.scraper.fetch(candidate.url)
+                score = self.gate.score(text, candidate.jurisdiction)
+                if not self.gate.passes(score):
+                    continue
+                sha = hashlib.sha256(text.encode("utf-8")).hexdigest()
+                existing = LegalResource.query.filter_by(sha256=sha).first()
+                if existing:
+                    continue
+                resource = LegalResource(
+                    title=candidate.title or candidate.url,
+                    url=candidate.url,
+                    jurisdiction=candidate.jurisdiction,
+                    content=text,
+                    metadata_json={"score": score},
+                    sha256=sha,
+                )
+                db.session.add(resource)
+                db.session.commit()
+                self.kb.index(resource)
+                if candidate.jurisdiction:
+                    self.graph.link(resource, candidate.jurisdiction)
+                resources.append(resource)
+            except Exception as exc:
+                logging.warning("failed to ingest %s: %s", candidate.url, exc)
+        return resources
+
+    def add_manual_resource(self, title: str, url: str, jurisdiction: str, content: str) -> LegalResource:
+        sha = hashlib.sha256(content.encode("utf-8")).hexdigest()
+        resource = LegalResource(
+            title=title,
+            url=url,
+            jurisdiction=jurisdiction,
+            content=content,
+            metadata_json={},
+            sha256=sha,
+        )
+        db.session.add(resource)
+        db.session.commit()
+        self.kb.index(resource)
+        if jurisdiction:
+            self.graph.link(resource, jurisdiction)
+        return resource
+
+    def search(self, query: str) -> List[LegalResource]:
+        ids = self.kb.search(query)
+        if not ids:
+            return []
+        return LegalResource.query.filter(LegalResource.id.in_(ids)).all()

--- a/apps/legal_discovery/trial_prep_routes.py
+++ b/apps/legal_discovery/trial_prep_routes.py
@@ -1,0 +1,45 @@
+"""Flask routes for Trial Prep Academy APIs."""
+from __future__ import annotations
+
+from flask import Blueprint, abort, jsonify, request
+
+from .models import LegalResource, Lesson
+from .trial_prep import CurriculumManager, ResourceManager
+
+trial_prep_bp = Blueprint("trial_prep", __name__)
+resource_manager = ResourceManager()
+curriculum_manager = CurriculumManager()
+
+
+@trial_prep_bp.route("/api/resources/search")
+def search_resources():
+    query = request.args.get("query", "")
+    resources = (
+        resource_manager.search(query) if query else LegalResource.query.all()
+    )
+    return jsonify([r.to_dict() for r in resources])
+
+
+@trial_prep_bp.route("/api/resources/<int:res_id>")
+def get_resource(res_id: int):
+    resource = LegalResource.query.get_or_404(res_id)
+    return jsonify(resource.to_dict(include_content=True))
+
+
+@trial_prep_bp.route("/api/lessons")
+def list_lessons():
+    topic = request.args.get("topic")
+    lessons = curriculum_manager.list_lessons(topic)
+    return jsonify([l.to_dict(with_progress=True) for l in lessons])
+
+
+@trial_prep_bp.route("/api/lessons/<int:lesson_id>/progress", methods=["POST"])
+def update_progress(lesson_id: int):
+    data = request.get_json() or {}
+    progress = curriculum_manager.record_progress(
+        lesson_id,
+        completed=bool(data.get("completed")),
+        quiz_score=data.get("quiz_score"),
+        thumbs_up=data.get("thumbs_up"),
+    )
+    return jsonify(progress.to_dict())

--- a/tests/coded_tools/legal_discovery/test_trial_prep_academy.py
+++ b/tests/coded_tools/legal_discovery/test_trial_prep_academy.py
@@ -1,0 +1,53 @@
+import unittest
+from flask import Flask
+
+from apps.legal_discovery.database import db
+from apps.legal_discovery.trial_prep_routes import trial_prep_bp
+from apps.legal_discovery.trial_prep import LessonBuilder, ResourceManager
+
+
+class TrialPrepAcademyAPITest(unittest.TestCase):
+    def setUp(self):
+        app = Flask(__name__)
+        app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+        app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
+        db.init_app(app)
+        app.register_blueprint(trial_prep_bp)
+        self.app = app
+        with app.app_context():
+            db.create_all()
+            manager = ResourceManager()
+            resource = manager.add_manual_resource(
+                "Rule 403", "http://example.com/rule403", "CA", "Rule 403 excludes relevant evidence on grounds." )
+            builder = LessonBuilder()
+            builder.build_from_resource(resource, topic="Evidence")
+        self.client = app.test_client()
+
+    def test_search_and_get_resource(self):
+        resp = self.client.get("/api/resources/search?query=Rule")
+        self.assertEqual(resp.status_code, 200)
+        data = resp.get_json()
+        self.assertTrue(data)
+        res_id = data[0]["id"]
+        resp = self.client.get(f"/api/resources/{res_id}")
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn("content", resp.get_json())
+
+    def test_lesson_progress(self):
+        resp = self.client.get("/api/lessons")
+        self.assertEqual(resp.status_code, 200)
+        lessons = resp.get_json()
+        self.assertEqual(len(lessons), 1)
+        lesson_id = lessons[0]["id"]
+        resp = self.client.post(
+            f"/api/lessons/{lesson_id}/progress",
+            json={"completed": True, "quiz_score": 0.9, "thumbs_up": True},
+        )
+        self.assertEqual(resp.status_code, 200)
+        progress = resp.get_json()
+        self.assertTrue(progress["completed"])
+        self.assertAlmostEqual(progress["quiz_score"], 0.9)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- introduce LegalResource, Lesson, and LessonProgress models
- add resource ingestion, indexing, and curriculum modules with Flask APIs
- expose "Trial Prep School" React tab for lessons and progress tracking

## Testing
- `pytest tests/coded_tools/legal_discovery/test_trial_prep_academy.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689488ed0f888333935b9991de3c119e