### PR TITLE
test: add voice command and objection regression tests

### DIFF
--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -858,3 +858,6 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 ## Update 2025-09-15T00:00Z
 - Instrumented STT/TTS with Prometheus metrics and logging; exposed `/metrics` endpoint and added alert rules.
 - Next: monitor metrics in staging and tune alert thresholds.
+## Update 2025-09-16T00:00Z
+- Mocked STT/TTS layers and added tests for voice command routing, auth failures, message bus alerts, WebSocket transcripts and objection detection.
+- Next: broaden command coverage and expand streaming edge-case tests.

--- a/condensed AGENTS.md
+++ b/condensed AGENTS.md
@@ -176,3 +176,6 @@ we are now working on implementing a major feature, so stand by, this is  A GDDM
 ## Update 2025-09-15T00:00Z
 - Instrumented STT/TTS with Prometheus metrics and `/metrics` endpoint; added alerting rules.
 - Next: monitor latency and failure alerts in staging.
+## Update 2025-09-16T00:00Z
+- Mocked speech engines and added tests for command routing, auth errors, message bus alerts, streaming transcripts and objection detection.
+- Next: expand coverage for additional voice workflows.

--- a/tests/apps/test_objection_engine_regression.py
+++ b/tests/apps/test_objection_engine_regression.py
@@ -1,0 +1,56 @@
+from flask import Flask
+
+from apps.legal_discovery.database import db
+from apps.legal_discovery.models_trial import (
+    TrialSession,
+    TranscriptSegment,
+    ObjectionEvent,
+)
+from apps.legal_discovery.trial_assistant.services.objection_engine import (
+    ObjectionEngine,
+)
+
+
+def _create_app():
+    app = Flask(__name__)
+    app.config.update(
+        SQLALCHEMY_DATABASE_URI="sqlite://",
+        SQLALCHEMY_TRACK_MODIFICATIONS=False,
+    )
+    db.init_app(app)
+    with app.app_context():
+        db.create_all()
+    return app
+
+
+def test_objection_engine_detects_hearsay():
+    app = _create_app()
+    engine = ObjectionEngine()
+    with app.app_context():
+        sess = TrialSession(id="s", case_id="1")
+        seg = TranscriptSegment(
+            session_id="s",
+            t0_ms=0,
+            t1_ms=1,
+            speaker="lawyer",
+            text="objection hearsay",
+            confidence=100,
+        )
+        db.session.add_all([sess, seg])
+        db.session.commit()
+        events = engine.analyze_segment("s", seg)
+        assert any(e.ground == "hearsay" for e in events)
+        assert ObjectionEvent.query.count() == 1
+        clean_seg = TranscriptSegment(
+            session_id="s",
+            t0_ms=1,
+            t1_ms=2,
+            speaker="lawyer",
+            text="no objection here",
+            confidence=100,
+        )
+        db.session.add(clean_seg)
+        db.session.commit()
+        assert engine.analyze_segment("s", clean_seg) == []
+
+

--- a/tests/apps/test_voice_command_routing.py
+++ b/tests/apps/test_voice_command_routing.py
@@ -1,0 +1,88 @@
+from flask import Flask
+
+from apps.legal_discovery.extensions import socketio, limiter
+from apps.legal_discovery.database import db
+from apps.legal_discovery.chat_routes import chat_bp
+from apps.message_bus import TIMELINE_ALERT_TOPIC
+
+
+def _create_app():
+    app = Flask(__name__)
+    app.config.update(
+        JWT_SECRET="secret",
+        SQLALCHEMY_DATABASE_URI="sqlite://",
+        SQLALCHEMY_TRACK_MODIFICATIONS=False,
+        RATELIMIT_ENABLED=False,
+    )
+    db.init_app(app)
+    socketio.init_app(app, logger=False, engineio_logger=False)
+    limiter.init_app(app)
+    app.register_blueprint(chat_bp)
+    with app.app_context():
+        db.create_all()
+    return app
+
+
+def test_voice_command_routing_and_bus(monkeypatch):
+    app = _create_app()
+
+    monkeypatch.setattr(
+        "apps.legal_discovery.chat_routes._ensure_listeners_started", lambda: None
+    )
+    monkeypatch.setattr(
+        "apps.legal_discovery.chat_routes._require_auth", lambda: True
+    )
+
+    publish_calls = []
+
+    def fake_publish(topic, message):
+        publish_calls.append((topic, message.payload))
+
+    monkeypatch.setattr(
+        "apps.legal_discovery.chat_routes.bus.publish", fake_publish
+    )
+    monkeypatch.setattr(
+        "apps.legal_discovery.chat_routes.synthesize_voice",
+        lambda text, model: "audio",
+    )
+
+    class DummyAgent:
+        def query(self, **kwargs):
+            return {"answer": "ok", "message_id": 1}
+
+    monkeypatch.setattr(
+        "apps.legal_discovery.chat_routes.RetrievalChatAgent", DummyAgent
+    )
+
+    class DummyTM:
+        def summarize(self, case_id: int) -> str:  # pragma: no cover - trivial
+            return "summary"
+
+    monkeypatch.setattr(
+        "apps.legal_discovery.voice_commands.TimelineManager", DummyTM
+    )
+
+    with app.test_client() as client:
+        resp = client.post(
+            "/api/chat/voice",
+            json={"transcript": "timeline summary please", "case_id": 1},
+        )
+
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["command"] == "timeline summary"
+    assert data["result"] == "summary"
+    assert any(t == TIMELINE_ALERT_TOPIC for t, _ in publish_calls)
+
+
+def test_voice_query_auth_error(monkeypatch):
+    app = _create_app()
+    monkeypatch.setattr(
+        "apps.legal_discovery.chat_routes._ensure_listeners_started", lambda: None
+    )
+    with app.test_client() as client:
+        resp = client.post("/api/chat/voice", json={"transcript": "hi"})
+    assert resp.status_code == 401
+    assert resp.get_json()["error"] == "unauthorized"
+
+

--- a/tests/apps/test_voice_ws_transcript.py
+++ b/tests/apps/test_voice_ws_transcript.py
@@ -1,0 +1,75 @@
+from flask import Flask
+import base64
+
+from apps.legal_discovery.extensions import socketio, limiter
+from apps.legal_discovery.database import db
+from apps.legal_discovery.chat_routes import chat_bp
+
+
+def _create_app():
+    app = Flask(__name__)
+    app.config.update(
+        JWT_SECRET="secret",
+        SQLALCHEMY_DATABASE_URI="sqlite://",
+        SQLALCHEMY_TRACK_MODIFICATIONS=False,
+        RATELIMIT_ENABLED=False,
+    )
+    db.init_app(app)
+    socketio.init_app(app, logger=False, engineio_logger=False)
+    limiter.init_app(app)
+    app.register_blueprint(chat_bp)
+    with app.app_context():
+        db.create_all()
+    return app
+
+
+def test_voice_ws_transcript_updates(monkeypatch):
+    app = _create_app()
+    monkeypatch.setattr(
+        "apps.legal_discovery.chat_routes._require_auth", lambda: True
+    )
+    monkeypatch.setattr(
+        "apps.legal_discovery.chat_routes._ensure_listeners_started", lambda: None
+    )
+
+    def fake_stream(_):
+        yield {"text": "hi", "is_final": False}
+        yield {"text": "bye", "is_final": True}
+
+    monkeypatch.setattr(
+        "apps.legal_discovery.chat_routes.stream_transcribe", fake_stream
+    )
+    monkeypatch.setattr(
+        "apps.legal_discovery.chat_routes._handle_transcript", lambda t, d: {}
+    )
+
+    client = socketio.test_client(app, namespace="/chat")
+    client.emit(
+        "voice_query",
+        {"frames": [base64.b64encode(b"a").decode("utf-8")]},
+        namespace="/chat",
+    )
+    received = client.get_received("/chat")
+    assert any(
+        r["name"] == "voice_transcript" and r["args"][0]["text"] == "hi" and not r["args"][0]["final"]
+        for r in received
+    )
+    assert any(
+        r["name"] == "voice_transcript" and r["args"][0]["text"] == "bye" and r["args"][0]["final"]
+        for r in received
+    )
+
+
+
+def test_voice_ws_auth_error(monkeypatch):
+    app = _create_app()
+    monkeypatch.setattr(
+        "apps.legal_discovery.chat_routes._ensure_listeners_started", lambda: None
+    )
+    client = socketio.test_client(app, namespace="/chat")
+    client.emit("voice_query", {"frames": [""]}, namespace="/chat")
+    received = client.get_received("/chat")
+    assert any(
+        r["name"] == "voice_error" and r["args"][0]["error"] == "unauthorized"
+        for r in received
+    )


### PR DESCRIPTION
## Summary
- add unit tests for voice command routing with mocked STT/TTS engines and message bus events
- cover authentication failures and WebSocket transcript streaming
- add regression test for objection detection engine

## Testing
- `pytest tests/apps/test_voice_command_routing.py tests/apps/test_voice_ws_transcript.py tests/apps/test_objection_engine_regression.py tests/apps/test_trial_objection_ws.py tests/apps/test_stt.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a1efa0e9d08333ade42e52a7147eb2