### PR TITLE
feat: add conversation-aware voice chat

### DIFF
--- a/agents--features and memory/condensed_agents.md
+++ b/agents--features and memory/condensed_agents.md
@@ -283,3 +283,9 @@ WE STARTED ON #3, INSTEAD OF #1. DEAL WITH IT, FINISH IMPLEMENTING #3, AND THEN 
 - Unified Neo4j credentials across Docker Compose and switched host paths to cross-platform relative volumes.
 - Removed deprecated version header and aligned healthcheck with container password.
 - Next: verify fresh stack start on Windows and document volume setup.
+
+## Update 2025-08-16T14:30Z
+- Enabled conversation-aware chat by passing `conversation_id` through voice and text routes.
+- Retrieval agent now injects prior conversation snippets into LLM prompts.
+- React chat panel tracks conversation IDs and sports a bordered dark chat box.
+- Next: persist conversation history across sessions and refine prompt weighting.

--- a/apps/legal_discovery/src/components/ChatSection.jsx
+++ b/apps/legal_discovery/src/components/ChatSection.jsx
@@ -6,6 +6,7 @@ function ChatSection() {
   const [input, setInput] = useState("");
   const [recording, setRecording] = useState(false);
   const [voiceModel, setVoiceModel] = useState("en-US");
+  const [conversationId, setConversationId] = useState(null);
   const boxRef = useRef(null);
   const mediaRecorderRef = useRef(null);
   const audioChunksRef = useRef([]);
@@ -38,8 +39,17 @@ function ChatSection() {
     fetch("/api/chat/query", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ text: input, voice_model: voiceModel }),
-    }).then(() => setInput(""));
+      body: JSON.stringify({
+        text: input,
+        voice_model: voiceModel,
+        conversation_id: conversationId,
+      }),
+    })
+      .then((r) => r.json())
+      .then((d) => {
+        if (d.conversation_id) setConversationId(d.conversation_id);
+      })
+      .finally(() => setInput(""));
   };
 
   const startRecording = async () => {
@@ -88,8 +98,17 @@ function ChatSection() {
     fetch("/api/chat/voice", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ audio, transcript, voice_model: voiceModel }),
-    });
+      body: JSON.stringify({
+        audio,
+        transcript,
+        voice_model: voiceModel,
+        conversation_id: conversationId,
+      }),
+    })
+      .then((r) => r.json())
+      .then((d) => {
+        if (d.conversation_id) setConversationId(d.conversation_id);
+      });
     if (transcript) {
       setMessages((m) => [...m, { type: "user", text: transcript }]);
     }
@@ -119,7 +138,7 @@ function ChatSection() {
       </div>
       <div
         ref={boxRef}
-        className="chat-box overflow-y-auto"
+        className="chat-box overflow-y-auto p-2 bg-gray-900 rounded border border-gray-700 shadow-inner"
         style={{ maxHeight: "200px" }}
       >
         {messages.map((m, i) => (

--- a/tests/apps/test_chat_audit.py
+++ b/tests/apps/test_chat_audit.py
@@ -33,6 +33,7 @@ def test_voice_query_logs_message(client, monkeypatch):
         json={"audio": audio, "transcript": "hi", "voice_model": "en-US"},
     )
     assert resp.status_code == 200
+    data = resp.get_json()
     with app.app_context():
         log = MessageAuditLog.query.filter_by(transcript="hi").first()
         assert log is not None
@@ -41,14 +42,24 @@ def test_voice_query_logs_message(client, monkeypatch):
 
 def test_voice_command_executes_and_logs(client, monkeypatch):
     monkeypatch.setattr("apps.legal_discovery.voice.synthesize_voice", lambda text, model: "")
-    monkeypatch.setattr("coded_tools.legal_discovery.chat_agent.RetrievalChatAgent.query", lambda self, question, sender_id=0, conversation_id=None: {"message_id": "1", "facts": []})
+    monkeypatch.setattr(
+        "coded_tools.legal_discovery.chat_agent.RetrievalChatAgent.query",
+        lambda self, question, sender_id=0, conversation_id=None: {
+            "message_id": "1",
+            "facts": [],
+            "conversation_id": "abc",
+        },
+    )
     called = {}
     from apps.legal_discovery import voice_commands
     def dummy(data):
         called["hit"] = True
         return "done"
     monkeypatch.setattr(voice_commands, "COMMAND_REGISTRY", {"dummy": dummy})
-    resp = client.post("/api/chat/voice", json={"transcript": "dummy action", "voice_model": "en-US"})
+    resp = client.post(
+        "/api/chat/voice",
+        json={"transcript": "dummy action", "voice_model": "en-US"},
+    )
     assert resp.status_code == 200
     data = resp.get_json()
     assert data["command"] == "dummy"


### PR DESCRIPTION
## Summary
- propagate conversation_id through chat routes so sessions persist
- surface prior conversation snippets in RetrievalChatAgent prompts
- track conversation_id on the React chat panel and polish chat box styling

## Testing
- `npm test` *(fails: Missing script "test")*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a18d41cf24833393b209ef78ea42bd