### PR TITLE
Improve error handling in legal discovery modules

### DIFF
--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -1005,3 +1005,8 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 ## Update 2025-09-27T15:00Z
 - Secured binder and zip export routes with auth enforcement, case ownership checks and path sanitization.
 - Next: expand tests for unauthorized and invalid path scenarios.
+
+## Update 2025-09-27T16:00Z
+- Replaced silent exception handlers with structured logging in Hippo, interface, database and trial prep modules.
+- Added error responses for redaction review and tests confirming error logs and HTTP failures.
+- Next: audit remaining modules for hidden failures and broaden negative-case tests.

--- a/apps/legal_discovery/trial_prep.py
+++ b/apps/legal_discovery/trial_prep.py
@@ -21,6 +21,9 @@ from .database import db
 from .models import LegalResource, Lesson, LessonProgress
 
 
+logger = logging.getLogger(__name__)
+
+
 def _load_spacy_model():
     try:
         return spacy.load("en_core_web_sm")
@@ -182,8 +185,8 @@ class GraphManager:
                 title=resource.title,
                 topic=topic,
             )
-        except Exception:  # pragma: no cover - external service
-            pass
+        except Exception as exc:  # pragma: no cover - external service
+            logger.exception("failed to link resource to graph", exc_info=exc)
 
     def close(self) -> None:
         if self.session:

--- a/tests/apps/test_database_logging.py
+++ b/tests/apps/test_database_logging.py
@@ -1,0 +1,25 @@
+import logging
+
+from apps.legal_discovery import database
+
+
+class DummySession:
+    def merge(self, entry):
+        raise RuntimeError("merge fail")
+
+    def commit(self):
+        raise RuntimeError("commit fail")
+
+    def rollback(self):
+        raise RuntimeError("rollback fail")
+
+
+def test_log_ingestion_failure_logs(monkeypatch, caplog):
+    dummy = DummySession()
+    monkeypatch.setattr(database.db, "session", dummy)
+    with caplog.at_level(logging.ERROR):
+        database.log_ingestion(
+            case_id="c", path="p", doc_id="d", segment_hashes=[], status="ingested"
+        )
+    assert "failed to log ingestion" in caplog.text
+    assert "failed to rollback ingestion log" in caplog.text

--- a/tests/apps/test_review_redaction_error.py
+++ b/tests/apps/test_review_redaction_error.py
@@ -1,0 +1,38 @@
+import importlib
+import logging
+import os
+
+import pytest
+
+
+def test_review_redaction_copy_failure(monkeypatch, caplog, tmp_path):
+    monkeypatch.setenv("FLASK_SECRET_KEY", "test")
+    monkeypatch.setenv("JWT_SECRET", "test")
+    monkeypatch.setenv("DATABASE_URL", "sqlite://")
+    ifl = importlib.import_module("apps.legal_discovery.interface_flask")
+    ifl.socketio.stop = lambda *a, **kw: None
+    ifl.app.config["SECURE_FOLDER"] = str(tmp_path)
+    with ifl.app.app_context():
+        case = ifl.Case(name="case")
+        ifl.db.session.add(case)
+        ifl.db.session.commit()
+        doc = ifl.Document(
+            case_id=case.id,
+            name="doc.txt",
+            file_path=str(tmp_path / "doc.txt"),
+            sha256="hash",
+            source=ifl.DocumentSource.USER,
+        )
+        ifl.db.session.add(doc)
+        ifl.db.session.commit()
+        doc_id = doc.id
+    def _raise(*args, **kwargs):
+        raise OSError("boom")
+    monkeypatch.setattr(ifl.shutil, "copy", _raise)
+    with caplog.at_level(logging.ERROR):
+        resp = ifl.app.test_client().post(
+            f"/api/redaction/{doc_id}",
+            json={"action": "override", "reviewer": "r", "reason": "r"},
+        )
+    assert resp.status_code == 500
+    assert "failed to restore original file" in caplog.text


### PR DESCRIPTION
## Summary
- log and surface failures in hippo, interface, database, and trial prep modules
- return 500 on redaction restore failures
- test error logging and response codes

## Testing
- `pytest tests/apps/test_review_redaction_error.py tests/apps/test_database_logging.py`

------
https://chatgpt.com/codex/tasks/task_e_68a54f8a65a483339959c55cafe2ecf3