### PR TITLE
Allow passwordless Neo4j connections

### DIFF
--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -804,3 +804,8 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 - Switched to google-genai and dropped pygraphviz from build.
 - Cleaned Dockerfile and requirements to avoid Graphviz dependency.
 - Next: mock Neo4j for offline tests.
+
+## Update 2025-08-13T00:00Z
+- Allowed passwordless Neo4j connections and suppressed errors when the graph service is offline.
+- Confirmed chat agent unit tests run without requiring a Neo4j instance.
+- Next: exercise graph features against a live database.

--- a/apps/legal_discovery/README.md
+++ b/apps/legal_discovery/README.md
@@ -17,11 +17,12 @@ particular set a password for Neo4j:
 
 ```bash
 cp .env.example .env  # if you haven't created one
-# then edit .env and set NEO4J_PASSWORD=your_password
+# then edit .env and set NEO4J_PASSWORD=your_password (leave blank to disable auth)
 ```
 
 Docker Compose reads `NEO4J_PASSWORD` for both the app and database services so
-they always share the same credentials.
+they always share the same credentials. If the variable is empty, the database
+starts without authentication which is convenient for local testing.
 
 ## Running with Docker Compose
 

--- a/apps/legal_discovery/trial_prep.py
+++ b/apps/legal_discovery/trial_prep.py
@@ -162,9 +162,10 @@ class GraphManager:
     def __init__(self, uri: str | None = None, user: str | None = None, password: str | None = None) -> None:
         uri = uri or os.environ.get("NEO4J_URI", "bolt://localhost:7687")
         user = user or os.environ.get("NEO4J_USER", "neo4j")
-        password = password or os.environ.get("NEO4J_PASSWORD", "neo4jPass123")
+        password = password or os.environ.get("NEO4J_PASSWORD")
         try:
-            self.driver = GraphDatabase.driver(uri, auth=(user, password))
+            auth = (user, password) if password else None
+            self.driver = GraphDatabase.driver(uri, auth=auth)
             self.session = self.driver.session()
         except Exception:  # pragma: no cover - external service
             self.driver = None

--- a/condensed AGENTS.md
+++ b/condensed AGENTS.md
@@ -158,3 +158,8 @@ we are now working on implementing a major feature, so stand by, this is  A GDDM
 - Replaced google-generativeai with google-genai and removed conflicting packages.
 - Dropped pygraphviz to avoid build-time failures.
 - Next: stub external services so tests run without Neo4j.
+
+## Update 2025-08-13T00:00Z
+- Made Neo4j authentication optional and handled unreachable graph instances gracefully.
+- Verified chat agent tests pass without a running Neo4j service.
+- Next: run full application suite once Neo4j and related services are available.


### PR DESCRIPTION
## Summary
- Allow KnowledgeGraphManager and GraphManager to run without a Neo4j password and skip connection when the graph is offline
- Document how to run Neo4j without authentication for local testing

## Testing
- `pytest tests/coded_tools/legal_discovery/test_chat_agent.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689ff2022bec8333935a4226c44da5c9