### PR TITLE
refactor: centralize graph bootstrap across legal discovery

### DIFF
--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -940,3 +940,8 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 - Added entity-linked query seeding fallback and integrated Neo4j GDS PPR plus Chroma retrieval in `hippo_query`.
 - Introduced optional cross-encoder re-ranking with merged graph/dense/LLM scores and path expansion.
 - Next: validate retrieval quality against real services and tune re-ranker weights.
+
+## Update 2025-09-23T12:00Z
+- Consolidated Neo4j schema bootstrap via shared `bootstrap_graph` helper and removed legacy `ensure_graph_constraints`.
+- `hippo_routes` and `interface_flask` now invoke `bootstrap_graph` on load.
+- Next: verify redundant calls are trimmed once live Neo4j integration is confirmed.

--- a/apps/legal_discovery/hippo.py
+++ b/apps/legal_discovery/hippo.py
@@ -87,28 +87,6 @@ def setup_neo4j_schema(driver: Driver, database: str | None = None) -> None:
             session.run(q)
 
 
-def ensure_graph_constraints() -> None:
-    """Best-effort schema bootstrap using environment variables."""
-
-    if not GraphDatabase:  # pragma: no cover - driver not installed
-        return
-    uri = os.environ.get("NEO4J_URI", "bolt://neo4j:7687")
-    user = os.environ.get("NEO4J_USER", "neo4j")
-    pwd = os.environ.get("NEO4J_PASSWORD")
-    auth = (user, pwd) if pwd else None
-    db = os.environ.get("NEO4J_DATABASE", "neo4j")
-    try:  # pragma: no cover - external dependency
-        driver = GraphDatabase.driver(uri, auth=auth)
-        setup_neo4j_schema(driver, db)
-    except Exception:
-        pass
-    finally:  # pragma: no cover - ensure closure
-        try:
-            driver.close()
-        except Exception:
-            pass
-
-
 # ---------------------------------------------------------------------------
 # Helpers
 

--- a/apps/legal_discovery/hippo_routes.py
+++ b/apps/legal_discovery/hippo_routes.py
@@ -6,8 +6,10 @@ import time
 
 from flask import Blueprint, jsonify, request
 
-from . import hippo
+from . import hippo, bootstrap_graph
 from .database import log_retrieval_trace
+
+bootstrap_graph()
 
 bp = Blueprint("hippo", __name__, url_prefix="/api/hippo")
 

--- a/apps/legal_discovery/interface_flask.py
+++ b/apps/legal_discovery/interface_flask.py
@@ -53,8 +53,10 @@ from more_itertools import chunked
 from pyhocon import ConfigFactory
 from werkzeug.utils import secure_filename
 
-from apps.legal_discovery import settings
-from apps.legal_discovery.database import db
+from . import settings, bootstrap_graph
+from .database import db
+
+bootstrap_graph()
 from coded_tools.legal_discovery.deposition_prep import DepositionPrep
 from apps.legal_discovery.models import (
     Agent,


### PR DESCRIPTION
## Summary
- drop unused `ensure_graph_constraints` in Hippo module and rely on `bootstrap_graph`
- call shared `bootstrap_graph` during Hippo API and Flask interface imports
- log consolidation in legal discovery AGENTS file

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a47d6e6b948333b99f501028cb54f5