### PR TITLE
feat: add hippo ingestion logging and hashing

### DIFF
--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -880,3 +880,8 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 - Implemented minimal HippoRAG-style indexing and query endpoints with deterministic segment IDs.
 - Added unit tests for chunking determinism and query path structure.
 - Next: connect endpoints to real Neo4j and Chroma services and enrich objection events with retrieval refs.
+
+## Update 2025-09-18T12:00Z
+- Added deterministic ``segment_hash`` plus pluggable entity extractor and bulk Neo4j/Chroma upserts in ``hippo.py``.
+- Created ``ingestion_logs`` table and helper to record document ingestions with idempotent hashing.
+- Next: validate graph/vector batch operations against live services and expand ingestion telemetry.

--- a/apps/legal_discovery/database.py
+++ b/apps/legal_discovery/database.py
@@ -1,3 +1,44 @@
+"""Database helpers for the legal discovery application."""
+
+from __future__ import annotations
+
+from typing import List
+
 from flask_sqlalchemy import SQLAlchemy
 
 db = SQLAlchemy()
+
+
+class IngestionLog(db.Model):
+    """Tracks document ingestions to ensure idempotency."""
+
+    __tablename__ = "ingestion_logs"
+
+    id = db.Column(db.Integer, primary_key=True)
+    case_id = db.Column(db.String(64), nullable=False)
+    path = db.Column(db.String(1024), nullable=False)
+    doc_id = db.Column(db.String(64), nullable=False, unique=True)
+    segment_hashes = db.Column(db.JSON, nullable=False, default=list)
+    status = db.Column(db.String(32), nullable=False, default="ingested")
+    created_at = db.Column(db.DateTime, server_default=db.func.now())
+
+
+def log_ingestion(
+    *, case_id: str, path: str, doc_id: str, segment_hashes: List[str]
+) -> None:
+    """Persist an ingestion event if it has not already been recorded."""
+
+    try:
+        if IngestionLog.query.filter_by(doc_id=doc_id).first():
+            return
+        entry = IngestionLog(
+            case_id=case_id, path=path, doc_id=doc_id, segment_hashes=segment_hashes
+        )
+        db.session.add(entry)
+        db.session.commit()
+    except Exception:  # pragma: no cover - best effort
+        try:
+            db.session.rollback()
+        except Exception:
+            pass
+

--- a/apps/legal_discovery/hippo.py
+++ b/apps/legal_discovery/hippo.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 import hashlib
 import re
-from typing import Dict, List
+from typing import Callable, Dict, List, Optional
 
 
 # ---------------------------------------------------------------------------
@@ -24,6 +24,7 @@ class Segment:
 
     doc_id: str
     segment_id: str
+    segment_hash: str
     text: str
     page: int
     para: int
@@ -46,35 +47,48 @@ def make_doc_id(case_id: str, path: str) -> str:
     return hashlib.sha256(f"{case_id}:{path}".encode()).hexdigest()[:32]
 
 
-def _segment_hash(doc_id: str, start: int, end: int) -> int:
+def _segment_hash(doc_id: str, start: int, end: int) -> str:
+    """Return a 64-bit hex hash for a text segment."""
+
     h = hashlib.sha256(f"{doc_id}:{start}:{end}".encode()).hexdigest()
     # first 16 hex = 64 bits
-    return int(h[:16], 16)
+    return h[:16]
 
 
-def chunk_text(text: str, doc_id: str, page: int = 1, tokens_per_chunk: int = 200) -> List[Segment]:
+def chunk_text(
+    text: str,
+    doc_id: str,
+    page: int = 1,
+    tokens_per_chunk: int = 200,
+    entity_extractor: Optional[Callable[[str], List[str]]] = None,
+) -> List[Segment]:
     """Deterministically split ``text`` into segments.
 
     Each segment id follows the ``doc_id:page:para:start-end`` pattern and a
     64-bit ``segment_hash`` is derived from these values.  Tokens are simple
-    whitespace splits which is adequate for the unit tests.
+    whitespace splits which is adequate for the unit tests.  The ``entity_extractor``
+    parameter allows callers to plug in a richer legal information extraction
+    routine.  When omitted, a tiny built-in extractor is used.
     """
 
     tokens = text.split()
     segments: List[Segment] = []
     para = 0
     t = 0
+    extractor = entity_extractor or _extract_entities
     while t < len(tokens):
         chunk_tokens = tokens[t : t + tokens_per_chunk]
         start = t
         end = t + len(chunk_tokens)
         segment_id = f"{doc_id}:{page}:{para}:{start}-{end}"
         seg_text = " ".join(chunk_tokens)
-        entities = _extract_entities(seg_text)
+        seg_hash = _segment_hash(doc_id, start, end)
+        entities = extractor(seg_text)
         segments.append(
             Segment(
                 doc_id=doc_id,
                 segment_id=segment_id,
+                segment_hash=seg_hash,
                 text=seg_text,
                 page=page,
                 para=para,
@@ -106,13 +120,99 @@ def _extract_entities(text: str) -> List[str]:
 # Ingestion / Query
 
 
-def ingest_document(case_id: str, text: str, path: str = "") -> str:
-    """Index ``text`` for ``case_id`` and return the generated ``doc_id``."""
+def ingest_document(
+    case_id: str,
+    text: str,
+    path: str = "",
+    *,
+    entity_extractor: Optional[Callable[[str], List[str]]] = None,
+    graph_db: Optional[object] = None,
+    vector_db: Optional[object] = None,
+) -> str:
+    """Index ``text`` for ``case_id`` and return the generated ``doc_id``.
+
+    The function accepts optional ``graph_db`` and ``vector_db`` managers to
+    perform bulk upserts to Neo4j and Chroma respectively.  Callers may also
+    supply a custom ``entity_extractor`` for legal information extraction.
+    """
 
     doc_id = make_doc_id(case_id, path or "inline")
-    segments = chunk_text(text, doc_id)
     case_index = INDEX.setdefault(case_id, {})
+    if doc_id in case_index:
+        return doc_id
+    segments = chunk_text(text, doc_id, entity_extractor=entity_extractor)
+
+    # In-memory index -----------------------------------------------------------------
     case_index[doc_id] = segments
+
+    # Bulk vector upsert ---------------------------------------------------------------
+    if vector_db:
+        try:  # pragma: no cover - best effort
+            vector_db.add_documents(
+                documents=[s.text for s in segments],
+                metadatas=[
+                    {
+                        "doc_id": doc_id,
+                        "case_id": case_id,
+                        "segment_id": s.segment_id,
+                        "segment_hash": s.segment_hash,
+                        "path": path,
+                    }
+                    for s in segments
+                ],
+                ids=[s.segment_hash for s in segments],
+            )
+        except Exception:
+            pass
+
+    # Bulk graph upsert ----------------------------------------------------------------
+    if graph_db and segments:
+        try:  # pragma: no cover - best effort
+            seg_dicts = [
+                {
+                    "hash": s.segment_hash,
+                    "text": s.text,
+                    "page": s.page,
+                    "para": s.para,
+                    "entities": s.entities,
+                }
+                for s in segments
+            ]
+            cypher = (
+                "MERGE (d:Document {doc_id: $doc_id}) "
+                "SET d.case_id=$case_id, d.path=$path "
+                "WITH d UNWIND $segments AS seg "
+                "MERGE (s:Segment {hash: seg.hash}) "
+                "SET s.text=seg.text, s.page=seg.page, s.para=seg.para "
+                "MERGE (d)-[:HAS_SEGMENT]->(s) "
+                "FOREACH (e IN seg.entities | MERGE (ent:Entity {key:e}) MERGE (s)-[:MENTIONS]->(ent))"
+            )
+            graph_db.run_query(
+                cypher,
+                {
+                    "doc_id": doc_id,
+                    "case_id": case_id,
+                    "path": path,
+                    "segments": seg_dicts,
+                },
+                cache=False,
+            )
+        except Exception:
+            pass
+
+    # Postgres ingestion log ----------------------------------------------------------
+    try:  # pragma: no cover - external dependency
+        from .database import log_ingestion
+
+        log_ingestion(
+            case_id=case_id,
+            path=path,
+            doc_id=doc_id,
+            segment_hashes=[s.segment_hash for s in segments],
+        )
+    except Exception:
+        pass
+
     return doc_id
 
 


### PR DESCRIPTION
## Summary
- add deterministic `segment_hash` and pluggable entity extraction
- bulk upsert segments to Neo4j and Chroma with idempotent hashes
- log document ingestions in Postgres via new `ingestion_logs` table

## Testing
- `pytest -q` *(fails: tests/apps/test_voice_ws_transcript.py::test_voice_ws_transcript_updates, tests/apps/test_voice_ws_transcript.py::test_voice_ws_auth_error)*

------
https://chatgpt.com/codex/tasks/task_e_68a253570658833385325f649099747b