### PR TITLE
Add health check endpoint and wire Docker healthchecks

### DIFF
--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -970,3 +970,8 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 - Ensured HippoRAG, sentence-transformers and scikit-learn dependencies are listed.
 - Documented `EMBED_MODEL` and `CROSS_ENCODER_MODEL` variables and Docker setup in the root README.
 - Next: build the Docker image and verify retrieval models load correctly.
+
+## Update 2025-09-25T00:00Z
+- Added `/api/health` route in `hippo_routes` checking Neo4j and Chroma connectivity.
+- Registered blueprint in `interface_flask` and pointed Docker health checks to this endpoint.
+- Next: monitor service health and extend diagnostics as needed.

--- a/apps/legal_discovery/Dockerfile
+++ b/apps/legal_discovery/Dockerfile
@@ -59,7 +59,7 @@ RUN rm -rf apps/legal_discovery/node_modules
 # Expose app port
 EXPOSE 5001
 
-HEALTHCHECK --interval=30s --timeout=5s --retries=5 CMD curl -f http://localhost:5001/api/health || exit 1
+HEALTHCHECK --interval=30s --timeout=5s --retries=5 CMD curl -fsS http://localhost:5001/api/health || exit 1
 
 # Environment defaults (can be overridden at runtime)
 ENV AGENT_MANIFEST_FILE=/usr/src/app/registries/manifest.hocon \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - ./docker_volumes/legal_discovery/audio_cache:/usr/src/app/audio_cache
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:5001/api/health"]
+      test: ["CMD", "curl", "-fsS", "http://localhost:5001/api/health"]
       interval: 30s
       timeout: 5s
       retries: 5

--- a/tests/apps/test_health_endpoint.py
+++ b/tests/apps/test_health_endpoint.py
@@ -1,0 +1,15 @@
+"""Unit tests for health endpoint."""
+
+from flask import Flask
+
+from apps.legal_discovery.hippo_routes import health_bp
+
+
+def test_health_endpoint_returns_status_keys():
+    app = Flask(__name__)
+    app.register_blueprint(health_bp)
+    client = app.test_client()
+    resp = client.get("/api/health")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert set(data.keys()) == {"neo4j", "chroma"}


### PR DESCRIPTION
## Summary
- add `/api/health` route that checks Neo4j and Chroma connectivity
- register health blueprint in Flask app and remove legacy handler
- point Dockerfile and docker-compose health checks to new endpoint
- add unit test for health endpoint

## Testing
- `pytest tests/apps/test_health_endpoint.py -q --disable-warnings --no-cov`

------
https://chatgpt.com/codex/tasks/task_e_68a4e41319e08333bc44e65574446f2a