### PR TITLE
feat: log retrieval traces with weights

### DIFF
--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -949,3 +949,8 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 ## Update 2025-09-23T18:00Z
 - Safeguarded Neo4j driver initialization and cleanup in `hippo.py`.
 - Next: validate failure paths when Neo4j is unreachable.
+
+## Update 2025-09-24T00:00Z
+- Added query weighting, path toggling and trace timing to `hippo_routes` with persistence to `retrieval_traces`.
+- Extended tests for score weighting and retrieval trace logging.
+- Next: surface retrieval trace analytics in the dashboard UI.

--- a/tests/apps/test_hippo_query.py
+++ b/tests/apps/test_hippo_query.py
@@ -1,7 +1,9 @@
 from flask import Flask
+import pytest
 
 from apps.legal_discovery.hippo import chunk_text, make_doc_id
 from apps.legal_discovery.hippo_routes import bp as hippo_bp
+from apps.legal_discovery.database import db, RetrievalTrace
 
 
 def _create_app():
@@ -83,3 +85,44 @@ def test_query_return_paths_toggle():
     )
     first = res.get_json()["items"][0]
     assert "path" not in first
+
+
+def test_query_score_weights():
+    app = _create_app()
+    client = app.test_client()
+    client.post(
+        "/api/hippo/index",
+        json={"case_id": "c1", "text": "Alice met Bob at Acme."},
+    )
+    base = client.post(
+        "/api/hippo/query", json={"case_id": "c1", "query": "Bob"}
+    ).get_json()
+    weighted = client.post(
+        "/api/hippo/query",
+        json={"case_id": "c1", "query": "Bob", "graph_weight": 2.0},
+    ).get_json()
+    default_graph = base["items"][0]["scores"]["graph"]
+    boosted_graph = weighted["items"][0]["scores"]["graph"]
+    assert pytest.approx(boosted_graph, rel=1e-6) == default_graph * 2
+
+
+def test_query_logs_retrieval_trace():
+    app = Flask(__name__)
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite://"
+    app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
+    db.init_app(app)
+    app.register_blueprint(hippo_bp)
+    with app.app_context():
+        db.create_all()
+        client = app.test_client()
+        client.post(
+            "/api/hippo/index",
+            json={"case_id": "c1", "text": "Alice met Bob at Acme."},
+        )
+        res = client.post(
+            "/api/hippo/query", json={"case_id": "c1", "query": "Bob"}
+        )
+        trace_id = res.get_json()["trace_id"]
+        trace = db.session.query(RetrievalTrace).filter_by(trace_id=trace_id).first()
+        assert trace is not None
+        assert trace.results


### PR DESCRIPTION
## Summary
- extend Hippo query route to accept `graph_weight`, `dense_weight`, and `return_paths`
- generate `trace_id`, record query/format timings, and persist results to `retrieval_traces`
- add tests for weight scaling and retrieval trace persistence

## Testing
- `pytest tests/apps/test_hippo_query.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4cf347bb88333824f7683924d985e