### PR TITLE
Add minimal HippoRAG indexing and query endpoints

### DIFF
--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -875,3 +875,8 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 ## Update 2025-09-17T18:30Z
 - Added in-memory vector DB and optional embedding imports to keep tests passing without heavy services
 - Next: verify full test suite after restoring chromadb integration
+
+## Update 2025-09-18T00:00Z
+- Implemented minimal HippoRAG-style indexing and query endpoints with deterministic segment IDs.
+- Added unit tests for chunking determinism and query path structure.
+- Next: connect endpoints to real Neo4j and Chroma services and enrich objection events with retrieval refs.

--- a/apps/legal_discovery/hippo.py
+++ b/apps/legal_discovery/hippo.py
@@ -1,0 +1,152 @@
+"""Minimal HippoRAG-style indexing and retrieval utilities.
+
+This module provides deterministic document chunking, a very light-weight
+entity extraction, and in-memory storage so that the Flask endpoints can
+index and search documents without requiring external services. The goal is
+not to be feature complete but to exercise the expected control flow for
+indexing and retrieval.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+import re
+from typing import Dict, List
+
+
+# ---------------------------------------------------------------------------
+# Dataclasses
+
+
+@dataclass
+class Segment:
+    """Text segment with deterministic identifier."""
+
+    doc_id: str
+    segment_id: str
+    text: str
+    page: int
+    para: int
+    tok_start: int
+    tok_end: int
+    entities: List[str]
+
+
+# In-memory index: {case_id: {doc_id: [Segment, ...]}}
+INDEX: Dict[str, Dict[str, List[Segment]]] = {}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+
+
+def make_doc_id(case_id: str, path: str) -> str:
+    """Return a stable 128-bit hex id for a document."""
+
+    return hashlib.sha256(f"{case_id}:{path}".encode()).hexdigest()[:32]
+
+
+def _segment_hash(doc_id: str, start: int, end: int) -> int:
+    h = hashlib.sha256(f"{doc_id}:{start}:{end}".encode()).hexdigest()
+    # first 16 hex = 64 bits
+    return int(h[:16], 16)
+
+
+def chunk_text(text: str, doc_id: str, page: int = 1, tokens_per_chunk: int = 200) -> List[Segment]:
+    """Deterministically split ``text`` into segments.
+
+    Each segment id follows the ``doc_id:page:para:start-end`` pattern and a
+    64-bit ``segment_hash`` is derived from these values.  Tokens are simple
+    whitespace splits which is adequate for the unit tests.
+    """
+
+    tokens = text.split()
+    segments: List[Segment] = []
+    para = 0
+    t = 0
+    while t < len(tokens):
+        chunk_tokens = tokens[t : t + tokens_per_chunk]
+        start = t
+        end = t + len(chunk_tokens)
+        segment_id = f"{doc_id}:{page}:{para}:{start}-{end}"
+        seg_text = " ".join(chunk_tokens)
+        entities = _extract_entities(seg_text)
+        segments.append(
+            Segment(
+                doc_id=doc_id,
+                segment_id=segment_id,
+                text=seg_text,
+                page=page,
+                para=para,
+                tok_start=start,
+                tok_end=end,
+                entities=entities,
+            )
+        )
+        para += 1
+        t = end
+    return segments
+
+
+def _extract_entities(text: str) -> List[str]:
+    """Very small NER extractor.
+
+    We flag capitalised words as entities and normalise them to lower case to
+    act as stable keys.  This keeps the implementation light-weight while
+    allowing unit tests to exercise entity seeded queries.
+    """
+
+    ents = set()
+    for match in re.findall(r"\b([A-Z][a-zA-Z]+)\b", text):
+        ents.add(match.lower())
+    return sorted(ents)
+
+
+# ---------------------------------------------------------------------------
+# Ingestion / Query
+
+
+def ingest_document(case_id: str, text: str, path: str = "") -> str:
+    """Index ``text`` for ``case_id`` and return the generated ``doc_id``."""
+
+    doc_id = make_doc_id(case_id, path or "inline")
+    segments = chunk_text(text, doc_id)
+    case_index = INDEX.setdefault(case_id, {})
+    case_index[doc_id] = segments
+    return doc_id
+
+
+def hippo_query(case_id: str, query: str, k: int = 10) -> Dict[str, object]:
+    """Perform a naïve retrieval over the in-memory index.
+
+    Scores are a simple count of query token occurrences.  Paths include the
+    originating entities for demonstrative purposes.
+    """
+
+    results = []
+    q_tokens = query.lower().split()
+    case_index = INDEX.get(case_id, {})
+    for doc_segments in case_index.values():
+        for seg in doc_segments:
+            score = sum(seg.text.lower().count(t) for t in q_tokens)
+            if score:
+                spans = [
+                    {"start": m.start(), "end": m.end()}
+                    for t in q_tokens
+                    for m in re.finditer(re.escape(t), seg.text.lower())
+                ]
+                path = [{"type": "Segment", "segment_id": seg.segment_id}]
+                for ent in seg.entities:
+                    path.insert(0, {"type": "Entity", "key": ent})
+                results.append(
+                    {
+                        "doc_id": seg.doc_id,
+                        "segment_id": seg.segment_id,
+                        "snippet": seg.text[:200],
+                        "spans": spans,
+                        "path": path,
+                        "scores": {"graph": score, "dense": score, "hybrid": score},
+                    }
+                )
+    results.sort(key=lambda r: r["scores"]["hybrid"], reverse=True)
+    return {"answer": "", "items": results[:k], "trace_id": hashlib.sha1(query.encode()).hexdigest()}

--- a/apps/legal_discovery/hippo_routes.py
+++ b/apps/legal_discovery/hippo_routes.py
@@ -1,0 +1,32 @@
+"""Flask blueprint exposing minimal HippoRAG endpoints."""
+from __future__ import annotations
+
+from flask import Blueprint, jsonify, request
+
+from . import hippo
+
+bp = Blueprint("hippo", __name__, url_prefix="/api/hippo")
+
+
+@bp.post("/index")
+def index_document():
+    data = request.get_json() or {}
+    case_id = data.get("case_id")
+    text = data.get("text")
+    path = data.get("doc_path", "")
+    if not case_id or not text:
+        return jsonify({"error": "case_id and text required"}), 400
+    doc_id = hippo.ingest_document(case_id, text, path)
+    segments = len(hippo.INDEX[case_id][doc_id])
+    return jsonify({"doc_id": doc_id, "segments": segments})
+
+
+@bp.post("/query")
+def query_document():
+    data = request.get_json() or {}
+    case_id = data.get("case_id")
+    query = data.get("query", "")
+    k = int(data.get("k", 10))
+    if not case_id:
+        return jsonify({"error": "case_id required"}), 400
+    return jsonify(hippo.hippo_query(case_id, query, k=k))

--- a/apps/legal_discovery/interface_flask.py
+++ b/apps/legal_discovery/interface_flask.py
@@ -88,6 +88,7 @@ from .exhibit_routes import exhibits_bp
 from .trial_prep_routes import trial_prep_bp
 from .chain_logger import ChainEventType, log_event
 from .trial_assistant import bp as trial_assistant_bp  # noqa: E402
+from .hippo_routes import bp as hippo_bp  # noqa: E402
 from coded_tools.legal_discovery.bates_numbering import (
     BatesNumberingService,
     stamp_pdf,
@@ -143,6 +144,7 @@ limiter.init_app(app)
 app.register_blueprint(exhibits_bp)
 app.register_blueprint(trial_prep_bp)
 app.register_blueprint(trial_assistant_bp)
+app.register_blueprint(hippo_bp)
 if FEATURE_FLAGS.get("theories"):
     from .theory_routes import theories_bp
 

--- a/tests/apps/test_hippo_query.py
+++ b/tests/apps/test_hippo_query.py
@@ -1,0 +1,39 @@
+from flask import Flask
+
+from flask import Flask
+
+from apps.legal_discovery.hippo import chunk_text, make_doc_id
+from apps.legal_discovery.hippo_routes import bp as hippo_bp
+
+
+def _create_app():
+    app = Flask(__name__)
+    app.register_blueprint(hippo_bp)
+    return app
+
+
+def test_chunker_deterministic():
+    doc_id = make_doc_id("case", "path.txt")
+    text = "Hello world " * 50
+    segs1 = chunk_text(text, doc_id)
+    segs2 = chunk_text(text, doc_id)
+    assert [s.segment_id for s in segs1] == [s.segment_id for s in segs2]
+
+
+def test_query_endpoint_returns_paths():
+    app = _create_app()
+    client = app.test_client()
+    client.post(
+        "/api/hippo/index",
+        json={"case_id": "c1", "text": "Alice met Bob at Acme."},
+    )
+    res = client.post(
+        "/api/hippo/query",
+        json={"case_id": "c1", "query": "Bob"},
+    )
+    assert res.status_code == 200
+    data = res.get_json()
+    assert data["items"]
+    first = data["items"][0]
+    assert "segment_id" in first
+    assert first["path"]  # at least one element


### PR DESCRIPTION
## Summary
- implement deterministic segment chunking and in-memory HippoRAG utilities
- expose `/api/hippo/index` and `/api/hippo/query` blueprints and register in Flask app
- add tests for chunking determinism and query paths

## Testing
- `pytest tests/apps/test_hippo_query.py -q`
- `pytest -q` *(fails: tests/apps/test_voice_ws_transcript.py::test_voice_ws_transcript_updates, tests/apps/test_voice_ws_transcript.py::test_voice_ws_auth_error)*

------
https://chatgpt.com/codex/tasks/task_e_68a247fb2164833380dc2542fc92bcb5