### PR TITLE
Add hippo extraction, graph and load test coverage

### DIFF
--- a/condensed AGENTS.md
+++ b/condensed AGENTS.md
@@ -179,3 +179,9 @@ we are now working on implementing a major feature, so stand by, this is  A GDDM
 ## Update 2025-09-16T00:00Z
 - Mocked speech engines and added tests for command routing, auth errors, message bus alerts, streaming transcripts and objection detection.
 - Next: expand coverage for additional voice workflows.
+
+## Update 2025-09-16T12:00Z
+- Added unit tests for extractor typing, Neo4j upsert idempotency, and segment hashing.
+- Introduced integration test for hybrid retrieval paths and objection events with refs.
+- Implemented load test harness for 200 concurrent /api/hippo/query calls asserting p95 latency.
+- Next: extend load metrics and broaden graph retrieval coverage.

--- a/tests/apps/test_hippo_units.py
+++ b/tests/apps/test_hippo_units.py
@@ -1,0 +1,48 @@
+from typing import Dict, List
+
+from apps.legal_discovery.hippo import (
+    _segment_hash,
+    chunk_text,
+    make_doc_id,
+    upsert_document_and_segments,
+)
+
+
+def test_entity_extractor_typing_accepts_list_and_dict():
+    doc_id = make_doc_id("case", "path.txt")
+    text = "Alice met Bob."
+
+    def list_extractor(t: str) -> List[str]:
+        return ["alice", "bob"]
+
+    segs = chunk_text(text, doc_id, entity_extractor=list_extractor)
+    assert segs[0].entities == ["alice", "bob"]
+    assert segs[0].facts == []
+
+    def dict_extractor(t: str) -> Dict[str, object]:
+        return {"entities": ["carol"], "facts": [("k", "s", "o")]}  # type: ignore[arg-type]
+
+    segs2 = chunk_text(text, doc_id, entity_extractor=dict_extractor)
+    assert segs2[0].entities == ["carol"]
+    assert segs2[0].facts == [("k", "s", "o")]
+
+
+def test_segment_hashing_deterministic_and_unique():
+    h1 = _segment_hash("some text")
+    h2 = _segment_hash("some text")
+    h3 = _segment_hash("other text")
+    assert h1 == h2
+    assert h1 != h3
+    assert len(h1) == 16
+
+
+def test_upsert_document_and_segments_idempotent():
+    segs = [
+        {"hash": "h1", "text": "seg", "page": 1, "para": 0, "entities": [], "facts": []}
+    ]
+    cypher1, params1 = upsert_document_and_segments("d1", "c1", "p.txt", segs)
+    cypher2, params2 = upsert_document_and_segments("d1", "c1", "p.txt", segs)
+    assert cypher1 == cypher2
+    assert params1 == params2
+    assert "MERGE (d:Document" in cypher1
+    assert "MERGE (s:Segment" in cypher1

--- a/tests/apps/test_hybrid_objection_integration.py
+++ b/tests/apps/test_hybrid_objection_integration.py
@@ -1,0 +1,72 @@
+from flask import Flask
+
+from apps.legal_discovery.database import db, RetrievalTrace
+from apps.legal_discovery.extensions import socketio
+from apps.legal_discovery.hippo_routes import bp as hippo_bp
+from apps.legal_discovery.objection_routes import bp as objections_bp
+from apps.legal_discovery.trial_assistant import bp as trial_bp
+from apps.legal_discovery.models_trial import TrialSession
+from apps.legal_discovery import hippo
+
+
+def _create_app():
+    app = Flask(__name__)
+    app.config.update(
+        SQLALCHEMY_DATABASE_URI="sqlite://",
+        SQLALCHEMY_TRACK_MODIFICATIONS=False,
+    )
+    db.init_app(app)
+    socketio.init_app(app, logger=False, engineio_logger=False)
+    app.register_blueprint(hippo_bp)
+    app.register_blueprint(trial_bp)
+    app.register_blueprint(objections_bp)
+    with app.app_context():
+        db.create_all()
+    return app
+
+
+def test_hybrid_retrieval_path_and_objection_refs():
+    app = _create_app()
+    client = app.test_client()
+    # Seed small graph via hippo indexing
+    hippo.INDEX.clear()
+    client.post(
+        "/api/hippo/index",
+        json={"case_id": "c1", "text": "Alice met Bob at Acme."},
+    )
+    res = client.post(
+        "/api/hippo/query",
+        json={"case_id": "c1", "query": "Bob"},
+    )
+    assert res.status_code == 200
+    first = res.get_json()["items"][0]
+    assert first["path"][0]["type"] == "Document"
+    assert any(n["type"] == "Entity" for n in first["path"])
+    assert first["path"][-1]["type"] == "Segment"
+
+    # Prepare trial session and analyze segment for objections
+    sock = socketio.test_client(app, namespace="/ws/trial")
+    sock.emit("join", {"session_id": "trial_objections"}, namespace="/ws/trial")
+    with app.app_context():
+        hippo.INDEX.clear()
+        hippo.ingest_document("c1", "this is hearsay evidence", "doc.txt")
+        sess = TrialSession(id="s1", case_id="c1")
+        db.session.add(sess)
+        db.session.commit()
+    res2 = client.post(
+        "/api/objections/analyze-segment",
+        json={
+            "session_id": "s1",
+            "text": "that's hearsay",
+            "t0_ms": 0,
+            "t1_ms": 1,
+            "speaker": "witness",
+            "confidence": 100,
+        },
+    )
+    assert res2.status_code == 200
+    received = sock.get_received("/ws/trial")
+    assert any(r["name"] == "objection_event" and r["args"][0]["refs"] for r in received)
+    with app.app_context():
+        traces = db.session.query(RetrievalTrace).all()
+        assert any(t.results for t in traces)

--- a/tests/apps/test_load.py
+++ b/tests/apps/test_load.py
@@ -1,0 +1,36 @@
+import time
+from concurrent.futures import ThreadPoolExecutor
+from typing import List
+
+from flask import Flask
+
+from apps.legal_discovery.hippo_routes import bp as hippo_bp
+
+
+def _create_app() -> Flask:
+    app = Flask(__name__)
+    app.register_blueprint(hippo_bp)
+    return app
+
+
+def _do_query(app: Flask) -> float:
+    with app.test_client() as client:
+        t0 = time.perf_counter()
+        res = client.post(
+            "/api/hippo/query", json={"case_id": "c1", "query": "Bob"}
+        )
+        assert res.status_code == 200
+        return time.perf_counter() - t0
+
+
+def test_p95_latency_under_500ms():
+    app = _create_app()
+    with app.test_client() as client:
+        client.post(
+            "/api/hippo/index", json={"case_id": "c1", "text": "Alice met Bob."}
+        )
+    with ThreadPoolExecutor(max_workers=50) as ex:
+        latencies: List[float] = list(ex.map(lambda _: _do_query(app), range(200)))
+    latencies.sort()
+    p95 = latencies[int(len(latencies) * 0.95) - 1]
+    assert p95 < 0.5


### PR DESCRIPTION
## Summary
- Cover `hippo` utilities with extractor typing, segment hash, and Neo4j upsert idempotency unit tests
- Seed a tiny graph to verify hybrid retrieval paths and objection refs in integration test
- Add load harness simulating 200 `/api/hippo/query` calls and asserting p95 latency

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3496e6be08333b6557f4c671dab1f