### PR TITLE
feat: add retrieval trace logging

### DIFF
--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -895,3 +895,8 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 - Added entity-linked query seeding with fallback tokens and merged Neo4j/Chroma candidate searches in ``hippo_query``.
 - Introduced simple cross-encoder re-ranking and expanded result paths with document nodes.
 - Next: wire to real GDS PPR and Chroma similarity APIs for richer scoring.
+
+## Update 2025-09-19T12:00Z
+- Logged retrieval traces with timing data and trace identifiers in Hippo routes.
+- Persisted queries to a new ``retrieval_traces`` table and added tests for path toggling.
+- Next: surface retrieval trace analytics in the dashboard UI.

--- a/apps/legal_discovery/database.py
+++ b/apps/legal_discovery/database.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import List
+from typing import Dict, List
 
 from flask_sqlalchemy import SQLAlchemy
 
@@ -33,6 +33,53 @@ def log_ingestion(
             return
         entry = IngestionLog(
             case_id=case_id, path=path, doc_id=doc_id, segment_hashes=segment_hashes
+        )
+        db.session.add(entry)
+        db.session.commit()
+    except Exception:  # pragma: no cover - best effort
+        try:
+            db.session.rollback()
+        except Exception:
+            pass
+
+
+class RetrievalTrace(db.Model):
+    """Persists retrieval query results for analysis."""
+
+    __tablename__ = "retrieval_traces"
+
+    id = db.Column(db.Integer, primary_key=True)
+    trace_id = db.Column(db.String(40), nullable=False, index=True)
+    case_id = db.Column(db.String(64), nullable=False)
+    query = db.Column(db.Text, nullable=False)
+    graph_weight = db.Column(db.Float, nullable=False, default=1.0)
+    dense_weight = db.Column(db.Float, nullable=False, default=1.0)
+    timings = db.Column(db.JSON, nullable=False)
+    results = db.Column(db.JSON, nullable=False)
+    created_at = db.Column(db.DateTime, server_default=db.func.now())
+
+
+def log_retrieval_trace(
+    *,
+    trace_id: str,
+    case_id: str,
+    query: str,
+    graph_weight: float,
+    dense_weight: float,
+    timings: Dict[str, float],
+    results: List[Dict],
+) -> None:
+    """Best-effort persistence of a retrieval trace."""
+
+    try:
+        entry = RetrievalTrace(
+            trace_id=trace_id,
+            case_id=case_id,
+            query=query,
+            graph_weight=graph_weight,
+            dense_weight=dense_weight,
+            timings=timings,
+            results=results,
         )
         db.session.add(entry)
         db.session.commit()


### PR DESCRIPTION
## Summary
- allow Hippo query to accept `graph_weight`, `dense_weight`, and `return_paths`
- log query timings and persist results to new `retrieval_traces` table
- expose trace identifiers and timings in responses

## Testing
- `pytest tests/apps/test_hippo_query.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a27585e8748333a17073e67b626e9e