### PR TITLE
Add voice command registry and logging

### DIFF
--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -828,3 +828,7 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 ## Update 2025-08-16T18:00Z
 - Introduced Whisper-based streaming STT with WebSocket voice query and offline fallback.
 - Next: tune interim transcription latency and expand client integration.
+
+## Update 2025-08-16T19:00Z
+- Added voice command registry with logging in voice queries.
+- Next: expand command coverage and refine confirmation responses.

--- a/apps/legal_discovery/voice_commands.py
+++ b/apps/legal_discovery/voice_commands.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+"""Keyword-driven registry for voice commands."""
+
+from typing import Callable, Dict, Optional, Tuple
+
+from coded_tools.legal_discovery.timeline_manager import TimelineManager
+
+
+CommandResult = Tuple[str, str]
+CommandHandler = Callable[[dict], str]
+
+
+def _timeline_summary(data: dict) -> str:
+    """Return a simple timeline summary for the provided case."""
+    case_id = data.get("case_id", 1)
+    tm = TimelineManager()
+    return tm.summarize(case_id)
+
+
+COMMAND_REGISTRY: Dict[str, CommandHandler] = {
+    "timeline summary": _timeline_summary,
+}
+
+
+def match_command(transcript: str) -> Optional[CommandHandler]:
+    """Return a handler if the transcript matches a registered command."""
+    lower = transcript.lower()
+    for keyword, handler in COMMAND_REGISTRY.items():
+        if keyword in lower:
+            return handler
+    return None
+
+
+def execute_command(transcript: str, data: dict) -> Optional[CommandResult]:
+    """Execute the command if found and return its keyword and result."""
+    handler = match_command(transcript)
+    if not handler:
+        return None
+    keyword = next(k for k, v in COMMAND_REGISTRY.items() if v is handler)
+    result = handler(data)
+    return keyword, result
+
+
+__all__ = ["COMMAND_REGISTRY", "execute_command"]

--- a/tests/apps/test_chat_audit.py
+++ b/tests/apps/test_chat_audit.py
@@ -37,3 +37,24 @@ def test_voice_query_logs_message(client, monkeypatch):
         log = MessageAuditLog.query.filter_by(transcript="hi").first()
         assert log is not None
         assert log.voice_model == "en-US"
+
+
+def test_voice_command_executes_and_logs(client, monkeypatch):
+    monkeypatch.setattr("apps.legal_discovery.voice.synthesize_voice", lambda text, model: "")
+    monkeypatch.setattr("coded_tools.legal_discovery.chat_agent.RetrievalChatAgent.query", lambda self, question, sender_id=0, conversation_id=None: {"message_id": "1", "facts": []})
+    called = {}
+    from apps.legal_discovery import voice_commands
+    def dummy(data):
+        called["hit"] = True
+        return "done"
+    monkeypatch.setattr(voice_commands, "COMMAND_REGISTRY", {"dummy": dummy})
+    resp = client.post("/api/chat/voice", json={"transcript": "dummy action", "voice_model": "en-US"})
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["command"] == "dummy"
+    assert data["result"] == "done"
+    assert called.get("hit")
+    with app.app_context():
+        log = MessageAuditLog.query.filter_by(sender="command").first()
+        assert log is not None
+        assert log.transcript == "dummy"


### PR DESCRIPTION
## Summary
- Map keywords to command handlers in a new voice command registry
- Invoke registry from `voice_query` and log executed commands
- Cover voice command flow with audit log test

## Testing
- `python3 -m pytest -q` *(fails: No module named 'flask_sqlalchemy', 'schedule', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a1792446b08333876dd413a0daa1c3