### PR TITLE
Add async background queries and caching

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -1,0 +1,39 @@
+"""Simple benchmarking script for vector and graph queries."""
+import asyncio
+import time
+
+from coded_tools.legal_discovery.vector_database_manager import VectorDatabaseManager
+from coded_tools.legal_discovery.knowledge_graph_manager import KnowledgeGraphManager
+
+
+async def bench_vector():
+    mgr = VectorDatabaseManager()
+    mgr.add_documents(["doc"], [{}], ["1"])
+    start = time.time()
+    for _ in range(5):
+        await mgr.aquery(["doc"])
+    return time.time() - start
+
+
+async def bench_graph():
+    mgr = KnowledgeGraphManager()
+    if not mgr.driver:
+        return None
+    start = time.time()
+    for _ in range(5):
+        await mgr.arun_query("RETURN 1")
+    return time.time() - start
+
+
+async def main():
+    v = await bench_vector()
+    g = await bench_graph()
+    print(f"vector: {v:.4f}s")
+    if g is not None:
+        print(f"graph: {g:.4f}s")
+    else:
+        print("graph: driver unavailable")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -1,0 +1,23 @@
+# Performance Benchmarking and Best Practices
+
+This project now supports asynchronous background queries and in-memory caching for
+vector and graph operations.  To measure the impact of these features:
+
+1. Run the provided benchmark script:
+
+```bash
+python benchmark.py
+```
+
+2. The script times a series of cached vector and graph queries.  Repeated
+   executions should remain fast because results are served from cache and heavy
+   calls run in background threads.
+
+## Best Practices
+
+- Use the `aquery` and `arun_query` helpers to offload long-running operations
+  without blocking the main thread.
+- Cache lookups are invalidated automatically whenever underlying data is
+  modified.
+- For manual benchmarking, wrap calls with `time.perf_counter` and compare cached
+  versus uncached execution.

--- a/tests/coded_tools/legal_discovery/test_query_caching.py
+++ b/tests/coded_tools/legal_discovery/test_query_caching.py
@@ -1,0 +1,57 @@
+import asyncio
+from unittest.mock import MagicMock
+
+from coded_tools.legal_discovery.vector_database_manager import VectorDatabaseManager
+from coded_tools.legal_discovery.knowledge_graph_manager import KnowledgeGraphManager
+
+
+def test_vector_query_cache_invalidation():
+    mgr = VectorDatabaseManager()
+    mgr.collection = MagicMock()
+    mgr.collection.query.return_value = {"documents": [["d"]], "metadatas": [[{}]], "ids": [["1"]]}
+    mgr.collection.get.return_value = {"ids": []}
+    mgr.collection.add.return_value = None
+
+    mgr.query(["hello"])
+    mgr.query(["hello"])
+    assert mgr.collection.query.call_count == 1
+    mgr.collection.query.reset_mock()
+    mgr.add_documents(["hello"], [{}], ["1"])
+    mgr.collection.query.reset_mock()
+    mgr.collection.query.return_value = {"documents": [["d2"]], "metadatas": [[{}]], "ids": [["1"]]}
+    mgr.query(["hello"])
+    assert mgr.collection.query.call_count == 1
+
+    asyncio.run(mgr.aquery(["hello"]))
+    assert mgr.collection.query.call_count == 1
+
+
+def test_graph_query_cache_invalidation():
+    mgr = KnowledgeGraphManager()
+    session = MagicMock()
+
+    def make_record(data):
+        rec = MagicMock()
+        rec.data.return_value = data
+        return rec
+
+    session.run.side_effect = [
+        [make_record({})],
+        [make_record({"id": 1})],
+        [make_record({})],
+    ]
+
+    driver = MagicMock()
+    driver.session.return_value.__enter__.return_value = session
+    mgr.driver = driver
+
+    mgr.run_query("MATCH (n) RETURN n")
+    mgr.run_query("MATCH (n) RETURN n")
+    assert session.run.call_count == 1
+
+    mgr.create_node("Test", {"name": "a"})
+    mgr.run_query("MATCH (n) RETURN n")
+    assert session.run.call_count == 3
+
+    asyncio.run(mgr.arun_query("MATCH (n) RETURN n"))
+    assert session.run.call_count == 3


### PR DESCRIPTION
## Summary
- run vector and graph queries in background threads with asyncio helpers
- cache vector, message, conversation, and graph queries to avoid repeated work
- provide benchmark script and docs on measuring async cache performance

## Testing
- `PYTEST_ADDOPTS="" PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -o addopts="" tests/coded_tools/legal_discovery/test_query_caching.py -q`
- `PYTEST_ADDOPTS="" PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -o addopts="" tests/coded_tools/legal_discovery/test_knowledge_graph_manager.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a228bf870c833391055d3ecff2d675