### PR TITLE
feat: enrich hippo query with graph and vector reranking

### DIFF
--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -890,3 +890,8 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 - Bootstrapped Neo4j schema with constraints and indices in ``hippo.py`` and added upsert helpers.
 - Startup routine now ensures constraints run on application launch.
 - Next: validate Neo4j upserts against a live database service.
+
+## Update 2025-09-19T00:00Z
+- Added entity-linked query seeding with fallback tokens and merged Neo4j/Chroma candidate searches in ``hippo_query``.
+- Introduced simple cross-encoder re-ranking and expanded result paths with document nodes.
+- Next: wire to real GDS PPR and Chroma similarity APIs for richer scoring.


### PR DESCRIPTION
## Summary
- add graph and vector candidate helpers with entity-linked seeding and token fallback
- merge Neo4j/Chroma results, apply simple cross-encoder reranking, and expand result paths
- test query scoring fields and token-seed fallback

## Testing
- `pytest`
  - 2 failing (voice WS connection)
  - 66 passed

------
https://chatgpt.com/codex/tasks/task_e_68a2710835288333a6bb93c2c8f068e8