### PR TITLE
feat: broadcast objection events with segment highlights

### DIFF
--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -836,3 +836,8 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 ## Update 2025-08-30T00:00Z
 - Emitted TeamMessage alerts for timeline and document actions triggered by voice queries and started cross-team listeners.
 - Next: broaden document workflows and bus topics for additional commands.
+
+## Update 2025-08-30T12:00Z
+- Highlighted transcript segments when objection events are detected and broadcast over Socket.IO.
+- Added WebSocket test ensuring objection events persist to the database with segment references.
+- Next: expand visual cues for multiple simultaneous objections and refine client-side dismissal flows.

--- a/apps/legal_discovery/src/components/trial/TrialConsole.tsx
+++ b/apps/legal_discovery/src/components/trial/TrialConsole.tsx
@@ -12,6 +12,7 @@ interface Segment {
 
 interface ObjectionEvent {
   event_id: string;
+  segment_id: string;
   ground: string;
   confidence: number;
   suggested_cures: any[];
@@ -21,6 +22,7 @@ export default function TrialConsole({ sessionId }: { sessionId: string }) {
   const sock = useRef<any>(null);
   const [segments, setSegments] = useState<Segment[]>([]);
   const [objection, setObjection] = useState<ObjectionEvent | null>(null);
+  const [highlightId, setHighlightId] = useState<string | null>(null);
   const [listening, setListening] = useState(false);
 
   // Voice recognition powered by the Web Speech API. Use the wake phrase
@@ -77,7 +79,10 @@ export default function TrialConsole({ sessionId }: { sessionId: string }) {
     s.on("transcript_update", (msg: Segment) => {
       setSegments((prev) => [...prev, msg]);
     });
-    s.on("objection_event", (evt: ObjectionEvent) => setObjection(evt));
+    s.on("objection_event", (evt: ObjectionEvent) => {
+      setObjection(evt);
+      setHighlightId(evt.segment_id);
+    });
     sock.current = s;
     return () => s.disconnect();
   }, [sessionId]);
@@ -89,6 +94,7 @@ export default function TrialConsole({ sessionId }: { sessionId: string }) {
       body: JSON.stringify({ event_id: eventId, action: cureKey }),
     });
     setObjection(null);
+    setHighlightId(null);
   };
 
   return (
@@ -101,7 +107,12 @@ export default function TrialConsole({ sessionId }: { sessionId: string }) {
       </div>
       <div className="space-y-1 overflow-y-auto pr-2" style={{ maxHeight: "60vh" }}>
         {segments.map((s) => (
-          <div key={s.segment_id} className="text-sm">
+          <div
+            key={s.segment_id}
+            className={`text-sm ${
+              s.segment_id === highlightId ? "bg-yellow-500/20" : ""
+            }`}
+          >
             <span className="font-semibold mr-2">{s.speaker}:</span>
             <span>{s.text}</span>
           </div>

--- a/tests/apps/test_trial_objection_ws.py
+++ b/tests/apps/test_trial_objection_ws.py
@@ -1,0 +1,44 @@
+from flask import Flask
+
+from apps.legal_discovery.extensions import socketio
+from apps.legal_discovery.database import db
+from apps.legal_discovery.trial_assistant import bp
+from apps.legal_discovery.models_trial import ObjectionEvent
+
+
+def _create_app():
+    app = Flask(__name__)
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite://"
+    app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
+    db.init_app(app)
+    socketio.init_app(app, logger=False, engineio_logger=False)
+    app.register_blueprint(bp)
+    with app.app_context():
+        db.create_all()
+    return app
+
+
+def test_objection_event_emitted_and_persisted():
+    app = _create_app()
+    client = socketio.test_client(app, namespace="/ws/trial")
+    client.emit("join", {"session_id": "s"}, namespace="/ws/trial")
+    client.emit(
+        "segment",
+        {
+            "session_id": "s",
+            "text": "that's hearsay",
+            "t0_ms": 0,
+            "t1_ms": 1,
+            "speaker": "witness",
+            "confidence": 100,
+        },
+        namespace="/ws/trial",
+    )
+    received = client.get_received("/ws/trial")
+    assert any(
+        r["name"] == "objection_event" and "segment_id" in r["args"][0]
+        for r in received
+    )
+    with app.app_context():
+        assert ObjectionEvent.query.count() == 1
+


### PR DESCRIPTION
## Summary
- emit transcript updates and objection events with segment references over the trial Socket.IO channel
- highlight offending transcript segments in the trial console UI
- add regression test to ensure objection events persist and broadcast

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1a77371e88333b0db9a770cb6c4a8