### PR TITLE
feat: add configurable tts with voice caching

### DIFF
--- a/agents--features and memory/condensed_agents.md
+++ b/agents--features and memory/condensed_agents.md
@@ -289,3 +289,8 @@ WE STARTED ON #3, INSTEAD OF #1. DEAL WITH IT, FINISH IMPLEMENTING #3, AND THEN 
 - Retrieval agent now injects prior conversation snippets into LLM prompts.
 - React chat panel tracks conversation IDs and sports a bordered dark chat box.
 - Next: persist conversation history across sessions and refine prompt weighting.
+
+## Update 2025-08-31T00:00Z
+- Added configurable voice synthesis pipeline with Redis/DB caching.
+- React chat now lists available voices from backend.
+- Next: allow users to switch engines in the settings panel.

--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -841,3 +841,8 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 - Highlighted transcript segments when objection events are detected and broadcast over Socket.IO.
 - Added WebSocket test ensuring objection events persist to the database with segment references.
 - Next: expand visual cues for multiple simultaneous objections and refine client-side dismissal flows.
+
+## Update 2025-08-31T00:00Z
+- Abstracted text-to-speech to support gTTS, Coqui-TTS or system engines with Redis/DB caching.
+- Added `/api/chat/voices` endpoint and React selector for available voices.
+- Next: surface engine choice in settings and broaden voice options.

--- a/apps/legal_discovery/chat_routes.py
+++ b/apps/legal_discovery/chat_routes.py
@@ -7,7 +7,7 @@ from .database import db
 from .models import MessageAuditLog
 from .extensions import socketio
 from .chat_state import user_input_queue
-from .voice import synthesize_voice
+from .voice import synthesize_voice, get_available_voices
 from .stt import stream_transcribe
 from .voice_commands import execute_command
 
@@ -205,6 +205,11 @@ def voice_query():
 
     result = _handle_transcript(transcript, data)
     return jsonify(result)
+
+
+@chat_bp.get("/voices")
+def list_voices():
+    return jsonify({"voices": get_available_voices()})
 
 
 @socketio.on("voice_query", namespace="/chat")

--- a/apps/legal_discovery/interface_flask.py
+++ b/apps/legal_discovery/interface_flask.py
@@ -75,6 +75,7 @@ from apps.legal_discovery.models import (
     MessageAuditLog,
     NarrativeDiscrepancy,
     DocumentVersion,
+    VoiceCache,
 )
 from coded_tools.legal_discovery.deposition_prep import DepositionPrep
 from coded_tools.legal_discovery.legal_crawler import LegalCrawler

--- a/apps/legal_discovery/migrations/011_add_voice_cache.py
+++ b/apps/legal_discovery/migrations/011_add_voice_cache.py
@@ -1,0 +1,25 @@
+"""Add voice cache table"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "011_add_voice_cache"
+down_revision = ("010_add_timeline_links", "010_add_document_scores")
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    op.create_table(
+        "voice_cache",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("text", sa.Text(), nullable=False),
+        sa.Column("model", sa.String(length=100), nullable=False),
+        sa.Column("audio", sa.Text(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now()),
+        sa.UniqueConstraint("text", "model", name="uix_voice_cache_text_model"),
+    )
+
+
+def downgrade():
+    op.drop_table("voice_cache")
+

--- a/apps/legal_discovery/models.py
+++ b/apps/legal_discovery/models.py
@@ -84,6 +84,18 @@ class MessageAuditLog(db.Model):
     message = db.relationship("Message", backref=db.backref("audit_logs", lazy=True))
 
 
+class VoiceCache(db.Model):
+    """Cached audio snippets keyed by text and model."""
+
+    id = db.Column(db.Integer, primary_key=True)
+    text = db.Column(db.Text, nullable=False)
+    model = db.Column(db.String(100), nullable=False)
+    audio = db.Column(db.Text, nullable=False)
+    created_at = db.Column(db.DateTime, server_default=db.func.now())
+
+    __table_args__ = (db.UniqueConstraint("text", "model", name="uix_voice_cache_text_model"),)
+
+
 class DocumentSource(enum.Enum):
     """Origin of an uploaded document."""
 

--- a/apps/legal_discovery/requirements.txt
+++ b/apps/legal_discovery/requirements.txt
@@ -27,6 +27,9 @@ spacy
 weasyprint
 reportlab
 gTTS
+TTS
+pyttsx3
+redis
 
 en-core-web-sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.7.1/en_core_web_sm-3.7.1-py3-none-any.whl
 

--- a/apps/legal_discovery/src/components/ChatSection.jsx
+++ b/apps/legal_discovery/src/components/ChatSection.jsx
@@ -5,7 +5,8 @@ function ChatSection() {
   const [messages, setMessages] = useState([]);
   const [input, setInput] = useState("");
   const [recording, setRecording] = useState(false);
-  const [voiceModel, setVoiceModel] = useState("en-US");
+  const [voiceModel, setVoiceModel] = useState("");
+  const [voices, setVoices] = useState([]);
   const [conversationId, setConversationId] = useState(null);
   const boxRef = useRef(null);
   const mediaRecorderRef = useRef(null);
@@ -26,6 +27,15 @@ function ChatSection() {
       }
     });
     return () => socket.disconnect();
+  }, []);
+
+  useEffect(() => {
+    fetch("/api/chat/voices")
+      .then((r) => r.json())
+      .then((d) => {
+        setVoices(d.voices || []);
+        if (d.voices && d.voices.length) setVoiceModel(d.voices[0].id);
+      });
   }, []);
 
   useEffect(() => {
@@ -123,8 +133,11 @@ function ChatSection() {
           onChange={(e) => setVoiceModel(e.target.value)}
           className="mr-2 bg-gray-800 text-gray-100 p-1 rounded"
         >
-          <option value="en-US">English US</option>
-          <option value="en-GB">English UK</option>
+          {voices.map((v) => (
+            <option key={v.id} value={v.id}>
+              {v.name}
+            </option>
+          ))}
         </select>
         {recording ? (
           <button className="button-secondary" onClick={stopRecording}>

--- a/apps/legal_discovery/voice.py
+++ b/apps/legal_discovery/voice.py
@@ -1,18 +1,131 @@
+"""Text to speech utilities with caching support."""
+
 import base64
+import os
 from io import BytesIO
+from typing import List, Dict
+
+from .database import db
+from .models import VoiceCache
+
+try:  # pragma: no cover - optional
+    import redis
+except Exception:  # pragma: no cover - allow missing dependency
+    redis = None
+
+_redis_client = None
+if redis is not None:
+    url = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+    try:  # pragma: no cover - best effort connection
+        _redis_client = redis.Redis.from_url(url)
+    except Exception:
+        _redis_client = None
+
+
+def _cache_get(key: str, text: str, model: str) -> str:
+    if _redis_client:
+        val = _redis_client.get(key)
+        if isinstance(val, bytes):
+            return val.decode("utf-8")
+    record = VoiceCache.query.filter_by(text=text, model=model).first()
+    return record.audio if record else ""
+
+
+def _cache_set(key: str, audio: str, text: str, model: str) -> None:
+    if _redis_client:
+        _redis_client.set(key, audio)
+    db.session.add(VoiceCache(text=text, model=model, audio=audio))
+    db.session.commit()
+
+
+def _synthesize_gtts(text: str, model: str) -> str:
+    from gtts import gTTS  # pragma: no cover - network dependent
+
+    audio_io = BytesIO()
+    gTTS(text=text, lang=model).write_to_fp(audio_io)
+    audio_io.seek(0)
+    return base64.b64encode(audio_io.read()).decode("utf-8")
+
+
+def _synthesize_coqui(text: str, model: str) -> str:
+    from TTS.api import TTS  # pragma: no cover - heavy dependency
+    import soundfile as sf  # pragma: no cover
+
+    tts = TTS(model)
+    wav = tts.tts(text)
+    buf = BytesIO()
+    sf.write(buf, wav, samplerate=tts.synthesizer.output_sample_rate, format="WAV")
+    buf.seek(0)
+    return base64.b64encode(buf.read()).decode("utf-8")
+
+
+def _synthesize_system(text: str, model: str) -> str:
+    import pyttsx3  # pragma: no cover - optional
+    import tempfile
+
+    engine = pyttsx3.init()
+    engine.setProperty("voice", model)
+    with tempfile.NamedTemporaryFile(suffix=".mp3", delete=False) as tmp:
+        engine.save_to_file(text, tmp.name)
+        engine.runAndWait()
+        tmp.seek(0)
+        data = tmp.read()
+    os.unlink(tmp.name)
+    return base64.b64encode(data).decode("utf-8")
+
+
+_ENGINE_MAP = {
+    "gtts": _synthesize_gtts,
+    "coqui": _synthesize_coqui,
+    "system": _synthesize_system,
+}
 
 
 def synthesize_voice(text: str, model: str) -> str:
-    """Generate base64-encoded audio from text using gTTS."""
-    try:  # pragma: no cover - best effort
-        from gtts import gTTS
+    """Generate base64-encoded audio, cached by text and model."""
+    key = f"{model}:{text}"
+    cached = _cache_get(key, text, model)
+    if cached:
+        return cached
 
-        audio_io = BytesIO()
-        gTTS(text=text, lang=model).write_to_fp(audio_io)
-        audio_io.seek(0)
-        return base64.b64encode(audio_io.read()).decode("utf-8")
+    engine = os.getenv("VOICE_ENGINE", "gtts").lower()
+    synth = _ENGINE_MAP.get(engine, _synthesize_gtts)
+    try:
+        audio = synth(text, model)
     except Exception:  # pragma: no cover
-        return ""
+        audio = ""
+    if audio:
+        _cache_set(key, audio, text, model)
+    return audio
 
 
-__all__ = ["synthesize_voice"]
+def get_available_voices() -> List[Dict[str, str]]:
+    """Return list of available voices for the configured engine."""
+    engine = os.getenv("VOICE_ENGINE", "gtts").lower()
+    if engine == "system":
+        try:  # pragma: no cover - optional
+            import pyttsx3
+
+            eng = pyttsx3.init()
+            return [{"id": v.id, "name": v.name} for v in eng.getProperty("voices")]
+        except Exception:
+            return []
+    if engine == "coqui":
+        try:  # pragma: no cover - optional
+            from TTS.utils.manage import ModelManager
+
+            manager = ModelManager()
+            models = manager.list_models()
+            return [{"id": m, "name": m} for m in models]
+        except Exception:
+            return []
+    try:
+        from gtts.lang import tts_langs
+
+        langs = tts_langs()
+        return [{"id": code, "name": name} for code, name in langs.items()]
+    except Exception:  # pragma: no cover
+        return []
+
+
+__all__ = ["synthesize_voice", "get_available_voices"]

--- a/tests/apps/test_chat_audit.py
+++ b/tests/apps/test_chat_audit.py
@@ -134,3 +134,13 @@ def test_voice_query_emits_document_message(client, monkeypatch):
     )
     assert resp.status_code == 200
     assert any(t == AUTO_DRAFTER_ALERT_TOPIC for t, _ in published)
+
+
+def test_list_voices(client, monkeypatch):
+    monkeypatch.setattr(
+        "apps.legal_discovery.chat_routes.get_available_voices", lambda: [{"id": "v1", "name": "Voice"}]
+    )
+    resp = client.get("/api/chat/voices")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["voices"][0]["id"] == "v1"


### PR DESCRIPTION
## Summary
- add VoiceCache model and migration with Redis-backed synthesis cache
- support gTTS, Coqui-TTS and system engines with runtime selection
- expose voice list endpoint and UI selector for available voices

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a1b9252a9c8333abc453e3b6d4cb77