### PR TITLE
feat: emit cross-team voice alerts

### DIFF
--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -832,3 +832,7 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 ## Update 2025-08-16T19:00Z
 - Added voice command registry with logging in voice queries.
 - Next: expand command coverage and refine confirmation responses.
+
+## Update 2025-08-30T00:00Z
+- Emitted TeamMessage alerts for timeline and document actions triggered by voice queries and started cross-team listeners.
+- Next: broaden document workflows and bus topics for additional commands.

--- a/tests/apps/test_chat_audit.py
+++ b/tests/apps/test_chat_audit.py
@@ -4,7 +4,8 @@ import pytest
 
 os.environ["DATABASE_URL"] = "sqlite://"
 
-from apps.legal_discovery.interface_flask import app, db, MessageAuditLog
+from apps.message_bus import AUTO_DRAFTER_ALERT_TOPIC, TIMELINE_ALERT_TOPIC
+from apps.legal_discovery.interface_flask import app, db, MessageAuditLog, Case
 
 
 @pytest.fixture
@@ -69,3 +70,67 @@ def test_voice_command_executes_and_logs(client, monkeypatch):
         log = MessageAuditLog.query.filter_by(sender="command").first()
         assert log is not None
         assert log.transcript == "dummy"
+
+
+def test_voice_query_emits_timeline_message(client, monkeypatch):
+    monkeypatch.setattr(
+        "apps.legal_discovery.voice.synthesize_voice", lambda text, model: ""
+    )
+    monkeypatch.setattr(
+        "apps.legal_discovery.chat_routes._ensure_listeners_started", lambda: None
+    )
+    monkeypatch.setattr(
+        "coded_tools.legal_discovery.chat_agent.RetrievalChatAgent.query",
+        lambda self, question, sender_id=0, conversation_id=None: {
+            "message_id": "1",
+            "facts": [],
+            "conversation_id": "abc",
+        },
+    )
+    published = []
+
+    def fake_publish(topic, message):
+        published.append((topic, message))
+
+    monkeypatch.setattr(
+        "apps.legal_discovery.chat_routes.bus.publish", fake_publish
+    )
+    with app.app_context():
+        db.session.add(Case(name="Test"))
+        db.session.commit()
+    resp = client.post(
+        "/api/chat/voice",
+        json={"transcript": "case:1 2024-01-01 Filing made", "voice_model": "en-US"},
+    )
+    assert resp.status_code == 200
+    assert any(t == TIMELINE_ALERT_TOPIC for t, _ in published)
+
+
+def test_voice_query_emits_document_message(client, monkeypatch):
+    monkeypatch.setattr(
+        "apps.legal_discovery.voice.synthesize_voice", lambda text, model: ""
+    )
+    monkeypatch.setattr(
+        "apps.legal_discovery.chat_routes._ensure_listeners_started", lambda: None
+    )
+    monkeypatch.setattr(
+        "coded_tools.legal_discovery.chat_agent.RetrievalChatAgent.query",
+        lambda self, question, sender_id=0, conversation_id=None: {
+            "message_id": "1",
+            "facts": [],
+            "conversation_id": "abc",
+        },
+    )
+    published = []
+
+    def fake_publish(topic, message):
+        published.append((topic, message))
+
+    monkeypatch.setattr(
+        "apps.legal_discovery.chat_routes.bus.publish", fake_publish
+    )
+    resp = client.post(
+        "/api/chat/voice", json={"transcript": "review document 42"}
+    )
+    assert resp.status_code == 200
+    assert any(t == AUTO_DRAFTER_ALERT_TOPIC for t, _ in published)


### PR DESCRIPTION
## Summary
- publish `TeamMessage` alerts from voice queries on timeline or document actions
- start cross-team listeners for voice events and log alerts
- test voice query bus emissions

## Testing
- `pytest tests/apps/test_chat_audit.py -q`
- `pytest tests/apps/test_timeline_chat.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a197cd1e48833382bf152d7dc0b0de