### PR TITLE
feat(trial): add voice widget with realtime objections

### DIFF
--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -846,3 +846,7 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 - Abstracted text-to-speech to support gTTS, Coqui-TTS or system engines with Redis/DB caching.
 - Added `/api/chat/voices` endpoint and React selector for available voices.
 - Next: surface engine choice in settings and broaden voice options.
+
+## Update 2025-09-01T00:00Z
+- Created `voice-widget.jsx` with microphone controls, transcript stream and objection bar.
+- Next: integrate widget into trial console and refine audio fallback handling.

--- a/apps/legal_discovery/src/components/voice-widget.jsx
+++ b/apps/legal_discovery/src/components/voice-widget.jsx
@@ -1,0 +1,105 @@
+import React, { useEffect, useRef, useState } from "react";
+import { io } from "socket.io-client";
+import ObjectionBar from "./trial/ObjectionBar";
+
+export default function VoiceWidget({ sessionId }) {
+  const socketRef = useRef(null);
+  const recRef = useRef(null);
+  const [segments, setSegments] = useState([]);
+  const [objection, setObjection] = useState(null);
+  const [listening, setListening] = useState(false);
+
+  useEffect(() => {
+    const socket = io("/ws/trial", { transports: ["websocket"] });
+    socket.emit("join", { session_id: sessionId });
+    socket.on("transcript_update", (s) => setSegments((prev) => [...prev, s]));
+    socket.on("objection_event", (evt) => setObjection(evt));
+    socketRef.current = socket;
+    return () => socket.disconnect();
+  }, [sessionId]);
+
+  useEffect(() => {
+    const SpeechRecognition =
+      window.SpeechRecognition || window.webkitSpeechRecognition;
+    if (!SpeechRecognition) return;
+    const rec = new SpeechRecognition();
+    rec.continuous = true;
+    rec.interimResults = true;
+    rec.lang = "en-US";
+    rec.onresult = (e) => {
+      let final = "";
+      for (let i = e.resultIndex; i < e.results.length; i++) {
+        if (e.results[i].isFinal) final += e.results[i][0].transcript;
+      }
+      const text = final.trim();
+      if (text && socketRef.current) {
+        const now = Date.now();
+        socketRef.current.emit("segment", {
+          session_id: sessionId,
+          text,
+          t0_ms: now,
+          t1_ms: now,
+          speaker: "local",
+          confidence: 100,
+        });
+      }
+    };
+    recRef.current = rec;
+    return () => rec.stop();
+  }, [sessionId]);
+
+  const toggle = () => {
+    if (!recRef.current) return;
+    if (listening) {
+      recRef.current.stop();
+      setListening(false);
+    } else {
+      try {
+        recRef.current.start();
+        setListening(true);
+      } catch (e) {
+        console.error(e);
+      }
+    }
+  };
+
+  const chooseCure = (id, key) => {
+    fetch("/api/trial/objection/action", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ event_id: id, action: key }),
+    });
+    setObjection(null);
+  };
+
+  return (
+    <div className="p-4 bg-white/5 rounded-xl text-white backdrop-blur relative">
+      <button
+        onClick={toggle}
+        className={`mb-4 rounded-full px-4 py-2 transition-colors ${
+          listening ? "bg-red-600" : "bg-white/10 hover:bg-white/20"
+        }`}
+      >
+        {listening ? "Stop" : "Start"} Mic
+      </button>
+      <div className="space-y-1 max-h-48 overflow-y-auto text-sm">
+        {segments.map((s) => (
+          <div key={s.segment_id || Math.random()}>
+            <span className="font-semibold mr-2">{s.speaker}:</span>
+            <span>{s.text}</span>
+          </div>
+        ))}
+      </div>
+      {objection && (
+        <ObjectionBar
+          event_id={objection.event_id}
+          ground={objection.ground}
+          confidence={objection.confidence}
+          suggested_cures={objection.suggested_cures}
+          onChoose={chooseCure}
+        />
+      )}
+    </div>
+  );
+}
+

--- a/condensed AGENTS.md
+++ b/condensed AGENTS.md
@@ -168,3 +168,7 @@ we are now working on implementing a major feature, so stand by, this is  A GDDM
 - Exposed `Agent` model in Flask import list and added missing `hashlib` import so document versioning tests collect properly.
 - Polished navigation bar with border and neon glow for clearer separation.
 - Next: exercise document stamping workflow against live databases.
+
+## Update 2025-09-01T00:00Z
+- Added React voice widget with microphone toggle, streaming transcript feed and objection alerts.
+- Next: embed widget in dashboard and broaden cross-browser audio support.


### PR DESCRIPTION
## Summary
- add standalone voice widget with microphone toggle, real-time transcript feed, and objection bar
- document progress in AGENTS files

## Testing
- `pytest`
- `cd apps/legal_discovery && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a1c26c10648333875d5e77d3e72ffc