### PR TITLE
Fix document ingestion race

### DIFF
--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -784,3 +784,13 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 - Next: verify Chroma service accepts persistence calls without warnings.
 
 
+## Update 2025-08-11T19:04Z
+- Commit document records and metadata before starting background ingestion to ensure worker sessions can load them.
+- Added safety check when a document lookup fails during ingestion.
+- Next: monitor upload batches for timeouts and optimise memory usage.
+
+## Update 2025-08-12T00:00Z
+- Raise lookup errors when document records are missing during ingestion so callers clean up skipped files.
+- Next: run tests after installing missing dependencies.
+
+

--- a/apps/legal_discovery/interface_flask.py
+++ b/apps/legal_discovery/interface_flask.py
@@ -703,6 +703,9 @@ def ingest_document(
             extra={"doc_id": doc_id, "privileged": privileged, "spans": [(s.start, s.end) for s in spans]},
         )
         doc = Document.query.get(doc_id)
+        if doc is None:
+            app.logger.error("Document %s not found during ingestion", doc_id)
+            raise LookupError(f"Document {doc_id} not found")
         if privileged:
             keywords = [text[s.start : s.end] for s in spans]
             if original_path.lower().endswith(".pdf"):
@@ -905,6 +908,9 @@ def upload_files():
             raw_meta = DocumentMetadata(document_id=doc.id, schema="raw", data=full_metadata)
             chroma_meta = DocumentMetadata(document_id=doc.id, schema="chroma", data=chroma_metadata)
             db.session.add_all([raw_meta, chroma_meta])
+            # Ensure the document and metadata are committed so the background
+            # ingestion thread can retrieve them using a separate session.
+            db.session.commit()
             future = executor.submit(
                 ingest_document,
                 original_path,


### PR DESCRIPTION
## Summary
- commit document metadata before launching background ingestion so worker sessions can find the record
- guard against missing documents during ingestion
- raise lookup errors when ingestion can't find document records

## Testing
- `pytest` *(fails: Failed to connect to Neo4j at bolt://neo4j:7687. Is the server running?)*

------
https://chatgpt.com/codex/tasks/task_e_68990633ca008333881bdae6f8b63fe3