### PR TITLE
Add voice assistant docs and Makefile scripts for STT/TTS services

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,1 +1,4 @@
 #### **please check the agents folder, your directions will be there autobuddy!** ###
+
+For details on the voice assistant architecture and APIs see
+[docs/voice_assistant.md](docs/voice_assistant.md).

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,13 @@ activate: ## Activate the venv
 		echo "To activate the environment in your current shell, run:"; \
 		echo "    source venv/bin/activate"; \
 		echo ""; \
-	fi
+        fi
+
+stt-service: ## Launch Flask app with speech-to-text enabled
+	ENABLE_VOICE_STT=1 ENABLE_VOICE_TTS=0 python apps/legal_discovery/interface_flask.py
+
+tts-service: ## Launch Flask app with text-to-speech enabled
+	ENABLE_VOICE_STT=0 ENABLE_VOICE_TTS=1 python apps/legal_discovery/interface_flask.py
 
 lint: ## Run code formatting and linting tools on source
 	@if [ -z "$$VIRTUAL_ENV" ]; then \
@@ -59,9 +65,9 @@ frontend-build: ## Install deps and build the legal discovery React dashboard
 	npm --prefix apps/legal_discovery run build
 
 test: lint lint-tests ## Run tests with coverage
-	PYTHONPATH=$(CURDIR) python -m pytest tests/ -v --cov=coded_tools,run.py
+        PYTHONPATH=$(CURDIR) python -m pytest tests/ -v --cov=coded_tools,run.py
 
-.PHONY: help venv install activate lint lint-tests test
+.PHONY: help venv install activate stt-service tts-service lint lint-tests test
 .DEFAULT_GOAL := help
 
 help: ## Show this help message and exit

--- a/README.md
+++ b/README.md
@@ -367,6 +367,11 @@ For examples of agent networks, check out [docs/examples.md](docs/examples.md).
 
 For the development guide, check out [docs/dev_guide.md](docs/dev_guide.md).
 
+## Voice Assistant
+
+Learn how speech features are wired into the studio in
+[docs/voice_assistant.md](docs/voice_assistant.md).
+
 ## Blog posts
 
 * [Code versus Model in Multi-Agentic Systems](https://medium.com/@evolutionmlmail/code-versus-model-in-multi-agentic-systems-e33cf581e32b):

--- a/docs/voice_assistant.md
+++ b/docs/voice_assistant.md
@@ -1,0 +1,55 @@
+# Voice Assistant
+
+The voice assistant enables speech-driven interactions through standalone
+Speech-to-Text (STT) and Text-to-Speech (TTS) components.
+
+## Architecture
+
+- **STT** – Incoming audio frames are decoded with an optional
+  [Whisper](https://github.com/openai/whisper) model via `stream_transcribe`.
+- **TTS** – Agent responses are rendered to audio with `synthesize_voice`,
+  supporting engines such as gTTS, Coqui and the host system.
+- **Orchestration** – `chat_routes.py` wires the STT and TTS utilities into
+  Flask and Socket.IO endpoints for real-time conversations.
+
+## Setup
+
+1. Install dependencies with `make install`.
+2. Launch the STT or TTS services:
+
+   ```bash
+   make stt-service   # start server with speech-to-text enabled
+   make tts-service   # start server with text-to-speech enabled
+   ```
+3. Optionally set `VOICE_ENGINE` (e.g. `gtts`, `coqui`, `system`) before
+   starting the TTS service.
+
+## APIs
+
+### Streaming STT
+
+Connect to the `/chat` namespace and emit a `voice_query` event with
+base64-encoded audio frames:
+
+```json
+{
+  "frames": ["<base64>", "..."]
+}
+```
+
+The server emits `voice_transcript` events with interim and final text or
+`voice_error` on failure.
+
+### Voice Query Endpoint
+
+`POST /api/chat/voice`
+
+Send a transcribed message to the agent network and receive identifiers for
+follow up requests.
+
+### Voice Synthesis
+
+- `GET /api/chat/voices` returns available voice options for the active TTS
+  engine.
+- When TTS is enabled, responses include a `voice_output` Socket.IO event
+  carrying base64 audio.


### PR DESCRIPTION
## Summary
- document speech architecture and APIs in `docs/voice_assistant.md`
- expose `stt-service` and `tts-service` Makefile targets for quick-starting voice features
- link the new guide from README and AGENTS notes

## Testing
- `pytest tests/apps/test_stt.py --no-cov -q`

------
https://chatgpt.com/codex/tasks/task_e_68a20de761ec8333a37ee50794498705