### PR TITLE
enforce auth and externalize secrets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -86,6 +86,10 @@ NEO4J_URI=bolt://neo4j:7687
 NEO4J_USER=neo4j
 NEO4J_PASSWORD=neo4jPass123
 
+# Flask and JWT secrets for the legal discovery app
+FLASK_SECRET_KEY="change_me"
+JWT_SECRET="change_me"
+
 # Retrieval model configuration
 EMBED_MODEL=sentence-transformers/all-MiniLM-L6-v2
 CROSS_ENCODER_MODEL=cross-encoder/ms-marco-MiniLM-L-6-v2

--- a/README.md
+++ b/README.md
@@ -367,13 +367,21 @@ For examples of agent networks, check out [docs/examples.md](docs/examples.md).
 
 The `apps/legal_discovery` stack runs a Flask frontend backed by PostgreSQL, Neo4j, ChromaDB and Redis. To launch the full stack with Docker:
 
-1. Copy `.env.example` to `.env` and set required secrets. At minimum set the shared Neo4j password and optionally override the retrieval models:
+1. Copy `.env.example` to `.env` and set required secrets. Generate strong values for `FLASK_SECRET_KEY` and `JWT_SECRET` used by the Flask app:
 
-   ```bash
-   NEO4J_PASSWORD=neo4jPass123
-   EMBED_MODEL=sentence-transformers/all-MiniLM-L6-v2
-   CROSS_ENCODER_MODEL=cross-encoder/ms-marco-MiniLM-L-6-v2
-   ```
+    ```bash
+    python -c 'import secrets; print(secrets.token_hex(32))'
+    ```
+
+    Then populate `.env`:
+
+    ```bash
+    FLASK_SECRET_KEY=<output from script>
+    JWT_SECRET=<output from script>
+    NEO4J_PASSWORD=neo4jPass123
+    EMBED_MODEL=sentence-transformers/all-MiniLM-L6-v2
+    CROSS_ENCODER_MODEL=cross-encoder/ms-marco-MiniLM-L-6-v2
+    ```
 
 2. Build and start the services:
 

--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -988,3 +988,9 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 ## Update 2025-09-27T12:30Z
 - Added `pyhocon` and `more-itertools` to `requirements.txt`, sorted dependencies alphabetically, and removed extra blank lines.
 - Next: verify installation of new dependencies and keep requirements tidy.
+
+## Update 2025-09-27T13:00Z
+- Enforced authentication across chat, exhibit, hippo and trial prep APIs.
+- Secrets now load from environment or config and fail fast when missing.
+- Documented secret generation and wired Docker environment variables.
+- Next: verify integration with remaining blueprints and expand auth tests.

--- a/apps/legal_discovery/Dockerfile
+++ b/apps/legal_discovery/Dockerfile
@@ -64,6 +64,8 @@ HEALTHCHECK --interval=30s --timeout=5s --retries=5 CMD curl -fsS http://localho
 # Environment defaults (can be overridden at runtime)
 ENV AGENT_MANIFEST_FILE=/usr/src/app/registries/manifest.hocon \
     AGENT_LLM_INFO_FILE=/usr/src/app/registries/llm_config.hocon
+ENV FLASK_SECRET_KEY="" \
+    JWT_SECRET=""
 
 # Run the Flask app via gunicorn+eventlet after ensuring Neo4j schema
 CMD ["bash", "-c", "python -c 'from apps.legal_discovery import bootstrap_graph; bootstrap_graph()' && python -m gunicorn -k eventlet -w 1 -b 0.0.0.0:5001 apps.legal_discovery.interface_flask:app"]

--- a/apps/legal_discovery/README.md
+++ b/apps/legal_discovery/README.md
@@ -13,11 +13,16 @@ powered by Google's Gemini 2.5 models.
 - API keys configured in `.env` (set `GOOGLE_API_KEY` for Gemini 2.5)
 
 Make a copy of `.env.example` to `.env` and fill in the required values. In
-particular set a password for Neo4j:
+particular generate secrets for Flask sessions and JWTs, then set a password for Neo4j:
 
 ```bash
 cp .env.example .env  # if you haven't created one
-# then edit .env and set NEO4J_PASSWORD=your_password (leave blank to disable auth)
+# generate secrets
+python -c 'import secrets; print(secrets.token_hex(32))'
+# then edit .env and set:
+# FLASK_SECRET_KEY=<output>
+# JWT_SECRET=<output>
+# NEO4J_PASSWORD=your_password (leave blank to disable auth)
 ```
 
 Docker Compose reads `NEO4J_PASSWORD` for both the app and database services so

--- a/apps/legal_discovery/auth.py
+++ b/apps/legal_discovery/auth.py
@@ -1,0 +1,53 @@
+"""Common authentication utilities for legal discovery routes."""
+
+from __future__ import annotations
+
+import jwt
+from flask import current_app, jsonify, request, session
+from functools import wraps
+
+from .database import db
+from .models import MessageAuditLog
+
+
+def _log_auth_failure(reason: str) -> None:
+    """Persist authentication failures for audit."""
+    db.session.add(
+        MessageAuditLog(message_id=None, sender="system", transcript=reason)
+    )
+    db.session.commit()
+
+
+def _require_auth() -> bool:
+    """Validate JWT or session token presence."""
+    auth_header = request.headers.get("Authorization", "")
+    token = None
+    if auth_header.startswith("Bearer "):
+        token = auth_header.split(" ", 1)[1]
+    if token:
+        try:
+            jwt.decode(token, current_app.config["JWT_SECRET"], algorithms=["HS256"])
+            return True
+        except jwt.PyJWTError:
+            _log_auth_failure("invalid_token")
+            return False
+    if session.get("user"):
+        return True
+    _log_auth_failure("missing_token")
+    return False
+
+
+def auth_required(func):
+    """Decorator enforcing JWT or session authentication."""
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        if not _require_auth():
+            return jsonify({"status": "error", "error": "unauthorized"}), 401
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
+__all__ = ["auth_required", "_require_auth"]
+

--- a/apps/legal_discovery/exhibit_routes.py
+++ b/apps/legal_discovery/exhibit_routes.py
@@ -5,6 +5,7 @@ import os
 from pathlib import Path
 
 from flask import Blueprint, jsonify, request, current_app
+from .auth import auth_required
 from PyPDF2 import PdfReader
 
 from .database import db
@@ -16,6 +17,7 @@ exhibits_bp = Blueprint("exhibits", __name__, url_prefix="/api/exhibits")
 
 @exhibits_bp.route("", methods=["GET"])
 @exhibits_bp.route("/", methods=["GET"])
+@auth_required
 def list_exhibits():
     """Return all exhibits for a given case."""
     case_id = request.args.get("case_id", type=int)
@@ -61,6 +63,7 @@ def list_exhibits():
 
 
 @exhibits_bp.route("/<int:doc_id>/links", methods=["GET"])
+@auth_required
 def exhibit_links(doc_id: int):
     """Return legal theories and timeline nodes linked to an exhibit."""
     doc = Document.query.get_or_404(doc_id)
@@ -73,6 +76,7 @@ def exhibit_links(doc_id: int):
 
 
 @exhibits_bp.post("/assign")
+@auth_required
 def assign():
     """Assign the next exhibit number to a document."""
     payload = request.get_json() or {}
@@ -86,6 +90,7 @@ def assign():
 
 
 @exhibits_bp.post("/reorder")
+@auth_required
 def reorder():
     """Update exhibit order based on provided list of IDs."""
     payload = request.get_json() or {}
@@ -106,6 +111,7 @@ def reorder():
 
 
 @exhibits_bp.post("/binder")
+@auth_required
 def binder():
     """Generate a combined PDF binder for the case exhibits."""
     payload = request.get_json() or {}
@@ -120,6 +126,7 @@ def binder():
 
 
 @exhibits_bp.post("/zip")
+@auth_required
 def zip_export():
     """Export exhibits and manifest as a zip archive."""
     payload = request.get_json() or {}

--- a/apps/legal_discovery/hippo_routes.py
+++ b/apps/legal_discovery/hippo_routes.py
@@ -8,6 +8,7 @@ import uuid
 
 import requests
 from flask import Blueprint, jsonify, request
+from .auth import auth_required
 
 try:  # pragma: no cover - optional dependency
     from neo4j import GraphDatabase
@@ -65,6 +66,7 @@ def health() -> 'flask.Response':
 
 
 @bp.post("/index")
+@auth_required
 def index_document():
     data = request.get_json() or {}
     case_id = data.get("case_id")
@@ -78,6 +80,7 @@ def index_document():
 
 
 @bp.post("/query")
+@auth_required
 def query_document():
     data = request.get_json() or {}
     case_id = data.get("case_id")
@@ -133,6 +136,7 @@ def query_document():
 
 
 @objections_bp.post("/analyze-segment")
+@auth_required
 def analyze_segment():
     data = request.get_json() or {}
     session_id = data.get("session_id")

--- a/apps/legal_discovery/interface_flask.py
+++ b/apps/legal_discovery/interface_flask.py
@@ -114,8 +114,17 @@ if not os.path.exists(BUNDLE_PATH):
         BUNDLE_PATH,
     )
 app = Flask(__name__)
-app.config["SECRET_KEY"] = os.environ.get("FLASK_SECRET_KEY", os.urandom(24).hex())
-app.config["JWT_SECRET"] = os.environ.get("JWT_SECRET", os.urandom(24).hex())
+config_path = os.environ.get("LEGAL_DISCOVERY_CONFIG")
+secret_key = os.environ.get("FLASK_SECRET_KEY")
+jwt_secret = os.environ.get("JWT_SECRET")
+if config_path and (not secret_key or not jwt_secret):
+    cfg = ConfigFactory.parse_file(config_path)
+    secret_key = secret_key or cfg.get("flask.secret_key", None)
+    jwt_secret = jwt_secret or cfg.get("flask.jwt_secret", None)
+if not secret_key or not jwt_secret:
+    raise RuntimeError("FLASK_SECRET_KEY and JWT_SECRET must be set")
+app.config["SECRET_KEY"] = secret_key
+app.config["JWT_SECRET"] = jwt_secret
 # Allow the primary relational store to be configured at runtime. Default to
 # SQLite for local development but override with an environment-provided
 # PostgreSQL connection string when available so the application scales under

--- a/apps/legal_discovery/trial_prep_routes.py
+++ b/apps/legal_discovery/trial_prep_routes.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from flask import Blueprint, abort, jsonify, request
+from .auth import auth_required
 
 from .models import LegalResource, Lesson
 from .trial_prep import CurriculumManager, ResourceManager
@@ -12,6 +13,7 @@ curriculum_manager = CurriculumManager()
 
 
 @trial_prep_bp.route("/api/resources/search")
+@auth_required
 def search_resources():
     query = request.args.get("query", "")
     resources = (
@@ -21,12 +23,14 @@ def search_resources():
 
 
 @trial_prep_bp.route("/api/resources/<int:res_id>")
+@auth_required
 def get_resource(res_id: int):
     resource = LegalResource.query.get_or_404(res_id)
     return jsonify(resource.to_dict(include_content=True))
 
 
 @trial_prep_bp.route("/api/lessons")
+@auth_required
 def list_lessons():
     topic = request.args.get("topic")
     lessons = curriculum_manager.list_lessons(topic)
@@ -34,6 +38,7 @@ def list_lessons():
 
 
 @trial_prep_bp.route("/api/lessons/<int:lesson_id>/progress", methods=["POST"])
+@auth_required
 def update_progress(lesson_id: int):
     data = request.get_json() or {}
     progress = curriculum_manager.record_progress(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,14 +5,16 @@ services:
       dockerfile: apps/legal_discovery/Dockerfile
     ports:
       - "8080:5001"   # keep using http://localhost:8080
-    environment:
-      - DATABASE_URL=postgresql+psycopg2://postgres:postgres@postgres:5432/legal_discovery
-      - CHROMA_HOST=chromadb
-      - CHROMA_PORT=8000
-      - NEO4J_URI=bolt://neo4j:7687
-      - NEO4J_USER=neo4j
-      - NEO4J_PASSWORD=${NEO4J_PASSWORD:-neo4jPass123}
-      - REDIS_URL=redis://redis:6379/0
+      environment:
+        - DATABASE_URL=postgresql+psycopg2://postgres:postgres@postgres:5432/legal_discovery
+        - CHROMA_HOST=chromadb
+        - CHROMA_PORT=8000
+        - NEO4J_URI=bolt://neo4j:7687
+        - NEO4J_USER=neo4j
+        - NEO4J_PASSWORD=${NEO4J_PASSWORD:-neo4jPass123}
+        - REDIS_URL=redis://redis:6379/0
+        - FLASK_SECRET_KEY=${FLASK_SECRET_KEY}
+        - JWT_SECRET=${JWT_SECRET}
     depends_on:
       postgres:
         condition: service_started

--- a/tests/apps/test_chat_audit.py
+++ b/tests/apps/test_chat_audit.py
@@ -3,6 +3,8 @@ import os
 import pytest
 
 os.environ["DATABASE_URL"] = "sqlite://"
+os.environ.setdefault("FLASK_SECRET_KEY", "test")
+os.environ.setdefault("JWT_SECRET", "test")
 
 from apps.message_bus import AUTO_DRAFTER_ALERT_TOPIC, TIMELINE_ALERT_TOPIC
 from apps.legal_discovery.interface_flask import app, db, MessageAuditLog, Case

--- a/tests/apps/test_document_versioning.py
+++ b/tests/apps/test_document_versioning.py
@@ -4,6 +4,8 @@ import fitz
 import pytest
 
 os.environ["DATABASE_URL"] = "sqlite://"
+os.environ.setdefault("FLASK_SECRET_KEY", "test")
+os.environ.setdefault("JWT_SECRET", "test")
 
 from apps.legal_discovery.interface_flask import app, db, Document, Agent, Case, DocumentVersion, DocumentSource
 

--- a/tests/apps/test_hippo_fixture_graph.py
+++ b/tests/apps/test_hippo_fixture_graph.py
@@ -1,4 +1,5 @@
 from flask import Flask
+import pytest
 
 from apps.legal_discovery.extensions import socketio
 from apps.legal_discovery.database import db
@@ -7,6 +8,12 @@ from apps.legal_discovery.hippo_routes import bp as hippo_bp, objections_bp
 from apps.legal_discovery import hippo
 from apps.legal_discovery.models import ObjectionEvent
 from apps.legal_discovery.models_trial import TrialSession
+from apps.legal_discovery import auth as auth_module
+
+
+@pytest.fixture(autouse=True)
+def _no_auth(monkeypatch):
+    monkeypatch.setattr(auth_module, "_require_auth", lambda: True)
 
 
 def _create_app() -> Flask:

--- a/tests/apps/test_hippo_query.py
+++ b/tests/apps/test_hippo_query.py
@@ -5,6 +5,12 @@ from apps.legal_discovery.hippo import chunk_text, make_doc_id
 from apps.legal_discovery.hippo_routes import bp as hippo_bp
 from apps.legal_discovery.database import db
 from apps.legal_discovery.models import RetrievalTrace
+from apps.legal_discovery import auth as auth_module
+
+
+@pytest.fixture(autouse=True)
+def _no_auth(monkeypatch):
+    monkeypatch.setattr(auth_module, "_require_auth", lambda: True)
 
 
 def _create_app():

--- a/tests/apps/test_hybrid_objection_integration.py
+++ b/tests/apps/test_hybrid_objection_integration.py
@@ -1,4 +1,5 @@
 from flask import Flask
+import pytest
 
 from apps.legal_discovery.database import db
 from apps.legal_discovery.extensions import socketio
@@ -7,6 +8,12 @@ from apps.legal_discovery.trial_assistant import bp as trial_bp
 from apps.legal_discovery.models import RetrievalTrace
 from apps.legal_discovery.models_trial import TrialSession
 from apps.legal_discovery import hippo
+from apps.legal_discovery import auth as auth_module
+
+
+@pytest.fixture(autouse=True)
+def _no_auth(monkeypatch):
+    monkeypatch.setattr(auth_module, "_require_auth", lambda: True)
 
 
 def _create_app():

--- a/tests/apps/test_metrics_endpoint.py
+++ b/tests/apps/test_metrics_endpoint.py
@@ -1,3 +1,8 @@
+import os
+
+os.environ.setdefault("FLASK_SECRET_KEY", "test")
+os.environ.setdefault("JWT_SECRET", "test")
+
 from apps.legal_discovery.interface_flask import app
 from apps.legal_discovery.stt import stt_errors, stream_transcribe
 

--- a/tests/apps/test_objection_route.py
+++ b/tests/apps/test_objection_route.py
@@ -1,4 +1,5 @@
 from flask import Flask
+import pytest
 
 from apps.legal_discovery.extensions import socketio
 from apps.legal_discovery.database import db
@@ -8,6 +9,12 @@ from apps.legal_discovery.models import ObjectionEvent, ObjectionResolution, Ret
 from apps.legal_discovery.models_trial import TrialSession, TranscriptSegment
 from apps.legal_discovery.trial_assistant.services.objection_engine import engine
 from apps.legal_discovery import hippo
+from apps.legal_discovery import auth as auth_module
+
+
+@pytest.fixture(autouse=True)
+def _no_auth(monkeypatch):
+    monkeypatch.setattr(auth_module, "_require_auth", lambda: True)
 
 
 def _create_app():

--- a/tests/apps/test_pretrial_export.py
+++ b/tests/apps/test_pretrial_export.py
@@ -3,6 +3,8 @@ import pytest
 from pathlib import Path
 
 os.environ["DATABASE_URL"] = "sqlite://"
+os.environ.setdefault("FLASK_SECRET_KEY", "test")
+os.environ.setdefault("JWT_SECRET", "test")
 
 from apps.legal_discovery.interface_flask import app, db
 

--- a/tests/apps/test_timeline_chat.py
+++ b/tests/apps/test_timeline_chat.py
@@ -4,6 +4,8 @@ import pathlib
 import pytest
 
 os.environ["DATABASE_URL"] = "sqlite://"
+os.environ.setdefault("FLASK_SECRET_KEY", "test")
+os.environ.setdefault("JWT_SECRET", "test")
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
 
 from apps.legal_discovery.interface_flask import app, db, Case, TimelineEvent
@@ -17,7 +19,10 @@ def client():
         case = Case(name="Test")
         db.session.add(case)
         db.session.commit()
-    return app.test_client()
+    client = app.test_client()
+    with client.session_transaction() as sess:
+        sess["user"] = "tester"
+    return client
 
 
 def test_chat_creates_timeline_event(client):

--- a/tests/apps/test_voice_command_routing.py
+++ b/tests/apps/test_voice_command_routing.py
@@ -30,7 +30,7 @@ def test_voice_command_routing_and_bus(monkeypatch):
         "apps.legal_discovery.chat_routes._ensure_listeners_started", lambda: None
     )
     monkeypatch.setattr(
-        "apps.legal_discovery.chat_routes._require_auth", lambda: True
+        "apps.legal_discovery.auth._require_auth", lambda: True
     )
 
     publish_calls = []

--- a/tests/apps/test_voice_ws_transcript.py
+++ b/tests/apps/test_voice_ws_transcript.py
@@ -28,7 +28,7 @@ def _create_app():
 def test_voice_ws_transcript_updates(monkeypatch):
     app = _create_app()
     monkeypatch.setattr(
-        "apps.legal_discovery.chat_routes._require_auth", lambda: True
+        "apps.legal_discovery.auth._require_auth", lambda: True
     )
     monkeypatch.setattr(
         "apps.legal_discovery.chat_routes._ensure_listeners_started", lambda: None

--- a/tests/coded_tools/legal_discovery/test_exhibit_api.py
+++ b/tests/coded_tools/legal_discovery/test_exhibit_api.py
@@ -14,6 +14,13 @@ from apps.legal_discovery.models import (
     Fact,
 )
 from apps.legal_discovery.exhibit_routes import exhibits_bp
+from apps.legal_discovery import auth as auth_module
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _no_auth(monkeypatch):
+    monkeypatch.setattr(auth_module, "_require_auth", lambda: True)
 
 def _create_pdf(path):
     c = canvas.Canvas(str(path))

--- a/tests/coded_tools/legal_discovery/test_trial_prep_academy.py
+++ b/tests/coded_tools/legal_discovery/test_trial_prep_academy.py
@@ -4,6 +4,13 @@ from flask import Flask
 from apps.legal_discovery.database import db
 from apps.legal_discovery.trial_prep_routes import trial_prep_bp
 from apps.legal_discovery.trial_prep import LessonBuilder, ResourceManager
+from apps.legal_discovery import auth as auth_module
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _no_auth(monkeypatch):
+    monkeypatch.setattr(auth_module, "_require_auth", lambda: True)
 
 
 class TrialPrepAcademyAPITest(unittest.TestCase):


### PR DESCRIPTION
## Summary
- secure secrets by sourcing `FLASK_SECRET_KEY` and `JWT_SECRET` from env or config with fail-fast checks
- require `auth_required` across chat, exhibit, hippo and trial prep blueprints
- document secret generation and wire secrets through Docker and env examples

## Testing
- `pytest` *(fails: tests/apps/test_load.py::test_p95_latency_under_900ms - assert 500 == 200)*

------
https://chatgpt.com/codex/tasks/task_e_68a51c8e31c48333a593c816833118f0