### PR TITLE
chore: upgrade neo4j and add rag deps

### DIFF
--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -910,3 +910,8 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 - Introduced RetrievalTrace, ObjectionEvent and ObjectionResolution models with migrations.
 - Trial and Hippo modules now log retrieval traces and link objection events via shared trace_ids.
 - Next: expose trace analytics in the dashboard and enrich objection paths.
+
+## Update 2025-09-21T00:00Z
+- Added HippoRAG, sentence-transformers and scikit-learn dependencies; bumped Neo4j to 5.23.
+- Documented EMBED_MODEL and CROSS_ENCODER_MODEL environment variables.
+- Next: build Docker image and verify retrieval models load correctly.

--- a/apps/legal_discovery/README.md
+++ b/apps/legal_discovery/README.md
@@ -24,6 +24,15 @@ Docker Compose reads `NEO4J_PASSWORD` for both the app and database services so
 they always share the same credentials. If the variable is empty, the database
 starts without authentication which is convenient for local testing.
 
+### Model configuration
+
+Set optional environment variables to customise the retrieval models used by HippoRAG:
+
+- `EMBED_MODEL` – embedding model name, for example `sentence-transformers/all-MiniLM-L6-v2`.
+- `CROSS_ENCODER_MODEL` – cross-encoder model for reranking, e.g. `cross-encoder/ms-marco-MiniLM-L-6-v2`.
+
+Add these variables to your `.env` file to override the defaults.
+
 ## Running with Docker Compose
 
 From the project root run:

--- a/apps/legal_discovery/requirements.txt
+++ b/apps/legal_discovery/requirements.txt
@@ -31,6 +31,10 @@ TTS
 pyttsx3
 redis
 
+hipporag
+sentence-transformers
+scikit-learn
+
 en-core-web-sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.7.1/en_core_web_sm-3.7.1-py3-none-any.whl
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
     restart: unless-stopped
 
   neo4j:
-    image: neo4j:4.4
+    image: neo4j:5.23
     ports:
       - "7474:7474"
       - "7687:7687"


### PR DESCRIPTION
## Summary
- update docker compose to run neo4j:5.23
- add hipporag, sentence-transformers and scikit-learn dependencies
- document EMBED_MODEL and CROSS_ENCODER_MODEL variables for retrieval tuning

## Testing
- `pytest` *(fails: KeyboardInterrupt during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a28d67358083338e5a43f47444192a