### PR TITLE
Secure exhibit export routes

### DIFF
--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -1001,3 +1001,7 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 - Dockerfile and shell startup scripts now import the pre-initialized app.
 - Next: confirm deployment uses `apps.legal_discovery.startup:app` and update
   any remaining documentation references.
+
+## Update 2025-09-27T15:00Z
+- Secured binder and zip export routes with auth enforcement, case ownership checks and path sanitization.
+- Next: expand tests for unauthorized and invalid path scenarios.


### PR DESCRIPTION
## Summary
- enforce case ownership and secure path validation for exhibit binder and zip exports
- require chat auth decorator for export endpoints
- record progress in Legal Discovery module log

## Testing
- `pytest tests/coded_tools/legal_discovery/test_exhibit_api.py::test_assign_list_and_exports -q` *(fails: KeyboardInterrupt: /root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sqlalchemy/sql/annotation.py:152)*

------
https://chatgpt.com/codex/tasks/task_e_68a543b3dee08333aed30ded96c89e38