### PR TITLE
chore: tidy imports and externalize frontend build

### DIFF
--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -979,3 +979,8 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 ## Update 2025-09-27T00:00Z
 - Added missing imports across legal discovery modules and cleaned redundant numpy import in trial prep.
 - Next: ensure modules load within Flask app and expand tests for import coverage.
+
+## Update 2025-09-27T12:00Z
+- Consolidated Flask interface imports and removed runtime npm build reliance.
+- Initialized BatesNumberingService once after imports.
+- Next: ensure deployment pipeline builds frontend assets prior to startup.

--- a/apps/legal_discovery/Dockerfile
+++ b/apps/legal_discovery/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /app
 COPY apps/legal_discovery/package*.json apps/legal_discovery/
 RUN npm --prefix apps/legal_discovery ci
 
-# Build
+# Build React bundle ahead of runtime so Flask serves precompiled assets
 COPY apps/legal_discovery apps/legal_discovery
 RUN npm --prefix apps/legal_discovery run build --silent
 


### PR DESCRIPTION
## Summary
- deduplicate and consolidate Flask interface imports
- move npm build step to Docker build and warn if bundle missing
- ensure BatesNumberingService initialized once

## Testing
- `pytest tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68a513f6f098833392f8fa576994a157