### PR TITLE
fix: ensure tests import apps package

### DIFF
--- a/agents--features and memory/condensed_agents.md
+++ b/agents--features and memory/condensed_agents.md
@@ -241,3 +241,7 @@ WE STARTED ON #3, INSTEAD OF #1. DEAL WITH IT, FINISH IMPLEMENTING #3, AND THEN 
 ## Update 2025-08-10T12:30Z
 - Added spec doc for Real-Time Court Presentation & Timeline Sync (feature #10).
 - Next: implement document viewer and websocket command bus.
+## Update 2025-08-07T14:48Z
+- Added test configuration to ensure `apps` package imports during pytest.
+- Installed missing dependencies to progress test run; remaining failures stem from absent optional packages like `weasyprint`.
+- Next: resolve outstanding dependency gaps and continue debugging failing test modules.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,11 @@
+"""Test configuration and helpers."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Ensure repository root is on sys.path so `apps` package imports succeed
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))


### PR DESCRIPTION
## Summary
- ensure pytest can import `apps` by adding repo root to `sys.path`
- log debugging progress and next steps in condensed agents roadmap

## Testing
- `flake8 tests/conftest.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'weasyprint')*

------
https://chatgpt.com/codex/tasks/task_e_6894bad082bc833382b7186077459b1a