### PR TITLE
Centralize Neo4j bootstrap

### DIFF
--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -994,3 +994,10 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 - Secrets now load from environment or config and fail fast when missing.
 - Documented secret generation and wired Docker environment variables.
 - Next: verify integration with remaining blueprints and expand auth tests.
+
+## Update 2025-09-27T14:00Z
+- Centralized Neo4j schema bootstrap in `startup.py` and removed redundant
+  `bootstrap_graph` calls from Flask modules.
+- Dockerfile and shell startup scripts now import the pre-initialized app.
+- Next: confirm deployment uses `apps.legal_discovery.startup:app` and update
+  any remaining documentation references.

--- a/apps/legal_discovery/Dockerfile
+++ b/apps/legal_discovery/Dockerfile
@@ -67,5 +67,6 @@ ENV AGENT_MANIFEST_FILE=/usr/src/app/registries/manifest.hocon \
 ENV FLASK_SECRET_KEY="" \
     JWT_SECRET=""
 
-# Run the Flask app via gunicorn+eventlet after ensuring Neo4j schema
-CMD ["bash", "-c", "python -c 'from apps.legal_discovery import bootstrap_graph; bootstrap_graph()' && python -m gunicorn -k eventlet -w 1 -b 0.0.0.0:5001 apps.legal_discovery.interface_flask:app"]
+# Run the Flask app via gunicorn+eventlet. Graph schema is bootstrapped in
+# `apps.legal_discovery.startup` when the application is imported.
+CMD ["bash", "-c", "python -m gunicorn -k eventlet -w 1 -b 0.0.0.0:5001 apps.legal_discovery.startup:app"]

--- a/apps/legal_discovery/__init__.py
+++ b/apps/legal_discovery/__init__.py
@@ -43,10 +43,6 @@ def bootstrap_graph() -> None:
 def create_app():
     """Return the configured Flask application."""
 
-    from .interface_flask import app
+    from .startup import app
 
-    try:  # pragma: no cover - best effort
-        bootstrap_graph()
-    except Exception:  # pragma: no cover - external dependency may fail
-        pass
     return app

--- a/apps/legal_discovery/hippo_routes.py
+++ b/apps/legal_discovery/hippo_routes.py
@@ -15,14 +15,12 @@ try:  # pragma: no cover - optional dependency
 except Exception:  # pragma: no cover - driver may be absent
     GraphDatabase = None
 
-from . import hippo, bootstrap_graph
+from . import hippo
 from .database import db, log_retrieval_trace, log_objection_resolution
 from .extensions import socketio
 from .models import ObjectionEvent, ObjectionResolution
 from .models_trial import TranscriptSegment, TrialSession
 from .trial_assistant.services.objection_engine import engine
-
-bootstrap_graph()
 
 bp = Blueprint("hippo", __name__, url_prefix="/api/hippo")
 objections_bp = Blueprint("objections", __name__, url_prefix="/api/objections")

--- a/apps/legal_discovery/interface_flask.py
+++ b/apps/legal_discovery/interface_flask.py
@@ -24,7 +24,7 @@ from spacy.cli import download as spacy_download
 from weasyprint import HTML
 from werkzeug.utils import secure_filename
 
-from . import bootstrap_graph, settings
+from . import settings
 from . import presentation_ws  # noqa: F401
 from .chat_state import user_input_queue
 from .chain_logger import ChainEventType, log_event
@@ -83,8 +83,6 @@ except Exception:  # pragma: no cover - optional dependency
 
     def tear_down_legal_discovery_assistant(*args, **kwargs):
         return None
-
-bootstrap_graph()
 
 # Configure logging before any other setup so early steps are captured
 logging.basicConfig(level=os.environ.get("LOG_LEVEL", "INFO"))

--- a/apps/legal_discovery/startup.py
+++ b/apps/legal_discovery/startup.py
@@ -1,0 +1,16 @@
+"""Application startup module for Legal Discovery.
+
+This module centralizes Neo4j schema initialization so that the graph is
+bootstrapped exactly once at process start. Downstream modules import the
+pre-configured Flask ``app`` from here.
+"""
+
+from . import bootstrap_graph
+
+# Apply graph constraints and indexes before the rest of the app imports.
+bootstrap_graph()
+
+# Import the Flask application after bootstrapping the graph.
+from .interface_flask import app
+
+__all__ = ["app"]

--- a/run_app.sh
+++ b/run_app.sh
@@ -16,8 +16,5 @@ export PYTHONPATH=$(pwd)
 pip install -r requirements.txt
 pip install python-dotenv
 
-# Ensure Neo4j schema constraints exist
-python -c "from apps.legal_discovery import bootstrap_graph; bootstrap_graph()"
-
 # Start the server and client.
 python -m run


### PR DESCRIPTION
## Summary
- add `startup.py` that initializes Neo4j schema once and exposes the Flask app
- drop `bootstrap_graph()` calls from `interface_flask` and `hippo_routes`
- update Docker and shell startup scripts to import the pre-initialized app

## Testing
- `pytest` *(fails: KeyboardInterrupt while loading spacy/torch)*

------
https://chatgpt.com/codex/tasks/task_e_68a526d373808333b5552ea7743c70bd