### PR TITLE
Fix document ingestion race

### DIFF
--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -784,3 +784,9 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 - Next: verify Chroma service accepts persistence calls without warnings.
 
 
+## Update 2025-08-11T19:04Z
+- Commit document records and metadata before starting background ingestion to ensure worker sessions can load them.
+- Added safety check when a document lookup fails during ingestion.
+- Next: monitor upload batches for timeouts and optimise memory usage.
+
+


### PR DESCRIPTION
## Summary
- commit document metadata before launching background ingestion so worker sessions can find the record
- guard against missing documents in ingestion

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask_sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68990633ca008333881bdae6f8b63fe3