### PR TITLE
feat: add voice subfeature flags and settings

### DIFF
--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -866,3 +866,8 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 - Installed ffmpeg and espeak in Dockerfile for Whisper and TTS support.
 - Added Redis service and audio cache volume to docker-compose; documented build/run steps.
 - Next: test voice flows end-to-end and optimise cache storage.
+
+## Update 2025-09-17T17:01Z
+- Added feature flags for voice transcription, synthesis and commands with UI toggles.
+- Wired flags into chat routes and voice utilities.
+- Next: persist flag selections across restarts and expand UI validation.

--- a/apps/legal_discovery/feature_flags.py
+++ b/apps/legal_discovery/feature_flags.py
@@ -4,6 +4,10 @@ FEATURE_FLAGS = {
     "theories": os.getenv("ENABLE_THEORIES", "1") == "1",
     "binder": os.getenv("ENABLE_BINDER", "1") == "1",
     "chat": os.getenv("ENABLE_CHAT", "1") == "1",
+    # Voice subfeatures
+    "voice_stt": os.getenv("ENABLE_VOICE_STT", "1") == "1",
+    "voice_tts": os.getenv("ENABLE_VOICE_TTS", "1") == "1",
+    "voice_commands": os.getenv("ENABLE_VOICE_COMMANDS", "1") == "1",
 }
 
 __all__ = ["FEATURE_FLAGS"]

--- a/apps/legal_discovery/src/components/SettingsModal.jsx
+++ b/apps/legal_discovery/src/components/SettingsModal.jsx
@@ -7,7 +7,10 @@ function SettingsModal({open,onClose}) {
       fetch('/api/settings').then(r=>r.json()).then(d=>setForm(d||{}));
     }
   }, [open]);
-  const update = e => setForm({...form,[e.target.name]:e.target.value});
+  const update = e => {
+    const { name, type, checked, value } = e.target;
+    setForm({ ...form, [name]: type === "checkbox" ? checked : value });
+  };
   const submit = e => {
     e.preventDefault();
     fetch('/api/settings',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(form)})
@@ -38,6 +41,9 @@ function SettingsModal({open,onClose}) {
           <label>GCP Vertex Data Store<input type="text" name="gcp_vertex_ai_data_store_id" value={form.gcp_vertex_ai_data_store_id||''} onChange={update} className="w-full p-2 rounded"/></label>
           <label>GCP Search App<input type="text" name="gcp_vertex_ai_search_app" value={form.gcp_vertex_ai_search_app||''} onChange={update} className="w-full p-2 rounded"/></label>
           <label>GCP Service Account Key<textarea name="gcp_service_account_key" value={form.gcp_service_account_key||''} onChange={update} className="w-full p-2 rounded" rows="2"/></label>
+          <label className="flex items-center space-x-2"><input type="checkbox" name="voice_stt" checked={form.voice_stt||false} onChange={update}/><span>Enable Voice Transcription</span></label>
+          <label className="flex items-center space-x-2"><input type="checkbox" name="voice_tts" checked={form.voice_tts||false} onChange={update}/><span>Enable Voice Synthesis</span></label>
+          <label className="flex items-center space-x-2"><input type="checkbox" name="voice_commands" checked={form.voice_commands||false} onChange={update}/><span>Enable Voice Commands</span></label>
           <button className="button-primary" type="submit">Save</button>
         </form>
       </div>

--- a/apps/legal_discovery/voice.py
+++ b/apps/legal_discovery/voice.py
@@ -11,6 +11,7 @@ from prometheus_client import Counter, Histogram
 
 from .database import db
 from .models import VoiceCache
+from .feature_flags import FEATURE_FLAGS
 
 try:  # pragma: no cover - optional
     import redis
@@ -96,6 +97,8 @@ _ENGINE_MAP = {
 
 def synthesize_voice(text: str, model: str) -> str:
     """Generate base64-encoded audio, cached by text and model."""
+    if not FEATURE_FLAGS["voice_tts"]:
+        return ""
     key = f"{model}:{text}"
     cached = _cache_get(key, text, model)
     if cached:
@@ -121,6 +124,8 @@ def synthesize_voice(text: str, model: str) -> str:
 
 def get_available_voices() -> List[Dict[str, str]]:
     """Return list of available voices for the configured engine."""
+    if not FEATURE_FLAGS["voice_tts"]:
+        return []
     engine = os.getenv("VOICE_ENGINE", "gtts").lower()
     if engine == "system":
         try:  # pragma: no cover - optional


### PR DESCRIPTION
## Summary
- extend legal discovery feature flags with voice transcription, synthesis, and command options
- gate Flask voice routes and utilities on the new flags
- add settings panel toggles to control voice subfeatures

## Testing
- `python -m py_compile apps/legal_discovery/chat_routes.py`
- `python -m py_compile apps/legal_discovery/voice.py`
- `python -m py_compile apps/legal_discovery/interface_flask.py`
- `python -m py_compile apps/legal_discovery/feature_flags.py`
- `pytest` *(fails: KeyboardInterrupt after ~40s)*

------
https://chatgpt.com/codex/tasks/task_e_68a207cf98388333aef8eab6b161da76