### PR TITLE
feat: log idempotent hippo ingestion

### DIFF
--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -920,3 +920,8 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 - Added `/api/health` endpoint checking Neo4j and Chroma connectivity.
 - Dockerfile and compose now use this route for container health checks.
 - Next: monitor service health and expand diagnostics.
+
+## Update 2025-09-22T12:00Z
+- Added content-hashed segment IDs with pluggable legal IE and bulk Neo4j/Chroma upserts.
+- Introduced `ingestion_logs` table to track status, timing and failures for idempotent indexing.
+- Next: validate graph/vector batch operations against live services and expand ingestion telemetry.


### PR DESCRIPTION
## Summary
- hash segment text to generate deterministic IDs and pluggable legal IE extraction
- bulk-upsert documents, segments, entities and facts to Neo4j and Chroma
- track ingestion status, timing and failures in new Postgres `ingestion_logs`

## Testing
- `pytest tests/apps -q`

------
https://chatgpt.com/codex/tasks/task_e_68a34382f8f08333a2cc1e2c23184261