### PR TITLE
fix: ensure document ingestion runs in app context

### DIFF
--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -775,3 +775,7 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 - Added unit test for counter objection detection.
 - Next: refine recognition accuracy and extend rule coverage.
 
+## Update 2025-08-10T16:00Z
+- Wrapped `ingest_document` in Flask app context so background ingestion can access the database safely.
+- Next: monitor vector DB persistence and ensure batch uploads commit without warnings.
+


### PR DESCRIPTION
## Summary
- wrap background `ingest_document` work in Flask `app.app_context` to avoid context errors when uploading files
- log progress update in Legal Discovery AGENTS notes

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask_sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68973d19774083338cacf08f403e0b33