### PR TITLE
feat: add routing and global state with theme toggle

### DIFF
--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -1020,3 +1020,7 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 ## Update 2025-09-27T17:00Z
 - Finalised objection analysis endpoint and Socket.IO cure handler.
 - Next: expose objection resolution history in dashboard.
+
+## Update 2025-09-27T18:00Z
+- Converted dashboard tabs to React Router routes with responsive grid layout, global context and theme toggling. Added skeleton loaders, error boundaries and accessibility improvements.
+- Next: extend loading/error handling across remaining components and enhance test coverage.

--- a/apps/legal_discovery/package-lock.json
+++ b/apps/legal_discovery/package-lock.json
@@ -13,6 +13,7 @@
         "react-calendar": "^6.0.0",
         "react-dom": "^18.2.0",
         "react-pdf": "^7.5.0",
+        "react-router-dom": "^6.22.3",
         "socket.io-client": "^4.8.1"
       },
       "devDependencies": {
@@ -824,6 +825,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.15.3.tgz",
+      "integrity": "sha512-Oy8rmScVrVxWZVOpEF57ovlnhpZ8CCPlnIIumVcV9nFdiSIrus99+Lw78ekXyGvVDlIsFJbSfmSovJUhCWYV3w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -3499,6 +3509,38 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.22.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.22.3.tgz",
+      "integrity": "sha512-dr2eb3Mj5zK2YISHK++foM9w4eBnO23eKnZEDs7c880P6oKbrjz/Svg9+nxqtHQK+oMW4OtjZca0RqPglXxguQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.15.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.22.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.22.3.tgz",
+      "integrity": "sha512-7ZILI7HjcE+p31oQvwbokjk6OA/bnFxrhJ19n82Ex9Ph8fNAq+Hm/7KchpMGlTgWhUxRHMMCut+vEtNpWpowKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.15.3",
+        "react-router": "6.22.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/readable-stream": {

--- a/apps/legal_discovery/package.json
+++ b/apps/legal_discovery/package.json
@@ -8,16 +8,17 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "pdfjs-dist": "^3.11.174",
     "react": "^18.2.0",
     "react-calendar": "^6.0.0",
     "react-dom": "^18.2.0",
-    "socket.io-client": "^4.8.1",
     "react-pdf": "^7.5.0",
-    "pdfjs-dist": "^3.11.174"
+    "react-router-dom": "^6.22.3",
+    "socket.io-client": "^4.8.1"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.2.0",
-    "vite": "^4.2.0",
-    "cypress": "^13.5.0"
+    "cypress": "^13.5.0",
+    "vite": "^4.2.0"
   }
 }

--- a/apps/legal_discovery/src/AppContext.jsx
+++ b/apps/legal_discovery/src/AppContext.jsx
@@ -1,0 +1,27 @@
+import React, { createContext, useContext, useState, useEffect, useMemo } from 'react';
+
+const AppContext = createContext();
+
+export function AppProvider({ children }) {
+  const [settings, setSettings] = useState({});
+  const [session, setSession] = useState(null);
+  const [featureFlags, setFeatureFlags] = useState({});
+  const [theme, setTheme] = useState(() => localStorage.getItem('theme') || 'dark');
+
+  useEffect(() => {
+    document.documentElement.dataset.theme = theme;
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  const toggleTheme = () => setTheme(t => (t === 'dark' ? 'light' : 'dark'));
+
+  const value = useMemo(
+    () => ({ settings, setSettings, session, setSession, featureFlags, setFeatureFlags, theme, toggleTheme }),
+    [settings, session, featureFlags, theme]
+  );
+
+  return <AppContext.Provider value={value}>{children}</AppContext.Provider>;
+}
+
+export const useAppContext = () => useContext(AppContext);
+

--- a/apps/legal_discovery/src/Dashboard.jsx
+++ b/apps/legal_discovery/src/Dashboard.jsx
@@ -1,106 +1,116 @@
-import React, { useState, useEffect } from "react";
-import ChatSection from "./components/ChatSection";
-import StatsSection from "./components/StatsSection";
-import PipelineSection from "./components/PipelineSection";
-import OverviewSection from "./components/OverviewSection";
-import UploadSection from "./components/UploadSection";
-import TimelineSection from "./components/TimelineSection";
-import GraphSection from "./components/GraphSection";
-import DocToolsSection from "./components/DocToolsSection";
-import DocumentDraftSection from "./components/DocumentDraftSection";
-import AutoDraftSection from "./components/AutoDraftSection";
-import ForensicSection from "./components/ForensicSection";
-import VectorSection from "./components/VectorSection";
-import VersionHistorySection from "./components/VersionHistorySection";
-import TasksSection from "./components/TasksSection";
-import CaseManagementSection from "./components/CaseManagementSection";
-import ResearchSection from "./components/ResearchSection";
-import SubpoenaSection from "./components/SubpoenaSection";
-import PresentationSection from "./components/PresentationSection";
-import AgentNetworkSection from "./components/AgentNetworkSection";
+import React, { useState, useRef, Suspense } from "react";
+import { NavLink, Routes, Route } from "react-router-dom";
 import SettingsModal from "./components/SettingsModal";
-import LegalTheorySection from "./components/LegalTheorySection";
-import ExhibitTab from "./components/ExhibitTab";
-import DepositionPrepSection from "./components/DepositionPrepSection";
-import ChainLogSection from "./components/ChainLogSection";
-import OppositionTrackerSection from "./components/OppositionTrackerSection";
-import DocumentReviewSection from "./components/DocumentReviewSection";
-import TrialPrepSchoolSection from "./components/TrialPrepSchoolSection";
+import ErrorBoundary from "./components/ErrorBoundary";
+import Skeleton from "./components/Skeleton";
+import ThemeToggle from "./components/ThemeToggle";
+
+const AgentNetworkSection = React.lazy(()=>import('./components/AgentNetworkSection'));
+const OverviewSection = React.lazy(()=>import('./components/OverviewSection'));
+const PipelineSection = React.lazy(()=>import('./components/PipelineSection'));
+const ChatSection = React.lazy(()=>import('./components/ChatSection'));
+const StatsSection = React.lazy(()=>import('./components/StatsSection'));
+const UploadSection = React.lazy(()=>import('./components/UploadSection'));
+const DocumentReviewSection = React.lazy(()=>import('./components/DocumentReviewSection'));
+const TimelineSection = React.lazy(()=>import('./components/TimelineSection'));
+const GraphSection = React.lazy(()=>import('./components/GraphSection'));
+const LegalTheorySection = React.lazy(()=>import('./components/LegalTheorySection'));
+const DocToolsSection = React.lazy(()=>import('./components/DocToolsSection'));
+const VersionHistorySection = React.lazy(()=>import('./components/VersionHistorySection'));
+const DocumentDraftSection = React.lazy(()=>import('./components/DocumentDraftSection'));
+const AutoDraftSection = React.lazy(()=>import('./components/AutoDraftSection'));
+const ForensicSection = React.lazy(()=>import('./components/ForensicSection'));
+const VectorSection = React.lazy(()=>import('./components/VectorSection'));
+const TasksSection = React.lazy(()=>import('./components/TasksSection'));
+const CaseManagementSection = React.lazy(()=>import('./components/CaseManagementSection'));
+const ResearchSection = React.lazy(()=>import('./components/ResearchSection'));
+const SubpoenaSection = React.lazy(()=>import('./components/SubpoenaSection'));
+const PresentationSection = React.lazy(()=>import('./components/PresentationSection'));
+const TrialPrepSchoolSection = React.lazy(()=>import('./components/TrialPrepSchoolSection'));
+const ExhibitTab = React.lazy(()=>import('./components/ExhibitTab'));
+const DepositionPrepSection = React.lazy(()=>import('./components/DepositionPrepSection'));
+const OppositionTrackerSection = React.lazy(()=>import('./components/OppositionTrackerSection'));
+const ChainLogSection = React.lazy(()=>import('./components/ChainLogSection'));
+
 const TABS = [
-  {id:'network', label:'Agent Network', icon:'fa-sitemap'},
-  {id:'overview', label:'Overview', icon:'fa-home'},
-  {id:'pipeline', label:'Team Pipeline', icon:'fa-route'},
-  {id:'chat', label:'Orchestrator', icon:'fa-comments'},
-  {id:'stats', label:'Stats', icon:'fa-chart-bar'},
-  {id:'upload', label:'Ingestion', icon:'fa-upload'},
-  {id:'review', label:'Doc Review', icon:'fa-list'},
-  {id:'timeline', label:'Timeline', icon:'fa-clock'},
-  {id:'graph', label:'Graph', icon:'fa-project-diagram'},
-  {id:'theory', label:'Case Theory', icon:'fa-balance-scale'},
+  {id:'network', label:'Agent Network', icon:'fa-sitemap', Component: AgentNetworkSection},
+  {id:'overview', label:'Overview', icon:'fa-home', Component: OverviewSection},
+  {id:'pipeline', label:'Team Pipeline', icon:'fa-route', Component: PipelineSection},
+  {id:'chat', label:'Orchestrator', icon:'fa-comments', Component: ChatSection},
+  {id:'stats', label:'Stats', icon:'fa-chart-bar', Component: StatsSection},
+  {id:'upload', label:'Ingestion', icon:'fa-upload', Component: UploadSection},
+  {id:'review', label:'Doc Review', icon:'fa-list', Component: DocumentReviewSection},
+  {id:'timeline', label:'Timeline', icon:'fa-clock', Component: TimelineSection},
+  {id:'graph', label:'Graph', icon:'fa-project-diagram', Component: GraphSection},
+  {id:'theory', label:'Case Theory', icon:'fa-balance-scale', Component: LegalTheorySection},
   {id:'docs', label:'Discovery Tools', icon:'fa-file-alt'},
-  {id:'forensic', label:'Forensics', icon:'fa-search-dollar'},
-  {id:'vector', label:'Vector DB', icon:'fa-database'},
-  {id:'tasks', label:'Scheduling', icon:'fa-tasks'},
-  {id:'case', label:'Case Mgmt', icon:'fa-folder-open'},
-  {id:'research', label:'Legal Research', icon:'fa-book-open'},
-  {id:'subpoena', label:'Subpoena', icon:'fa-gavel'},
-  {id:'presentation', label:'Trial Prep', icon:'fa-slideshare'},
-  {id:'academy', label:'Trial Prep School', icon:'fa-university'},
-  {id:'exhibits', label:'Exhibits', icon:'fa-book'},
-  {id:'deposition', label:'Deposition Prep', icon:'fa-user-tie'},
-  {id:'opposition', label:'Opposition Tracker', icon:'fa-flag'},
-  {id:'chain', label:'Chain Log', icon:'fa-link'}
+  {id:'forensic', label:'Forensics', icon:'fa-search-dollar', Component: ForensicSection},
+  {id:'vector', label:'Vector DB', icon:'fa-database', Component: VectorSection},
+  {id:'tasks', label:'Scheduling', icon:'fa-tasks', Component: TasksSection},
+  {id:'case', label:'Case Mgmt', icon:'fa-folder-open', Component: CaseManagementSection},
+  {id:'research', label:'Legal Research', icon:'fa-book-open', Component: ResearchSection},
+  {id:'subpoena', label:'Subpoena', icon:'fa-gavel', Component: SubpoenaSection},
+  {id:'presentation', label:'Trial Prep', icon:'fa-slideshare', Component: PresentationSection},
+  {id:'academy', label:'Trial Prep School', icon:'fa-university', Component: TrialPrepSchoolSection},
+  {id:'exhibits', label:'Exhibits', icon:'fa-book', Component: ExhibitTab},
+  {id:'deposition', label:'Deposition Prep', icon:'fa-user-tie', Component: DepositionPrepSection},
+  {id:'opposition', label:'Opposition Tracker', icon:'fa-flag', Component: OppositionTrackerSection},
+  {id:'chain', label:'Chain Log', icon:'fa-link', Component: ChainLogSection},
 ];
 
+const render = (Comp) => (
+  <ErrorBoundary>
+    <Suspense fallback={<Skeleton className="h-48" />}>
+      <Comp />
+    </Suspense>
+  </ErrorBoundary>
+);
+
+const DocsRoute = () => (
+  <div className="card-grid">
+    <DocToolsSection/>
+    <VersionHistorySection/>
+    <DocumentDraftSection/>
+    <AutoDraftSection/>
+  </div>
+);
+
 function Dashboard() {
-  const [tab, setTab] = useState('overview');
   const [showSettings,setShowSettings] = useState(false);
-  useEffect(()=>{
-    const btn=document.getElementById('settings-btn');
-    const handler = e=>{e.preventDefault();setShowSettings(true);};
-    if(btn) btn.addEventListener('click', handler);
-    return ()=>{if(btn) btn.removeEventListener('click', handler);};
-  },[]);
+  const tabListRef = useRef(null);
+
+  const handleKeyDown = e => {
+    if(e.key !== 'ArrowRight' && e.key !== 'ArrowLeft') return;
+    const buttons = tabListRef.current.querySelectorAll('.tab-button');
+    const index = Array.from(buttons).indexOf(document.activeElement);
+    if(index === -1) return;
+    const next = e.key === 'ArrowRight' ? (index + 1) % buttons.length : (index - 1 + buttons.length) % buttons.length;
+    buttons[next].focus();
+    e.preventDefault();
+  };
+
   return (
-    <div>
-      <div className="tab-buttons">
+    <div className="dashboard-grid">
+      <div className="tab-buttons" role="tablist" onKeyDown={handleKeyDown} ref={tabListRef}>
         {TABS.map(t => (
-          <button key={t.id} className={`tab-button ${tab===t.id?'active':''}`} onClick={()=>setTab(t.id)} data-target={`tab-${t.id}`}
-            title={t.label}>
-            <i className={`fa ${t.icon} mr-1`}></i>{t.label}
-          </button>
+          <NavLink key={t.id} to={t.id} className={({isActive})=>`tab-button${isActive?' active':''}`} role="tab" aria-label={t.label}>
+            <i className={`fa ${t.icon} mr-1`} aria-hidden="true"></i>{t.label}
+          </NavLink>
         ))}
+        <button className="tab-button" onClick={()=>setShowSettings(true)} aria-label="Open settings">
+          <i className="fa fa-cog"></i>
+        </button>
+        <ThemeToggle />
       </div>
-      <div className="tab-content" style={{display: tab==='network'?'block':'none'}} id="tab-network"><AgentNetworkSection/></div>
-      <div className="tab-content" style={{display: tab==='overview'?'block':'none'}} id="tab-overview"><OverviewSection/></div>
-      <div className="tab-content" style={{display: tab==='pipeline'?'block':'none'}} id="tab-pipeline"><PipelineSection/></div>
-      <div className="tab-content" style={{display: tab==='chat'?'block':'none'}} id="tab-chat"><ChatSection/></div>
-      <div className="tab-content" style={{display: tab==='stats'?'block':'none'}} id="tab-stats"><StatsSection/></div>
-      <div className="tab-content" style={{display: tab==='upload'?'block':'none'}} id="tab-upload"><UploadSection/></div>
-      <div className="tab-content" style={{display: tab==='review'?'block':'none'}} id="tab-review"><DocumentReviewSection/></div>
-      <div className="tab-content" style={{display: tab==='timeline'?'block':'none'}} id="tab-timeline"><TimelineSection/></div>
-      <div className="tab-content" style={{display: tab==='graph'?'block':'none'}} id="tab-graph"><GraphSection/></div>
-      <div className="tab-content" style={{display: tab==='theory'?'block':'none'}} id="tab-theory"><LegalTheorySection/></div>
-      <div className="tab-content" style={{display: tab==='docs'?'block':'none'}} id="tab-docs">
-        <div className="card-grid">
-          <DocToolsSection/>
-          <VersionHistorySection/>
-          <DocumentDraftSection/>
-          <AutoDraftSection/>
-        </div>
+      <div className="tab-panels">
+        <Routes>
+          {TABS.filter(t=>t.Component).map(t => (
+            <Route key={t.id} path={t.id} element={render(t.Component)} />
+          ))}
+          <Route path="docs" element={render(DocsRoute)} />
+          <Route index element={render(OverviewSection)} />
+        </Routes>
       </div>
-      <div className="tab-content" style={{display: tab==='forensic'?'block':'none'}} id="tab-forensic"><ForensicSection/></div>
-      <div className="tab-content" style={{display: tab==='vector'?'block':'none'}} id="tab-vector"><VectorSection/></div>
-      <div className="tab-content" style={{display: tab==='tasks'?'block':'none'}} id="tab-tasks"><TasksSection/></div>
-      <div className="tab-content" style={{display: tab==='case'?'block':'none'}} id="tab-case"><CaseManagementSection/></div>
-      <div className="tab-content" style={{display: tab==='research'?'block':'none'}} id="tab-research"><ResearchSection/></div>
-      <div className="tab-content" style={{display: tab==='subpoena'?'block':'none'}} id="tab-subpoena"><SubpoenaSection/></div>
-      <div className="tab-content" style={{display: tab==='presentation'?'block':'none'}} id="tab-presentation"><PresentationSection/></div>
-      <div className="tab-content" style={{display: tab==='academy'?'block':'none'}} id="tab-academy"><TrialPrepSchoolSection/></div>
-      <div className="tab-content" style={{display: tab==='exhibits'?'block':'none'}} id="tab-exhibits"><ExhibitTab/></div>
-      <div className="tab-content" style={{display: tab==='deposition'?'block':'none'}} id="tab-deposition"><DepositionPrepSection/></div>
-      <div className="tab-content" style={{display: tab==='opposition'?'block':'none'}} id="tab-opposition"><OppositionTrackerSection/></div>
-      <div className="tab-content" style={{display: tab==='chain'?'block':'none'}} id="tab-chain"><ChainLogSection/></div>
       <SettingsModal open={showSettings} onClose={()=>setShowSettings(false)}/>
     </div>
   );

--- a/apps/legal_discovery/src/components/ErrorBoundary.jsx
+++ b/apps/legal_discovery/src/components/ErrorBoundary.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error, info) {
+    console.error('ErrorBoundary caught', error, info);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <div role="alert">Something went wrong.</div>;
+    }
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/apps/legal_discovery/src/components/GraphSection.jsx
+++ b/apps/legal_discovery/src/components/GraphSection.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef, useCallback } from "react";
 import { fetchJSON } from "../utils";
+import Skeleton from "./Skeleton";
 /* global cytoscape */
 function GraphSection() {
   const [nodes,setNodes] = useState([]);
@@ -11,9 +12,11 @@ function GraphSection() {
   const cyRef = useRef(null);
   const [exporting,setExporting] = useState(false);
   const [analysis,setAnalysis] = useState([]);
+  const [loading,setLoading] = useState(true);
   const load = useCallback(() => {
+    setLoading(true);
     const url = '/api/graph' + (subnet?`?subnet=${encodeURIComponent(subnet)}`:'');
-    fetchJSON(url).then(d=>{setNodes(d.data.nodes||[]);setEdges(d.data.edges||[]);});
+    fetchJSON(url).then(d=>{setNodes(d.data.nodes||[]);setEdges(d.data.edges||[]);}).finally(()=>setLoading(false));
   }, [subnet]);
   useEffect(load, []);
   useEffect(() => {
@@ -74,6 +77,14 @@ function GraphSection() {
     fetch('/api/graph/cypher',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({query})})
       .then(r=>r.json()).then(d=>setCypherResult(d.data||d.error||null));
   };
+  if (loading) {
+    return (
+      <section className="card">
+        <h2>Knowledge Graph</h2>
+        <Skeleton className="h-48" />
+      </section>
+    );
+  }
   return (
     <section className="card">
       <h2>Knowledge Graph</h2>

--- a/apps/legal_discovery/src/components/Skeleton.jsx
+++ b/apps/legal_discovery/src/components/Skeleton.jsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function Skeleton({ className = '' }) {
+  return <div className={`skeleton ${className}`} aria-hidden="true" />;
+}

--- a/apps/legal_discovery/src/components/ThemeToggle.jsx
+++ b/apps/legal_discovery/src/components/ThemeToggle.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { useAppContext } from '../AppContext';
+
+export default function ThemeToggle() {
+  const { theme, toggleTheme } = useAppContext();
+  return (
+    <button onClick={toggleTheme} className="tab-button" aria-label="Toggle theme">
+      <i className={`fa fa-${theme === 'dark' ? 'sun' : 'moon'}`}></i>
+    </button>
+  );
+}

--- a/apps/legal_discovery/src/components/TimelineSection.jsx
+++ b/apps/legal_discovery/src/components/TimelineSection.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef } from "react";
 import { io } from "socket.io-client";
+import Skeleton from "./Skeleton";
 function TimelineSection() {
   const [query,setQuery] = useState('');
   const [events,setEvents] = useState([]);
@@ -8,9 +9,11 @@ function TimelineSection() {
   const [exporting,setExporting] = useState(false);
   const [startDate,setStartDate] = useState('');
   const [endDate,setEndDate] = useState('');
+  const [loading,setLoading] = useState(false);
   const load = () => {
+    setLoading(true);
     fetch('/api/timeline?query='+encodeURIComponent(query))
-      .then(r=>r.json()).then(d=>setEvents(d.data||[]));
+      .then(r=>r.json()).then(d=>setEvents(d.data||[])).finally(()=>setLoading(false));
   };
   const exportTimeline = () => {
     setExporting(true);
@@ -74,7 +77,7 @@ function TimelineSection() {
         <button className="button-secondary" onClick={exportTimeline}><i className="fa fa-file-export mr-1"></i>Export</button>
       </div>
       {exporting && <p className="text-sm mb-1">Exporting...</p>}
-      <div ref={containerRef} style={{height:'200px'}}></div>
+      {loading ? <Skeleton className="h-48" /> : <div ref={containerRef} style={{height:'200px'}}></div>}
     </section>
   );
 }

--- a/apps/legal_discovery/src/main.jsx
+++ b/apps/legal_discovery/src/main.jsx
@@ -1,21 +1,25 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { BrowserRouter, Routes, Route, useParams } from 'react-router-dom';
+import { AppProvider } from './AppContext';
 import Dashboard from './Dashboard';
 import DocumentViewer from './components/DocumentViewer';
 
-const path = window.location.pathname.split('/');
-const root = document.getElementById('root');
-
-if (path[1] === 'present') {
-  const mode = path[2];
-  const docId = decodeURIComponent(path.slice(3).join('/'));
-  ReactDOM.createRoot(root).render(
-    <DocumentViewer mode={mode} docId={docId} />
-  );
-} else {
-  ReactDOM.createRoot(root).render(
-    <React.StrictMode>
-      <Dashboard />
-    </React.StrictMode>
-  );
+function DocumentViewerWrapper() {
+  const { mode, '*': docId } = useParams();
+  return <DocumentViewer mode={mode} docId={decodeURIComponent(docId)} />;
 }
+
+const root = document.getElementById('root');
+ReactDOM.createRoot(root).render(
+  <React.StrictMode>
+    <AppProvider>
+      <BrowserRouter>
+        <Routes>
+          <Route path="/present/:mode/*" element={<DocumentViewerWrapper />} />
+          <Route path="/*" element={<Dashboard />} />
+        </Routes>
+      </BrowserRouter>
+    </AppProvider>
+  </React.StrictMode>
+);

--- a/apps/legal_discovery/static/style.css
+++ b/apps/legal_discovery/static/style.css
@@ -40,6 +40,20 @@
 
 }
 
+:root[data-theme='light'] {
+    --color-bg: #ffffff;
+    --color-bg-alt: #f3f4f6;
+    --color-surface: rgba(255,255,255,0.8);
+    --color-surface-hover: rgba(255,255,255,0.9);
+    --color-border: rgba(0,0,0,0.1);
+    --color-accent: #0066cc;
+    --color-accent-glow: rgba(0,102,204,0.4);
+    --color-text: #111827;
+    --color-text-muted: #6b7280;
+    --nav-bg: rgba(255,255,255,0.9);
+    --nav-text: #111827;
+}
+
 html, body {
     height: 100%;
     margin: 0;
@@ -200,6 +214,26 @@ h2 {
     box-shadow: 0 0 15px var(--color-accent-glow), inset 0 0 5px var(--color-accent);
 }
 
+.dashboard-grid {
+    display: grid;
+    grid-template-areas:
+        "tabs"
+        "content";
+}
+.tab-buttons { grid-area: tabs; }
+.tab-panels { grid-area: content; }
+
+@media (min-width: 768px) {
+    .dashboard-grid {
+        grid-template-columns: 220px 1fr;
+        grid-template-areas: "tabs content";
+    }
+    .tab-buttons {
+        flex-direction: column;
+        max-height: calc(100vh - 20px);
+    }
+}
+
 .tab-content {
     display: none;
 }
@@ -351,6 +385,19 @@ textarea:focus {
 .button-secondary:hover, .button-secondary:focus {
     background: var(--color-surface-hover);
     box-shadow: 0 0 8px var(--color-accent-glow);
+}
+
+.skeleton {
+    background: linear-gradient(90deg, var(--color-surface) 25%, var(--color-surface-hover) 37%, var(--color-surface) 63%);
+    background-size: 400% 100%;
+    animation: skeleton-loading 1.4s ease infinite;
+    border-radius: 4px;
+    width: 100%;
+}
+
+@keyframes skeleton-loading {
+    0% { background-position: 100% 0; }
+    100% { background-position: -100% 0; }
 }
 
 footer {


### PR DESCRIPTION
## Summary
- replace tab state with React Router and responsive grid layout
- add AppContext for settings, session, feature flags and theme toggling
- wrap sections with error boundaries and skeleton loaders for smoother UX

## Testing
- `npm run build`
- `npm test` *(fails: Missing script "test")*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a595f5e3748333a3be952ae124bce2