### PR TITLE
Align Neo4j defaults and document retrieval models

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -85,3 +85,7 @@ BRAVE_TIMEOUT=30
 NEO4J_URI=bolt://neo4j:7687
 NEO4J_USER=neo4j
 NEO4J_PASSWORD=neo4jPass123
+
+# Retrieval model configuration
+EMBED_MODEL=sentence-transformers/all-MiniLM-L6-v2
+CROSS_ENCODER_MODEL=cross-encoder/ms-marco-MiniLM-L-6-v2

--- a/README.md
+++ b/README.md
@@ -363,6 +363,29 @@ For examples of agent networks, check out [docs/examples.md](docs/examples.md).
 
 ---
 
+## Legal Discovery Docker Setup
+
+The `apps/legal_discovery` stack runs a Flask frontend backed by PostgreSQL, Neo4j, ChromaDB and Redis. To launch the full stack with Docker:
+
+1. Copy `.env.example` to `.env` and set required secrets. At minimum set the shared Neo4j password and optionally override the retrieval models:
+
+   ```bash
+   NEO4J_PASSWORD=neo4jPass123
+   EMBED_MODEL=sentence-transformers/all-MiniLM-L6-v2
+   CROSS_ENCODER_MODEL=cross-encoder/ms-marco-MiniLM-L-6-v2
+   ```
+
+2. Build and start the services:
+
+   ```bash
+   docker compose build legal_discovery
+   docker compose up
+   ```
+
+The web UI is available at <http://localhost:8080>. Neo4j exposes its browser on port 7474 and the Bolt protocol on 7687; both use the password specified in `NEO4J_PASSWORD`.
+
+---
+
 ## Developer Guide
 
 For the development guide, check out [docs/dev_guide.md](docs/dev_guide.md).

--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -964,3 +964,9 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 - Moved RetrievalTrace, ObjectionEvent and ObjectionResolution models into `models.py` and added logging helpers.
 - Ensured retrieval traces and objections share trace_ids for auditability.
 - Next: surface trace analytics in the dashboard UI.
+
+## Update 2025-09-24T20:00Z
+- Aligned Neo4j password defaults in `docker-compose.yml` with `.env` sample and confirmed ports.
+- Ensured HippoRAG, sentence-transformers and scikit-learn dependencies are listed.
+- Documented `EMBED_MODEL` and `CROSS_ENCODER_MODEL` variables and Docker setup in the root README.
+- Next: build the Docker image and verify retrieval models load correctly.

--- a/condensed AGENTS.md
+++ b/condensed AGENTS.md
@@ -185,3 +185,9 @@ we are now working on implementing a major feature, so stand by, this is  A GDDM
 - Introduced integration test for hybrid retrieval paths and objection events with refs.
 - Implemented load test harness for 200 concurrent /api/hippo/query calls asserting p95 latency.
 - Next: extend load metrics and broaden graph retrieval coverage.
+
+## Update 2025-09-24T20:00Z
+- Synced default Neo4j password across compose and env samples and confirmed service ports.
+- Ensured HippoRAG, sentence-transformers and scikit-learn dependencies are present.
+- Added README section covering `EMBED_MODEL`, `CROSS_ENCODER_MODEL` and Docker compose usage.
+- Next: rebuild the Docker image and verify retrieval models load successfully.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - CHROMA_PORT=8000
       - NEO4J_URI=bolt://neo4j:7687
       - NEO4J_USER=neo4j
-      - NEO4J_PASSWORD=${NEO4J_PASSWORD:-changeme}
+      - NEO4J_PASSWORD=${NEO4J_PASSWORD:-neo4jPass123}
       - REDIS_URL=redis://redis:6379/0
     depends_on:
       postgres:
@@ -50,12 +50,12 @@ services:
       - "7474:7474"
       - "7687:7687"
     environment:
-      - NEO4J_AUTH=neo4j/${NEO4J_PASSWORD:-changeme}
+      - NEO4J_AUTH=neo4j/${NEO4J_PASSWORD:-neo4jPass123}
     volumes:
       - ./docker_volumes/neo4j/data:/data
     healthcheck:
       # Ensure Bolt is up AND auth works
-      test: ["CMD-SHELL", "cypher-shell -a bolt://localhost:7687 -u neo4j -p \"$${NEO4J_PASSWORD:-changeme}\" \"RETURN 1\" | grep -q 1"]
+      test: ["CMD-SHELL", "cypher-shell -a bolt://localhost:7687 -u neo4j -p \"$${NEO4J_PASSWORD:-neo4jPass123}\" \"RETURN 1\" | grep -q 1"]
       interval: 10s
       timeout: 5s
       retries: 20


### PR DESCRIPTION
## Summary
- Align `NEO4J_PASSWORD` defaults across docker-compose and env sample
- Document EMBED_MODEL/CROSS_ENCODER_MODEL and Docker usage in README
- Log progress updates for legal discovery module

## Testing
- `pytest`
- `docker compose build legal_discovery` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4dec792588333a508b83aeefd7f6e