### PR TITLE
Add trial objection detection scaffold

### DIFF
--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -764,3 +764,8 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 ## Update 2025-08-08T20:47Z
 - Added pause/resume control to Upload tab so large batches can be temporarily halted.
 - Next: surface upload error details and add optional cancel action.
+
+## Update 2025-08-09T07:34Z
+- Added trial assistant scaffold with objection detection engine and frontend components.
+- Next: integrate audio streaming and broaden objection rule set.
+

--- a/apps/legal_discovery/interface_flask.py
+++ b/apps/legal_discovery/interface_flask.py
@@ -90,6 +90,7 @@ from coded_tools.legal_discovery.bates_numbering import (
 from .exhibit_routes import exhibits_bp
 from .trial_prep_routes import trial_prep_bp
 from .chain_logger import ChainEventType, log_event
+from .trial_assistant import bp as trial_assistant_bp  # noqa: E402
 from coded_tools.legal_discovery.bates_numbering import (
     BatesNumberingService,
     stamp_pdf,
@@ -141,6 +142,7 @@ db.init_app(app)
 socketio.init_app(app)
 app.register_blueprint(exhibits_bp)
 app.register_blueprint(trial_prep_bp)
+app.register_blueprint(trial_assistant_bp)
 if FEATURE_FLAGS.get("theories"):
     from .theory_routes import theories_bp
 

--- a/apps/legal_discovery/models_trial.py
+++ b/apps/legal_discovery/models_trial.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+from datetime import datetime
+import uuid
+from .database import db
+
+
+def uuid4() -> str:
+    return str(uuid.uuid4())
+
+
+class TrialSession(db.Model):
+    __tablename__ = "trial_sessions"
+    id = db.Column(db.String, primary_key=True, default=uuid4)
+    case_id = db.Column(db.String, index=True, nullable=False)
+    started_at = db.Column(db.DateTime, default=datetime.utcnow)
+    ended_at = db.Column(db.DateTime)
+    mode = db.Column(db.String, default="guidance")
+    local_only = db.Column(db.Boolean, default=True)
+    created_by = db.Column(db.String, index=True)
+
+
+class TranscriptSegment(db.Model):
+    __tablename__ = "transcript_segments"
+    id = db.Column(db.String, primary_key=True, default=uuid4)
+    session_id = db.Column(db.String, db.ForeignKey("trial_sessions.id"), index=True)
+    t0_ms = db.Column(db.Integer)
+    t1_ms = db.Column(db.Integer)
+    speaker = db.Column(db.String)
+    text = db.Column(db.Text)
+    confidence = db.Column(db.Integer)
+    privilege = db.Column(db.Boolean, default=False)
+    meta = db.Column(db.JSON)
+    session = db.relationship("TrialSession", backref="segments")
+
+
+class TrialNote(db.Model):
+    __tablename__ = "trial_notes"
+    id = db.Column(db.String, primary_key=True, default=uuid4)
+    session_id = db.Column(db.String, db.ForeignKey("trial_sessions.id"), index=True)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    author_id = db.Column(db.String, index=True)
+    text = db.Column(db.Text)
+    tags = db.Column(db.JSON)
+    link = db.Column(db.JSON)
+
+
+class PresentationEvent(db.Model):
+    __tablename__ = "presentation_events"
+    id = db.Column(db.String, primary_key=True, default=uuid4)
+    session_id = db.Column(db.String, index=True)
+    ts = db.Column(db.DateTime, default=datetime.utcnow)
+    command = db.Column(db.String)
+    payload = db.Column(db.JSON)
+    issued_by = db.Column(db.String, index=True)
+
+
+class StrategySuggestion(db.Model):
+    __tablename__ = "strategy_suggestions"
+    id = db.Column(db.String, primary_key=True, default=uuid4)
+    session_id = db.Column(db.String, index=True)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    kind = db.Column(db.String)
+    text = db.Column(db.Text)
+    rationale = db.Column(db.Text)
+    refs = db.Column(db.JSON)
+    confidence = db.Column(db.Integer)
+
+
+class ObjectionEvent(db.Model):
+    __tablename__ = "objection_events"
+    id = db.Column(db.String, primary_key=True, default=uuid4)
+    session_id = db.Column(db.String, index=True)
+    segment_id = db.Column(db.String, index=True)
+    ts = db.Column(db.DateTime, default=datetime.utcnow)
+    type = db.Column(db.String)
+    ground = db.Column(db.String)
+    confidence = db.Column(db.Integer)
+    extracted_phrase = db.Column(db.String)
+    suggested_cures = db.Column(db.JSON)
+    action_taken = db.Column(db.String)
+    outcome = db.Column(db.String)

--- a/apps/legal_discovery/rules/objections.yaml
+++ b/apps/legal_discovery/rules/objections.yaml
@@ -1,0 +1,58 @@
+versions: ["FRE-2024", "CA-Evid-2024"]
+objections:
+  hearsay:
+    patterns:
+      transcript_regex:
+        - "\\b(objection)\\b.*\\bhearsay\\b"
+        - "\\bhearsay\\b"
+    cures:
+      - key: exception_present_sense
+        label: "Exception: Present Sense Impression"
+        steps:
+          - "Establish timing: 'You heard this as it happened?'"
+          - "Confirm perception: 'You personally perceived it?'"
+        auto_links:
+          rules: ["FRE 803(1)"]
+      - key: admission_party_opponent
+        label: "Opposing Party Admission"
+        steps:
+          - "Identify speaker as adverse party or agent"
+          - "Establish relationship and scope"
+        auto_links:
+          rules: ["FRE 801(d)(2)"]
+  foundation:
+    patterns:
+      transcript_regex:
+        - "\\b(lack of foundation|no foundation)\\b"
+    cures:
+      - key: lay_witness_foundation
+        label: "Lay Witness Foundation"
+        steps:
+          - "Role and position"
+          - "Opportunity to observe"
+          - "Method of knowledge"
+      - key: authenticate_document
+        label: "Authenticate Document"
+        steps:
+          - "Identify document and custodian"
+          - "Explain creation method"
+        auto_links:
+          rules: ["FRE 901"]
+  relevance:
+    patterns:
+      transcript_regex:
+        - "\\b(objection)\\b.*\\brelevance\\b"
+        - "\\birrelevant\\b"
+    cures:
+      - key: narrow_scope
+        label: "Narrow the Scope"
+        steps:
+          - "Clarify time or subject"
+          - "Connect to material fact"
+      - key: probative_vs_prejudice
+        label: "Explain Probative Value"
+        steps:
+          - "State why evidence matters"
+          - "Address prejudice explicitly"
+        auto_links:
+          rules: ["FRE 403"]

--- a/apps/legal_discovery/src/components/trial/ObjectionBar.tsx
+++ b/apps/legal_discovery/src/components/trial/ObjectionBar.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+
+interface Cure {
+  key: string;
+  label: string;
+  steps?: string[];
+}
+
+export interface ObjectionEventProps {
+  event_id: string;
+  ground: string;
+  confidence: number;
+  suggested_cures: Cure[];
+  onChoose: (eventId: string, cureKey: string) => void;
+}
+
+export default function ObjectionBar({ event_id, ground, confidence, suggested_cures, onChoose }: ObjectionEventProps) {
+  return (
+    <div className="fixed bottom-4 right-4 w-96 rounded-2xl shadow-xl p-4 backdrop-blur bg-white/10 text-white">
+      <div className="flex items-center justify-between">
+        <div className="text-sm uppercase tracking-wide">{ground}</div>
+        <div className="text-xs opacity-70">{confidence}%</div>
+      </div>
+      <div className="mt-2 space-y-2">
+        {suggested_cures.slice(0, 4).map((c) => (
+          <button
+            key={c.key}
+            onClick={() => onChoose(event_id, c.key)}
+            className="w-full text-left rounded-xl px-3 py-2 hover:bg-white/10"
+          >
+            <div className="font-medium">{c.label}</div>
+            {c.steps && c.steps.length > 0 && (
+              <div className="text-xs opacity-80">{c.steps.slice(0, 2).join(" · ")}</div>
+            )}
+          </button>
+        ))}
+      </div>
+      <div className="mt-2 text-[11px] opacity-70">Procedural guidance. Not legal advice.</div>
+    </div>
+  );
+}

--- a/apps/legal_discovery/src/components/trial/TrialConsole.tsx
+++ b/apps/legal_discovery/src/components/trial/TrialConsole.tsx
@@ -1,0 +1,66 @@
+import React, { useEffect, useRef, useState } from "react";
+import { io } from "socket.io-client";
+import ObjectionBar from "./ObjectionBar";
+
+interface Segment {
+  segment_id: string;
+  speaker: string;
+  text: string;
+  t0_ms: number;
+  t1_ms: number;
+}
+
+interface ObjectionEvent {
+  event_id: string;
+  ground: string;
+  confidence: number;
+  suggested_cures: any[];
+}
+
+export default function TrialConsole({ sessionId }: { sessionId: string }) {
+  const sock = useRef<any>(null);
+  const [segments, setSegments] = useState<Segment[]>([]);
+  const [objection, setObjection] = useState<ObjectionEvent | null>(null);
+
+  useEffect(() => {
+    const s = io("/ws/trial", { transports: ["websocket"] });
+    s.emit("join", { session_id: sessionId });
+    s.on("transcript_update", (msg: Segment) => {
+      setSegments((prev) => [...prev, msg]);
+    });
+    s.on("objection_event", (evt: ObjectionEvent) => setObjection(evt));
+    sock.current = s;
+    return () => s.disconnect();
+  }, [sessionId]);
+
+  const chooseCure = (eventId: string, cureKey: string) => {
+    fetch("/api/trial/objection/action", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ event_id: eventId, action: cureKey }),
+    });
+    setObjection(null);
+  };
+
+  return (
+    <div className="relative h-full w-full text-white">
+      <div className="space-y-1 overflow-y-auto pr-2" style={{ maxHeight: "60vh" }}>
+        {segments.map((s) => (
+          <div key={s.segment_id} className="text-sm">
+            <span className="font-semibold mr-2">{s.speaker}:</span>
+            <span>{s.text}</span>
+          </div>
+        ))}
+      </div>
+      {objection && (
+        <ObjectionBar
+          event_id={objection.event_id}
+          ground={objection.ground}
+          confidence={objection.confidence}
+          suggested_cures={objection.suggested_cures}
+          onChoose={chooseCure}
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/legal_discovery/trial_assistant/__init__.py
+++ b/apps/legal_discovery/trial_assistant/__init__.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+from flask import Blueprint, request, jsonify
+from flask_socketio import emit, join_room
+from ..extensions import socketio
+from ..database import db
+from ..models_trial import TranscriptSegment, ObjectionEvent
+from .services.objection_engine import engine
+
+bp = Blueprint("trial_assistant", __name__, url_prefix="/api/trial")
+
+
+@bp.post("/objection/action")
+def objection_action():
+    payload = request.json or {}
+    evt_id = payload.get("event_id")
+    action = payload.get("action")
+    if not evt_id:
+        return jsonify({"error": "event_id required"}), 400
+    evt = db.session.get(ObjectionEvent, evt_id)
+    if evt:
+        evt.action_taken = action
+        db.session.commit()
+    return jsonify({"ok": True})
+
+
+@socketio.on("join", namespace="/ws/trial")
+def join(data):
+    sess = data.get("session_id")
+    if sess:
+        join_room(sess)
+
+
+@socketio.on("segment", namespace="/ws/trial")
+def handle_segment(data):
+    session_id = data.get("session_id")
+    text = data.get("text", "")
+    seg = TranscriptSegment(session_id=session_id, text=text, t0_ms=data.get("t0_ms"), t1_ms=data.get("t1_ms"), speaker=data.get("speaker"), confidence=data.get("confidence"))
+    db.session.add(seg)
+    db.session.commit()
+    events = engine.analyze_segment(session_id, seg)
+    for e in events:
+        emit("objection_event", {
+            "event_id": e.id,
+            "ground": e.ground,
+            "confidence": e.confidence,
+            "suggested_cures": e.suggested_cures,
+        }, room=session_id)

--- a/apps/legal_discovery/trial_assistant/services/__init__.py
+++ b/apps/legal_discovery/trial_assistant/services/__init__.py
@@ -1,0 +1,3 @@
+from .objection_engine import engine, ObjectionEngine
+
+__all__ = ["engine", "ObjectionEngine"]

--- a/apps/legal_discovery/trial_assistant/services/objection_engine.py
+++ b/apps/legal_discovery/trial_assistant/services/objection_engine.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+import re
+import yaml
+from typing import List
+from ...models_trial import ObjectionEvent, TranscriptSegment
+from ...database import db
+
+
+class ObjectionEngine:
+    def __init__(self, rules_path: str = "apps/legal_discovery/rules/objections.yaml"):
+        with open(rules_path, "r", encoding="utf-8") as f:
+            self.rules = yaml.safe_load(f)
+        self.compiled = []
+        for name, spec in self.rules.get("objections", {}).items():
+            patterns = [re.compile(r, re.I) for r in spec.get("patterns", {}).get("transcript_regex", [])]
+            cures = spec.get("cures", [])
+            self.compiled.append((name, patterns, cures))
+
+    def analyze_segment(self, session_id: str, seg: TranscriptSegment) -> List[ObjectionEvent]:
+        text = seg.text or ""
+        found: List[ObjectionEvent] = []
+        for ground, patterns, cures in self.compiled:
+            if any(p.search(text) for p in patterns):
+                evt = ObjectionEvent(
+                    session_id=session_id,
+                    segment_id=seg.id,
+                    type="incoming" if "objection" in text.lower() else "risk",
+                    ground=ground,
+                    confidence=85,
+                    extracted_phrase=text[:160],
+                    suggested_cures=cures,
+                )
+                db.session.add(evt)
+                found.append(evt)
+        if found:
+            db.session.commit()
+        return found
+
+
+def create_engine() -> ObjectionEngine:
+    return ObjectionEngine()
+
+
+engine = create_engine()


### PR DESCRIPTION
## Summary
- Add YAML registry for common objections with example cures
- Introduce trial models and real-time objection engine emitting cure suggestions
- Expose trial assistant Socket.IO namespace and React components to surface objections in the UI

## Testing
- `pytest` (fails: Interrupted: 23 errors during collection)

------
https://chatgpt.com/codex/tasks/task_e_6896f86c992083338a06eed75a707b75