### PR TITLE
Ensure Neo4j schema bootstrap at startup

### DIFF
--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -930,3 +930,8 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 - Bootstrapped Neo4j schema during app start and added container startup check.
 - Implemented document/segment and edge upsert helpers for Hippo ingestion.
 - Next: validate schema and upsert operations against a live Neo4j service.
+
+## Update 2025-09-22T20:00Z
+- Refactored graph bootstrap to reuse shared schema helper and wired Dockerfile to run it before gunicorn.
+- Ensured container startup applies Neo4j 5.23 constraints and indexes automatically.
+- Next: exercise upsert routines against a live Neo4j instance.

--- a/apps/legal_discovery/Dockerfile
+++ b/apps/legal_discovery/Dockerfile
@@ -65,5 +65,5 @@ HEALTHCHECK --interval=30s --timeout=5s --retries=5 CMD curl -f http://localhost
 ENV AGENT_MANIFEST_FILE=/usr/src/app/registries/manifest.hocon \
     AGENT_LLM_INFO_FILE=/usr/src/app/registries/llm_config.hocon
 
-# Run the Flask app via gunicorn+eventlet
-CMD ["python", "-m", "gunicorn", "-k", "eventlet", "-w", "1", "-b", "0.0.0.0:5001", "apps.legal_discovery.interface_flask:app"]
+# Run the Flask app via gunicorn+eventlet after ensuring Neo4j schema
+CMD ["bash", "-c", "python -c 'from apps.legal_discovery import bootstrap_graph; bootstrap_graph()' && python -m gunicorn -k eventlet -w 1 -b 0.0.0.0:5001 apps.legal_discovery.interface_flask:app"]

--- a/apps/legal_discovery/__init__.py
+++ b/apps/legal_discovery/__init__.py
@@ -9,13 +9,13 @@ try:  # pragma: no cover - allow tests without Neo4j installed
 except Exception:  # pragma: no cover - fallback when driver unavailable
     GraphDatabase = None
 
-from .hippo import SCHEMA_QUERIES
+from .hippo import setup_neo4j_schema
 
 __all__ = ["create_app", "bootstrap_graph"]
 
 
 def bootstrap_graph() -> None:
-    """Apply Neo4j constraints and indexes if possible."""
+    """Apply Neo4j 5.23 constraints and indexes if possible."""
 
     if not GraphDatabase:  # pragma: no cover - driver not installed
         return
@@ -29,9 +29,7 @@ def bootstrap_graph() -> None:
     driver = None
     try:  # pragma: no cover - external dependency
         driver = GraphDatabase.driver(uri, auth=auth)
-        with driver.session(database=db) as session:
-            for query in SCHEMA_QUERIES:
-                session.run(query)
+        setup_neo4j_schema(driver, db)
     except Exception:
         pass
     finally:  # pragma: no cover - ensure closure

--- a/apps/legal_discovery/hippo.py
+++ b/apps/legal_discovery/hippo.py
@@ -181,7 +181,11 @@ def _extract_entities(text: str) -> List[str]:
 def upsert_document_and_segments(
     doc_id: str, case_id: str, path: str, segments: List[dict]
 ) -> tuple[str, dict]:
-    """Return Cypher and parameters to upsert document segments."""
+    """Return Cypher and parameters to upsert document segments.
+
+    The statement merges ``Document`` and ``Segment`` nodes alongside
+    related ``Entity`` and ``Fact`` nodes using the Neo4j 5.23 templates.
+    """
 
     cypher = (
         "\n".join(
@@ -218,7 +222,7 @@ def upsert_document_and_segments(
 
 
 def upsert_graph(edges: Iterable[dict]) -> tuple[str, dict]:
-    """Return Cypher and parameters to upsert generic edges."""
+    """Return Cypher and parameters to upsert generic edges between segments."""
 
     cypher = "\n".join(
         [


### PR DESCRIPTION
## Summary
- Refactor Neo4j bootstrap to use shared schema helper and apply 5.23 constraints and indexes.
- Document HippoRAG upsert templates for documents and graph edges.
- Run schema setup on container start before launching gunicorn.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3b869c8d08333af997f11e6396831