### PR TITLE
Add CI workflow and deployment scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,55 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          python -m venv venv
+          source venv/bin/activate
+          pip install -r requirements-build.txt
+          pip install -r requirements.txt
+
+      - name: Lint and test
+        run: |
+          source venv/bin/activate
+          make lint
+          make lint-tests
+          make test
+
+  build:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: deploy/Dockerfile
+          push: ${{ github.ref == 'refs/heads/main' }}
+          tags: ghcr.io/${{ github.repository }}:${{ github.sha }}

--- a/deploy/deploy_production.sh
+++ b/deploy/deploy_production.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -euo pipefail
+
+IMAGE=${1:-ghcr.io/your-org/neuro-san-studio:latest}
+NAMESPACE=production
+
+kubectl set image deployment/neuro-san-studio neuro-san-studio="$IMAGE" -n "$NAMESPACE"
+kubectl rollout status deployment/neuro-san-studio -n "$NAMESPACE"

--- a/deploy/deploy_staging.sh
+++ b/deploy/deploy_staging.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -euo pipefail
+
+IMAGE=${1:-ghcr.io/your-org/neuro-san-studio:latest}
+NAMESPACE=staging
+
+kubectl set image deployment/neuro-san-studio neuro-san-studio="$IMAGE" -n "$NAMESPACE"
+kubectl rollout status deployment/neuro-san-studio -n "$NAMESPACE"


### PR DESCRIPTION
## Summary
- add CI workflow that runs linting, tests, and builds/pushes Docker images to GHCR
- add staging and production deployment scripts using kubectl to update running images

## Testing
- `make test` *(fails: lint format issues)*
- `pytest tests -q` *(fails: RuntimeError: not connected)*

------
https://chatgpt.com/codex/tasks/task_e_68a202fcb6108333bd8c00a5da93649d