### PR TITLE
Add Redis task queue and async discovery endpoints

### DIFF
--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -1024,3 +1024,8 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 ## Update 2025-09-27T18:00Z
 - Converted dashboard tabs to React Router routes with responsive grid layout, global context and theme toggling. Added skeleton loaders, error boundaries and accessibility improvements.
 - Next: extend loading/error handling across remaining components and enhance test coverage.
+
+## Update 2025-09-28T00:00Z
+- Introduced RQ task queue with Redis and async routes for binder generation, indexing and transcript analysis.
+- Added /api/tasks/<id> for polling.
+- Next: hook frontend to poll task status and handle long-running jobs.

--- a/apps/legal_discovery/hippo_routes.py
+++ b/apps/legal_discovery/hippo_routes.py
@@ -21,6 +21,7 @@ from .extensions import socketio
 from .models import ObjectionEvent, ObjectionResolution
 from .models_trial import TranscriptSegment, TrialSession
 from .trial_assistant.services.objection_engine import engine
+from .tasks import enqueue, index_document_task, analyze_segment_task
 
 bp = Blueprint("hippo", __name__, url_prefix="/api/hippo")
 objections_bp = Blueprint("objections", __name__, url_prefix="/api/objections")
@@ -72,9 +73,10 @@ def index_document():
     path = data.get("doc_path", "")
     if not case_id or not text:
         return jsonify({"error": "case_id and text required"}), 400
-    doc_id = hippo.ingest_document(case_id, text, path)
-    segments = len(hippo.INDEX[case_id][doc_id])
-    return jsonify({"doc_id": doc_id, "segments": segments})
+    task_id, result = enqueue(index_document_task, case_id, text, path)
+    if result is not None:
+        return jsonify({"task_id": task_id, **result})
+    return jsonify({"task_id": task_id}), 202
 
 
 @bp.post("/query")
@@ -159,54 +161,10 @@ def analyze_segment():
     )
     db.session.add(seg)
     db.session.commit()
-    events = engine.analyze_segment(session_id, seg)
-    refs: list = []
-    trace_id = None
-    try:
-        sess = db.session.get(TrialSession, session_id)
-        if sess:
-            start = time.perf_counter()
-            result = hippo.hippo_query(sess.case_id, text, k=3)
-            elapsed_ms = (time.perf_counter() - start) * 1000
-            items = result.get("items", [])
-            trace_id = result.get("trace_id")
-            refs = [
-                {"segment_id": item.get("segment_id"), "path": item.get("path")}
-                for item in items
-            ]
-            timings = {"total_ms": round(elapsed_ms, 2)}
-            log_retrieval_trace(
-                trace_id=trace_id,
-                case_id=sess.case_id,
-                query=text,
-                graph_weight=1.0,
-                dense_weight=1.0,
-                timings=timings,
-                results=items,
-            )
-    except Exception as exc:  # pragma: no cover - retrieval best effort
-        logger.exception("hippo_query failed: %s", exc)
-    for e in events:
-        e.refs = refs
-        e.trace_id = trace_id
-        e.path = refs[0]["path"] if refs else None
-    db.session.commit()
-    for e in events:
-        socketio.emit(
-            "objection_event",
-            {
-                "event_id": e.id,
-                "segment_id": e.segment_id,
-                "ground": e.ground,
-                "confidence": e.confidence,
-                "suggested_cures": e.suggested_cures,
-                "refs": e.refs,
-                "trace_id": e.trace_id,
-            },
-            room="trial_objections",
-            namespace="/ws/trial",
-        )
-    return jsonify({"events": [e.id for e in events], "segment_id": seg.id})
+    task_id, result = enqueue(analyze_segment_task, seg.id, session_id)
+    if result is not None:
+        return jsonify({"task_id": task_id, **result})
+    return jsonify({"task_id": task_id, "segment_id": seg.id}), 202
 
 
 @socketio.on("objection_cure_chosen", namespace="/ws/trial")

--- a/apps/legal_discovery/interface_flask.py
+++ b/apps/legal_discovery/interface_flask.py
@@ -33,6 +33,7 @@ from .exhibit_routes import exhibits_bp
 from .extensions import limiter, socketio
 from .feature_flags import FEATURE_FLAGS
 from .hippo_routes import bp as hippo_bp, objections_bp, health_bp
+from .tasks import tasks_bp
 from .trial_assistant import bp as trial_assistant_bp
 from .trial_prep_routes import trial_prep_bp
 from apps.legal_discovery.models import (
@@ -149,6 +150,7 @@ app.register_blueprint(trial_assistant_bp)
 app.register_blueprint(hippo_bp)
 app.register_blueprint(objections_bp)
 app.register_blueprint(health_bp)
+app.register_blueprint(tasks_bp)
 if FEATURE_FLAGS.get("theories"):
     from .theory_routes import theories_bp
 

--- a/apps/legal_discovery/requirements.txt
+++ b/apps/legal_discovery/requirements.txt
@@ -33,6 +33,7 @@ redis
 reportlab
 requests
 rfc3987
+rq
 schedule
 scikit-learn
 sentence-transformers

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ Flask-SQLAlchemy>=2.5.1
 pandas>=1.3.5
 reportlab
 redis>=5.0.0
+rq>=1.15.1
 prometheus-client>=0.20.0
 
 # We separate out requirements that are specific to the build, but not


### PR DESCRIPTION
## Summary
- integrate RQ + Redis task queue for legal discovery
- offload binder generation, document indexing, and transcript analysis to background tasks
- expose `/api/tasks/<id>` for task status polling

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a59bbc397c83338d8e85fa8366486e