### PR TITLE
docs: add court presentation timeline spec

### DIFF
--- a/agents--features and memory/#10_Real-Time_Court_Presentation_y_Timeline_Sync.md
+++ b/agents--features and memory/#10_Real-Time_Court_Presentation_y_Timeline_Sync.md
@@ -1,0 +1,24 @@
+## Real-Time Court Presentation & Timeline Sync
+
+### Document Viewer with Deep Links
+- React + PDF.js (or react-pdf) supporting page navigation, text selection, and highlights.
+- Deep link format: `/viewer/resource_id=offer_of_proof`.
+- Bookmarking: store user-specific positions and notes via `/api/bookmarks`; persisted in `user_resources`.
+
+### Presentation Command Bus
+- WebSocket channel (Flask-SocketIO or Supabase Realtime) broadcasting commands: `goto_page`, `zoom`, `highlight`, `play_media`.
+- Roles: Presenter (full controls) vs. Viewer (read-only).
+- URL structure: `/present/:mode/:doc_id`.
+
+### Timeline Integration
+- Timeline events (exhibit introductions, testimony segments) mapped to document pages.
+- Clicking an event sends `goto_page` to all connected views and highlights the active segment.
+- Transcript linkage: transcripts display in sync with viewer page for judges and jury displays.
+
+### Distribution & Offline Use
+- Presentation package export (HTML + assets) for USB/email sharing; auto-launches in offline mode.
+- Optional quick-share QR code or link for courtroom devices.
+
+### Crosslink & Annotation
+- "Learn more" tooltips trigger related rule lookup in the knowledge base and open in a side pane.
+- Annotations stored per user or per case; exportable with exhibits.

--- a/agents--features and memory/condensed_agents.md
+++ b/agents--features and memory/condensed_agents.md
@@ -237,3 +237,7 @@ WE STARTED ON #3, INSTEAD OF #1. DEAL WITH IT, FINISH IMPLEMENTING #3, AND THEN 
 - Built Gemini-driven pretrial generator aggregating stipulations, contested issues and witnesses.
 - Export creates editable DOCX and triggers timeline and binder updates with unit tests.
 - Next: surface pretrial export controls in dashboard and expand coverage.
+
+## Update 2025-08-10T12:30Z
+- Added spec doc for Real-Time Court Presentation & Timeline Sync (feature #10).
+- Next: implement document viewer and websocket command bus.


### PR DESCRIPTION
## Summary
- add spec for real-time court presentation & timeline sync
- log new feature in condensed agents file

## Testing
- `pytest` *(fails: 23 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6894b0b5f4248333a49fae256c1371ec