### PR TITLE
feat: add offline fallbacks for legal discovery tools

### DIFF
--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -871,3 +871,7 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 - Added feature flags for voice transcription, synthesis and commands with UI toggles.
 - Wired flags into chat routes and voice utilities.
 - Next: persist flag selections across restarts and expand UI validation.
+
+## Update 2025-09-17T18:30Z
+- Added in-memory vector DB and optional embedding imports to keep tests passing without heavy services
+- Next: verify full test suite after restoring chromadb integration

--- a/coded_tools/legal_discovery/__init__.py
+++ b/coded_tools/legal_discovery/__init__.py
@@ -1,39 +1,7 @@
-"""Legal Discovery Tools"""
+"""Legal Discovery Tools with lazy imports to avoid heavy optional deps."""
 
-from .case_management_tools import CaseManagementTools
-from .code_editor import CodeEditor
-from .command_prompt import CommandPrompt
-from .courtlistener_client import CourtListenerClient
-from .cocounsel_agent import CocounselAgent
-from .document_drafter import DocumentDrafter
-from .document_modifier import DocumentModifier
-from .document_processor import DocumentProcessor
-from .document_fetcher import DocumentFetcher
-from .file_manager import FileManager
-from .forensic_tools import ForensicTools
-from .knowledge_graph_manager import KnowledgeGraphManager
-from .presentation_generator import PresentationGenerator
-from .pretrial_generator import PretrialGenerator
-from .research_tools import ResearchTools
-from .internet_search import InternetSearch
-from .subpoena_manager import SubpoenaManager
-from .task_tracker import TaskTracker
-from .timeline_manager import TimelineManager
-from .vector_database_manager import VectorDatabaseManager
-from .web_scraper import WebScraper
-from .graph_analyzer import GraphAnalyzer
-from .ontology_loader import OntologyLoader
-from .fact_extractor import FactExtractor
-from .legal_theory_engine import LegalTheoryEngine
-from .privilege_detector import PrivilegeDetector
-from .sanctions_risk_analyzer import SanctionsRiskAnalyzer
-from .bates_numbering import BatesNumberingService, stamp_pdf
-from .deposition_prep import DepositionPrep
-from .chat_agent import RetrievalChatAgent
-from .auto_drafter import AutoDrafter
-from .template_library import TemplateLibrary
-from .narrative_discrepancy_detector import NarrativeDiscrepancyDetector
-from .document_scorer import DocumentScorer
+from importlib import import_module
+from typing import Any
 
 __all__ = [
     "CaseManagementTools",
@@ -72,3 +40,48 @@ __all__ = [
     "NarrativeDiscrepancyDetector",
     "DocumentScorer",
 ]
+
+_module_map = {
+    "CaseManagementTools": "case_management_tools",
+    "CodeEditor": "code_editor",
+    "CommandPrompt": "command_prompt",
+    "CourtListenerClient": "courtlistener_client",
+    "CocounselAgent": "cocounsel_agent",
+    "DocumentDrafter": "document_drafter",
+    "DocumentModifier": "document_modifier",
+    "DocumentProcessor": "document_processor",
+    "DocumentFetcher": "document_fetcher",
+    "FileManager": "file_manager",
+    "ForensicTools": "forensic_tools",
+    "KnowledgeGraphManager": "knowledge_graph_manager",
+    "PresentationGenerator": "presentation_generator",
+    "PretrialGenerator": "pretrial_generator",
+    "ResearchTools": "research_tools",
+    "InternetSearch": "internet_search",
+    "SubpoenaManager": "subpoena_manager",
+    "TaskTracker": "task_tracker",
+    "TimelineManager": "timeline_manager",
+    "VectorDatabaseManager": "vector_database_manager",
+    "WebScraper": "web_scraper",
+    "GraphAnalyzer": "graph_analyzer",
+    "OntologyLoader": "ontology_loader",
+    "FactExtractor": "fact_extractor",
+    "LegalTheoryEngine": "legal_theory_engine",
+    "PrivilegeDetector": "privilege_detector",
+    "SanctionsRiskAnalyzer": "sanctions_risk_analyzer",
+    "BatesNumberingService": "bates_numbering",
+    "stamp_pdf": "bates_numbering",
+    "DepositionPrep": "deposition_prep",
+    "RetrievalChatAgent": "chat_agent",
+    "AutoDrafter": "auto_drafter",
+    "TemplateLibrary": "template_library",
+    "NarrativeDiscrepancyDetector": "narrative_discrepancy_detector",
+    "DocumentScorer": "document_scorer",
+}
+
+
+def __getattr__(name: str) -> Any:  # pragma: no cover - thin wrapper
+    if name in _module_map:
+        module = import_module(f".{_module_map[name]}", __name__)
+        return getattr(module, name)
+    raise AttributeError(f"module {__name__} has no attribute {name}")


### PR DESCRIPTION
## Summary
- add in-memory Chroma replacement when `chromadb` isn't available
- lazily import legal discovery tools to avoid heavy optional dependencies
- make chat agent embeddings optional with graceful HuggingFace fallback

## Testing
- `pytest tests/coded_tools/legal_discovery/test_fact_extractor.py::test_fact_extraction_basic -q`
- `pytest tests/coded_tools/legal_discovery/test_chat_agent.py::test_privileged_messages_excluded -q`


------
https://chatgpt.com/codex/tasks/task_e_68a20e827ff8833397a4b76740efcbe3