### PR TITLE
chore: sync neo4j password env

### DIFF
--- a/agents--features and memory/condensed_agents.md
+++ b/agents--features and memory/condensed_agents.md
@@ -245,3 +245,8 @@ WE STARTED ON #3, INSTEAD OF #1. DEAL WITH IT, FINISH IMPLEMENTING #3, AND THEN 
 - Added test configuration to ensure `apps` package imports during pytest.
 - Installed missing dependencies to progress test run; remaining failures stem from absent optional packages like `weasyprint`.
 - Next: resolve outstanding dependency gaps and continue debugging failing test modules.
+
+## Update 2025-08-10T15:30Z
+- Parameterised Neo4j password in Docker Compose so app and database share credentials
+- Updated trial prep module to honour `NEO4J_URI` environment variable
+- Next: run full Docker stack to verify password overrides

--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -751,3 +751,8 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 - Unified Neo4j credentials and verified connection.
 - Replaced legacy Gemini model references with Gemini 2.5 Pro/Flash across code and docs.
 - Next: run full Docker stack to validate end-to-end flows.
+
+## Update 2025-08-10T15:30Z
+- Parameterised Neo4j password in docker-compose so services stay in sync
+- Switched trial prep helper to use `NEO4J_URI` for consistency
+- Next: spin up Docker stack and confirm password overrides apply

--- a/apps/legal_discovery/README.md
+++ b/apps/legal_discovery/README.md
@@ -20,6 +20,9 @@ cp .env.example .env  # if you haven't created one
 # then edit .env and set NEO4J_PASSWORD=your_password
 ```
 
+Docker Compose reads `NEO4J_PASSWORD` for both the app and database services so
+they always share the same credentials.
+
 ## Running with Docker Compose
 
 From the project root run:

--- a/apps/legal_discovery/trial_prep.py
+++ b/apps/legal_discovery/trial_prep.py
@@ -160,7 +160,7 @@ class GraphManager:
     """Links resources to topics and related materials in Neo4j."""
 
     def __init__(self, uri: str | None = None, user: str | None = None, password: str | None = None) -> None:
-        uri = uri or os.environ.get("NEO4J_URL", "bolt://localhost:7687")
+        uri = uri or os.environ.get("NEO4J_URI", "bolt://localhost:7687")
         user = user or os.environ.get("NEO4J_USER", "neo4j")
         password = password or os.environ.get("NEO4J_PASSWORD", "neo4jPass123")
         try:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - CHROMA_PORT=8000
       - NEO4J_URI=bolt://neo4j:7687
       - NEO4J_USER=neo4j
-      - NEO4J_PASSWORD=neo4jPass123
+      - NEO4J_PASSWORD=${NEO4J_PASSWORD:-neo4jPass123}
     depends_on:
       postgres:
         condition: service_started
@@ -43,7 +43,7 @@ services:
       - "7474:7474"
       - "7687:7687"
     environment:
-      - NEO4J_AUTH=neo4j/neo4jPass123
+      - NEO4J_AUTH=neo4j/${NEO4J_PASSWORD:-neo4jPass123}
     volumes:
       - /mnt/e/docker_volumes/neo4j/data:/data
     healthcheck:


### PR DESCRIPTION
## Summary
- share NEO4J_PASSWORD between app and database in docker-compose to avoid auth mismatch
- read NEO4J_URI in trial prep helper instead of legacy NEO4J_URL
- note in README that docker compose uses NEO4J_PASSWORD for both services

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask_sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_689552be96588333a30d2853630c7d9b