### PR TITLE
Add health endpoint and container healthchecks

### DIFF
--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -915,3 +915,8 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 - Added HippoRAG, sentence-transformers and scikit-learn dependencies; bumped Neo4j to 5.23.
 - Documented EMBED_MODEL and CROSS_ENCODER_MODEL environment variables.
 - Next: build Docker image and verify retrieval models load correctly.
+
+## Update 2025-09-22T00:00Z
+- Added `/api/health` endpoint checking Neo4j and Chroma connectivity.
+- Dockerfile and compose now use this route for container health checks.
+- Next: monitor service health and expand diagnostics.

--- a/apps/legal_discovery/Dockerfile
+++ b/apps/legal_discovery/Dockerfile
@@ -31,6 +31,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       libxml2 libxslt1.1 fonts-liberation \
       tesseract-ocr tesseract-ocr-eng \
       ffmpeg libsndfile1 espeak \
+      curl \
     && rm -rf /var/lib/apt/lists/*
 
 # Upgrade pip/setuptools first
@@ -57,6 +58,8 @@ RUN rm -rf apps/legal_discovery/node_modules
 
 # Expose app port
 EXPOSE 5001
+
+HEALTHCHECK --interval=30s --timeout=5s --retries=5 CMD curl -f http://localhost:5001/api/health || exit 1
 
 # Environment defaults (can be overridden at runtime)
 ENV AGENT_MANIFEST_FILE=/usr/src/app/registries/manifest.hocon \

--- a/apps/legal_discovery/interface_flask.py
+++ b/apps/legal_discovery/interface_flask.py
@@ -14,6 +14,12 @@ from difflib import SequenceMatcher
 from io import BytesIO, StringIO
 import csv
 import difflib
+import requests
+
+try:  # pragma: no cover - optional dependency
+    from neo4j import GraphDatabase
+except Exception:  # pragma: no cover - driver may be absent
+    GraphDatabase = None
 
 # pylint: disable=import-error
 import schedule
@@ -169,6 +175,40 @@ bates_service = BatesNumberingService()
 def metrics() -> Response:
     """Expose Prometheus metrics."""
     return Response(generate_latest(), mimetype=CONTENT_TYPE_LATEST)
+
+
+@app.get("/api/health")
+def health() -> Response:
+    """Report connectivity status for Neo4j and Chroma services."""
+    neo4j_status = "ok"
+    chroma_status = "ok"
+
+    try:  # pragma: no cover - external service
+        if GraphDatabase is None:
+            raise RuntimeError("neo4j driver missing")
+        uri = os.environ.get("NEO4J_URI", "bolt://neo4j:7687")
+        user = os.environ.get("NEO4J_USER", "neo4j")
+        pwd = os.environ.get("NEO4J_PASSWORD")
+        auth = (user, pwd) if pwd else None
+        db = os.environ.get("NEO4J_DATABASE", "neo4j")
+        with GraphDatabase.driver(uri, auth=auth) as driver:
+            with driver.session(database=db) as session:
+                session.run("RETURN 1")
+    except Exception:
+        neo4j_status = "fail"
+
+    try:  # pragma: no cover - external service
+        host = os.environ.get("CHROMA_HOST", "localhost")
+        port = int(os.environ.get("CHROMA_PORT", "8000"))
+        resp = requests.get(
+            f"http://{host}:{port}/api/v1/heartbeat", timeout=2
+        )
+        if resp.status_code != 200:
+            raise RuntimeError("chroma heartbeat failed")
+    except Exception:
+        chroma_status = "fail"
+
+    return jsonify({"neo4j": neo4j_status, "chroma": chroma_status})
 
 # Shared crawler instance for legal references
 legal_crawler = LegalCrawler()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,11 @@ services:
       - ./docker_volumes/legal_discovery/uploads:/usr/src/app/uploads
       - ./docker_volumes/legal_discovery/audio_cache:/usr/src/app/audio_cache
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:5001/api/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
 
   postgres:
     image: postgres:16-alpine


### PR DESCRIPTION
## Summary
- expose `/api/health` route reporting Neo4j and Chroma status
- add Dockerfile and compose healthchecks using this endpoint
- log update in `AGENTS.md`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a32c07b1188333ac84e475e3e55c0f