### PR TITLE
Persist feature flags with user settings

### DIFF
--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -1005,3 +1005,11 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 ## Update 2025-09-27T15:00Z
 - Secured binder and zip export routes with auth enforcement, case ownership checks and path sanitization.
 - Next: expand tests for unauthorized and invalid path scenarios.
+
+## Update 2025-09-27T16:00Z
+- Persisted feature flags in user settings with REST APIs and React toggles.
+- Next: extend tests for flag persistence and blueprint registration.
+
+## Update 2025-09-27T16:10Z
+- Cleaned up duplicate imports in settings module.
+- Next: monitor test hangs and streamline initialization.

--- a/apps/legal_discovery/interface_flask.py
+++ b/apps/legal_discovery/interface_flask.py
@@ -132,6 +132,16 @@ app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
 db.init_app(app)
 socketio.init_app(app)
 limiter.init_app(app)
+with app.app_context():
+    db.create_all()
+    if not Case.query.first():
+        default_case = Case(name="Default Case")
+        db.session.add(default_case)
+        db.session.commit()
+    db_flags = settings.get_feature_flags()
+    if db_flags:
+        for k, v in db_flags.items():
+            FEATURE_FLAGS[k] = bool(v)
 app.register_blueprint(exhibits_bp)
 app.register_blueprint(trial_prep_bp)
 app.register_blueprint(trial_assistant_bp)
@@ -187,14 +197,6 @@ def _initialize_agent() -> None:
         app.logger.info("Setting up legal discovery assistant...")
         legal_discovery_session, legal_discovery_thread = set_up_legal_discovery_assistant(_gather_upload_paths())
         app.logger.info("...legal discovery assistant set up.")
-
-
-with app.app_context():
-    db.create_all()
-    if not Case.query.first():
-        default_case = Case(name="Default Case")
-        db.session.add(default_case)
-        db.session.commit()
 
 threading.Thread(target=_initialize_agent, daemon=True).start()
 
@@ -290,16 +292,35 @@ def on_connect():
 @app.route("/api/settings", methods=["GET", "POST"])
 def manage_settings():
     if request.method == "POST":
-        data = request.get_json()
+        data = request.get_json() or {}
         settings.save_user_settings(data)
-        for flag, env_var in [
-            ("voice_stt", "ENABLE_VOICE_STT"),
-            ("voice_tts", "ENABLE_VOICE_TTS"),
-            ("voice_commands", "ENABLE_VOICE_COMMANDS"),
-        ]:
-            if flag in data:
-                FEATURE_FLAGS[flag] = bool(data[flag])
-                os.environ[env_var] = "1" if data[flag] else "0"
+        flags = {
+            k: data[k]
+            for k in [
+                "voice_stt",
+                "voice_tts",
+                "voice_commands",
+                "theories",
+                "binder",
+                "chat",
+            ]
+            if k in data
+        }
+        if flags:
+            settings.save_feature_flags(flags)
+            env_map = {
+                "theories": "ENABLE_THEORIES",
+                "binder": "ENABLE_BINDER",
+                "chat": "ENABLE_CHAT",
+                "voice_stt": "ENABLE_VOICE_STT",
+                "voice_tts": "ENABLE_VOICE_TTS",
+                "voice_commands": "ENABLE_VOICE_COMMANDS",
+            }
+            for flag, value in flags.items():
+                FEATURE_FLAGS[flag] = bool(value)
+                env_var = env_map.get(flag)
+                if env_var:
+                    os.environ[env_var] = "1" if value else "0"
         return jsonify({"message": "Settings saved successfully"})
     else:
         user_settings = settings.get_user_settings()
@@ -325,13 +346,10 @@ def manage_settings():
                 "gcp_vertex_ai_search_app": user_settings.gcp_vertex_ai_search_app,
                 "gcp_service_account_key": user_settings.gcp_service_account_key,
             }
-        resp.update(
-            {
-                "voice_stt": FEATURE_FLAGS["voice_stt"],
-                "voice_tts": FEATURE_FLAGS["voice_tts"],
-                "voice_commands": FEATURE_FLAGS["voice_commands"],
-            }
-        )
+        flags = settings.get_feature_flags()
+        for key in FEATURE_FLAGS:
+            flags.setdefault(key, FEATURE_FLAGS[key])
+        resp.update(flags)
         return jsonify(resp)
 
 
@@ -339,6 +357,31 @@ def manage_settings():
 def manage_api_keys():
     """Manage extended API key settings."""
     return manage_settings()
+
+
+@app.route("/api/feature-flags", methods=["GET", "POST"])
+def manage_feature_flags():
+    if request.method == "POST":
+        data = request.get_json() or {}
+        settings.save_feature_flags(data)
+        env_map = {
+            "theories": "ENABLE_THEORIES",
+            "binder": "ENABLE_BINDER",
+            "chat": "ENABLE_CHAT",
+            "voice_stt": "ENABLE_VOICE_STT",
+            "voice_tts": "ENABLE_VOICE_TTS",
+            "voice_commands": "ENABLE_VOICE_COMMANDS",
+        }
+        for flag, value in data.items():
+            FEATURE_FLAGS[flag] = bool(value)
+            env_var = env_map.get(flag)
+            if env_var:
+                os.environ[env_var] = "1" if value else "0"
+        return jsonify({"message": "Flags updated"})
+    flags = settings.get_feature_flags()
+    for key in FEATURE_FLAGS:
+        flags.setdefault(key, FEATURE_FLAGS[key])
+    return jsonify(flags)
 
 
 import shutil

--- a/apps/legal_discovery/models.py
+++ b/apps/legal_discovery/models.py
@@ -328,6 +328,7 @@ class UserSetting(db.Model):
     gcp_vertex_ai_data_store_id = db.Column(db.String(255), nullable=True)
     gcp_vertex_ai_search_app = db.Column(db.String(255), nullable=True)
     gcp_service_account_key = db.Column(db.Text, nullable=True)
+    feature_flags = db.Column(db.JSON, nullable=False, default=dict)
 
 
 class FileUpload(db.Model):

--- a/apps/legal_discovery/settings.py
+++ b/apps/legal_discovery/settings.py
@@ -1,5 +1,5 @@
-from .database import db
 from .models import UserSetting
+from .database import db
 
 
 # Settings helpers
@@ -37,7 +37,25 @@ def save_user_settings(data, user_id=1):
     settings.gcp_vertex_ai_data_store_id = data.get("gcp_vertex_ai_data_store_id")
     settings.gcp_vertex_ai_search_app = data.get("gcp_vertex_ai_search_app")
     settings.gcp_service_account_key = data.get("gcp_service_account_key")
-
     db.session.add(settings)
     db.session.commit()
     return settings
+
+
+def get_feature_flags(user_id=1):
+    """Return persisted feature flags for ``user_id``."""
+    settings = get_user_settings(user_id)
+    return settings.feature_flags if settings and settings.feature_flags else {}
+
+
+def save_feature_flags(flags, user_id=1):
+    """Persist feature flags for ``user_id``."""
+    settings = get_user_settings(user_id)
+    if not settings:
+        settings = UserSetting(user_id=user_id, feature_flags={})
+    current = settings.feature_flags or {}
+    current.update({k: bool(v) for k, v in flags.items()})
+    settings.feature_flags = current
+    db.session.add(settings)
+    db.session.commit()
+    return current

--- a/apps/legal_discovery/src/components/SettingsModal.jsx
+++ b/apps/legal_discovery/src/components/SettingsModal.jsx
@@ -4,7 +4,10 @@ function SettingsModal({open,onClose}) {
   const ref = useRef();
   useEffect(() => {
     if(open) {
-      fetch('/api/settings').then(r=>r.json()).then(d=>setForm(d||{}));
+      Promise.all([
+        fetch('/api/settings').then(r=>r.json()),
+        fetch('/api/feature-flags').then(r=>r.json())
+      ]).then(([settings, flags]) => setForm({...settings, ...flags}));
     }
   }, [open]);
   const update = e => {
@@ -13,8 +16,12 @@ function SettingsModal({open,onClose}) {
   };
   const submit = e => {
     e.preventDefault();
-    fetch('/api/settings',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(form)})
-      .then(()=>onClose());
+    const { voice_stt, voice_tts, voice_commands, theories, binder, chat, ...rest } = form;
+    const flags = { voice_stt, voice_tts, voice_commands, theories, binder, chat };
+    Promise.all([
+      fetch('/api/settings',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(rest)}),
+      fetch('/api/feature-flags',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(flags)})
+    ]).then(()=>onClose());
   };
   if(!open) return null;
   return (
@@ -41,6 +48,9 @@ function SettingsModal({open,onClose}) {
           <label>GCP Vertex Data Store<input type="text" name="gcp_vertex_ai_data_store_id" value={form.gcp_vertex_ai_data_store_id||''} onChange={update} className="w-full p-2 rounded"/></label>
           <label>GCP Search App<input type="text" name="gcp_vertex_ai_search_app" value={form.gcp_vertex_ai_search_app||''} onChange={update} className="w-full p-2 rounded"/></label>
           <label>GCP Service Account Key<textarea name="gcp_service_account_key" value={form.gcp_service_account_key||''} onChange={update} className="w-full p-2 rounded" rows="2"/></label>
+          <label className="flex items-center space-x-2"><input type="checkbox" name="theories" checked={form.theories||false} onChange={update}/><span>Enable Legal Theories</span></label>
+          <label className="flex items-center space-x-2"><input type="checkbox" name="binder" checked={form.binder||false} onChange={update}/><span>Enable Binder</span></label>
+          <label className="flex items-center space-x-2"><input type="checkbox" name="chat" checked={form.chat||false} onChange={update}/><span>Enable Chat</span></label>
           <label className="flex items-center space-x-2"><input type="checkbox" name="voice_stt" checked={form.voice_stt||false} onChange={update}/><span>Enable Voice Transcription</span></label>
           <label className="flex items-center space-x-2"><input type="checkbox" name="voice_tts" checked={form.voice_tts||false} onChange={update}/><span>Enable Voice Synthesis</span></label>
           <label className="flex items-center space-x-2"><input type="checkbox" name="voice_commands" checked={form.voice_commands||false} onChange={update}/><span>Enable Voice Commands</span></label>


### PR DESCRIPTION
## Summary
- store feature flags in `UserSetting` to retain per-user toggles
- expose `/api/feature-flags` for reading and updating flags, loading persisted values on startup
- wire settings modal to new flag API and add UI toggles so selections survive restarts

## Testing
- `pytest` *(fails: KeyboardInterrupt during imports)*

------
https://chatgpt.com/codex/tasks/task_e_68a54fa16ab083339f908921bd02bb79