### PR TITLE
Add retrieval and objection models with logging helpers

### DIFF
--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -959,3 +959,8 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 - Implemented `/api/objections/analyze-segment` in `hippo_routes` with Hippo citation refs and Socket.IO broadcast.
 - Added `objection_cure_chosen` handler to clear highlights and persist cures.
 - Next: refine citation ranking and broaden highlight clearing strategies.
+
+## Update 2025-09-24T18:00Z
+- Moved RetrievalTrace, ObjectionEvent and ObjectionResolution models into `models.py` and added logging helpers.
+- Ensured retrieval traces and objections share trace_ids for auditability.
+- Next: surface trace analytics in the dashboard UI.

--- a/apps/legal_discovery/hippo_routes.py
+++ b/apps/legal_discovery/hippo_routes.py
@@ -8,14 +8,10 @@ import uuid
 from flask import Blueprint, jsonify, request
 
 from . import hippo, bootstrap_graph
-from .database import db, log_retrieval_trace
+from .database import db, log_retrieval_trace, log_objection_resolution
 from .extensions import socketio
-from .models_trial import (
-    TranscriptSegment,
-    TrialSession,
-    ObjectionEvent,
-    ObjectionResolution,
-)
+from .models import ObjectionEvent, ObjectionResolution
+from .models_trial import TranscriptSegment, TrialSession
 from .trial_assistant.services.objection_engine import engine
 
 bootstrap_graph()
@@ -167,9 +163,7 @@ def objection_cure_chosen(data):
     cure = data.get("cure")
     if not evt_id:
         return
-    resolution = ObjectionResolution(event_id=evt_id, chosen_cure=cure)
-    db.session.add(resolution)
-    db.session.commit()
+    log_objection_resolution(event_id=evt_id, chosen_cure=cure)
     evt = db.session.get(ObjectionEvent, evt_id)
     if evt:
         socketio.emit(

--- a/apps/legal_discovery/models.py
+++ b/apps/legal_discovery/models.py
@@ -612,3 +612,48 @@ class LessonProgress(db.Model):
             "thumbs_up": self.thumbs_up,
             "updated_at": self.updated_at.isoformat() if self.updated_at else None,
         }
+
+
+class RetrievalTrace(db.Model):
+    """Persists retrieval query results for analysis."""
+
+    __tablename__ = "retrieval_traces"
+
+    id = db.Column(db.Integer, primary_key=True)
+    trace_id = db.Column(db.String(40), nullable=False, index=True)
+    case_id = db.Column(db.String(64), nullable=False)
+    query = db.Column(db.Text, nullable=False)
+    graph_weight = db.Column(db.Float, nullable=False, default=1.0)
+    dense_weight = db.Column(db.Float, nullable=False, default=1.0)
+    timings = db.Column(db.JSON, nullable=False)
+    results = db.Column(db.JSON, nullable=False)
+    created_at = db.Column(db.DateTime, server_default=db.func.now())
+
+
+class ObjectionEvent(db.Model):
+    __tablename__ = "objection_events"
+
+    id = db.Column(db.String, primary_key=True, default=lambda: str(uuid.uuid4()))
+    session_id = db.Column(db.String, index=True)
+    segment_id = db.Column(db.String, index=True)
+    trace_id = db.Column(db.String(40), index=True)
+    ts = db.Column(db.DateTime, default=datetime.utcnow)
+    type = db.Column(db.String)
+    ground = db.Column(db.String)
+    confidence = db.Column(db.Integer)
+    extracted_phrase = db.Column(db.String)
+    suggested_cures = db.Column(db.JSON)
+    refs = db.Column(db.JSON)
+    path = db.Column(db.JSON)
+    action_taken = db.Column(db.String)
+    outcome = db.Column(db.String)
+
+
+class ObjectionResolution(db.Model):
+    __tablename__ = "objection_resolutions"
+
+    id = db.Column(db.String, primary_key=True, default=lambda: str(uuid.uuid4()))
+    event_id = db.Column(db.String, db.ForeignKey("objection_events.id"), index=True)
+    chosen_cure = db.Column(db.String)
+    ts = db.Column(db.DateTime, default=datetime.utcnow)
+

--- a/apps/legal_discovery/models_trial.py
+++ b/apps/legal_discovery/models_trial.py
@@ -66,27 +66,3 @@ class StrategySuggestion(db.Model):
     confidence = db.Column(db.Integer)
 
 
-class ObjectionEvent(db.Model):
-    __tablename__ = "objection_events"
-    id = db.Column(db.String, primary_key=True, default=uuid4)
-    session_id = db.Column(db.String, index=True)
-    segment_id = db.Column(db.String, index=True)
-    trace_id = db.Column(db.String(40), index=True)
-    ts = db.Column(db.DateTime, default=datetime.utcnow)
-    type = db.Column(db.String)
-    ground = db.Column(db.String)
-    confidence = db.Column(db.Integer)
-    extracted_phrase = db.Column(db.String)
-    suggested_cures = db.Column(db.JSON)
-    refs = db.Column(db.JSON)
-    path = db.Column(db.JSON)
-    action_taken = db.Column(db.String)
-    outcome = db.Column(db.String)
-
-
-class ObjectionResolution(db.Model):
-    __tablename__ = "objection_resolutions"
-    id = db.Column(db.String, primary_key=True, default=uuid4)
-    event_id = db.Column(db.String, db.ForeignKey("objection_events.id"), index=True)
-    chosen_cure = db.Column(db.String)
-    ts = db.Column(db.DateTime, default=datetime.utcnow)

--- a/apps/legal_discovery/trial_assistant/__init__.py
+++ b/apps/legal_discovery/trial_assistant/__init__.py
@@ -4,11 +4,8 @@ from flask_socketio import emit, join_room
 import time
 from ..extensions import socketio
 from ..database import db, log_retrieval_trace
-from ..models_trial import (
-    TranscriptSegment,
-    ObjectionEvent,
-    TrialSession,
-)
+from ..models import ObjectionEvent
+from ..models_trial import TranscriptSegment, TrialSession
 from .. import hippo
 from .services.objection_engine import engine
 

--- a/tests/apps/test_hippo_query.py
+++ b/tests/apps/test_hippo_query.py
@@ -3,7 +3,8 @@ import pytest
 
 from apps.legal_discovery.hippo import chunk_text, make_doc_id
 from apps.legal_discovery.hippo_routes import bp as hippo_bp
-from apps.legal_discovery.database import db, RetrievalTrace
+from apps.legal_discovery.database import db
+from apps.legal_discovery.models import RetrievalTrace
 
 
 def _create_app():

--- a/tests/apps/test_hybrid_objection_integration.py
+++ b/tests/apps/test_hybrid_objection_integration.py
@@ -1,9 +1,10 @@
 from flask import Flask
 
-from apps.legal_discovery.database import db, RetrievalTrace
+from apps.legal_discovery.database import db
 from apps.legal_discovery.extensions import socketio
 from apps.legal_discovery.hippo_routes import bp as hippo_bp, objections_bp
 from apps.legal_discovery.trial_assistant import bp as trial_bp
+from apps.legal_discovery.models import RetrievalTrace
 from apps.legal_discovery.models_trial import TrialSession
 from apps.legal_discovery import hippo
 

--- a/tests/apps/test_objection_engine_regression.py
+++ b/tests/apps/test_objection_engine_regression.py
@@ -1,11 +1,8 @@
 from flask import Flask
 
 from apps.legal_discovery.database import db
-from apps.legal_discovery.models_trial import (
-    TrialSession,
-    TranscriptSegment,
-    ObjectionEvent,
-)
+from apps.legal_discovery.models import ObjectionEvent
+from apps.legal_discovery.models_trial import TrialSession, TranscriptSegment
 from apps.legal_discovery.trial_assistant.services.objection_engine import (
     ObjectionEngine,
 )

--- a/tests/apps/test_objection_route.py
+++ b/tests/apps/test_objection_route.py
@@ -1,15 +1,11 @@
 from flask import Flask
 
 from apps.legal_discovery.extensions import socketio
-from apps.legal_discovery.database import db, RetrievalTrace
+from apps.legal_discovery.database import db
 from apps.legal_discovery.trial_assistant import bp as trial_bp
 from apps.legal_discovery.hippo_routes import objections_bp
-from apps.legal_discovery.models_trial import (
-    TrialSession,
-    ObjectionEvent,
-    ObjectionResolution,
-    TranscriptSegment,
-)
+from apps.legal_discovery.models import ObjectionEvent, ObjectionResolution, RetrievalTrace
+from apps.legal_discovery.models_trial import TrialSession, TranscriptSegment
 from apps.legal_discovery.trial_assistant.services.objection_engine import engine
 from apps.legal_discovery import hippo
 

--- a/tests/apps/test_trial_objection_ws.py
+++ b/tests/apps/test_trial_objection_ws.py
@@ -1,9 +1,10 @@
 from flask import Flask
 
 from apps.legal_discovery.extensions import socketio
-from apps.legal_discovery.database import db, RetrievalTrace
+from apps.legal_discovery.database import db
 from apps.legal_discovery.trial_assistant import bp
-from apps.legal_discovery.models_trial import ObjectionEvent, TrialSession
+from apps.legal_discovery.models import ObjectionEvent, RetrievalTrace
+from apps.legal_discovery.models_trial import TrialSession
 from apps.legal_discovery import hippo
 
 

--- a/tests/coded_tools/legal_discovery/test_objection_engine.py
+++ b/tests/coded_tools/legal_discovery/test_objection_engine.py
@@ -1,16 +1,19 @@
 from types import SimpleNamespace
 
-from apps.legal_discovery.trial_assistant.services.objection_engine import ObjectionEngine, db
-
-
-def noop(*args, **kwargs):
-    return None
+from apps.legal_discovery.trial_assistant.services.objection_engine import ObjectionEngine
+from apps.legal_discovery.models import ObjectionEvent
 
 
 def test_counter_objection_detection(monkeypatch):
     engine = ObjectionEngine()
-    monkeypatch.setattr(db.session, "add", noop)
-    monkeypatch.setattr(db.session, "commit", noop)
+
+    def fake_log(**kwargs):
+        return ObjectionEvent(**kwargs)
+
+    monkeypatch.setattr(
+        "apps.legal_discovery.trial_assistant.services.objection_engine.log_objection_event",
+        fake_log,
+    )
     seg = SimpleNamespace(id="s1", text="That was an excited utterance")
     events = engine.analyze_segment("sess", seg)
     assert any(e.type == "counter" and e.ground == "hearsay" for e in events)


### PR DESCRIPTION
## Summary
- add RetrievalTrace, ObjectionEvent, and ObjectionResolution models to `models.py`
- include DB helpers for logging traces, objection events, and resolutions
- update trial and hippo flows and tests to use shared `trace_id`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4da8c1de483338c344a1161eb8a9a