### PR TITLE
Refactor coded tools to require explicit configuration

### DIFF
--- a/coded_tools/agentforce/agentforce_adapter.py
+++ b/coded_tools/agentforce/agentforce_adapter.py
@@ -60,18 +60,17 @@ class AgentforceAdapter:
         if client_secret is None:
             client_secret = AgentforceAdapter._get_env_variable("AGENTFORCE_CLIENT_SECRET")
 
-        if my_domain_url is None or agent_id is None or client_id is None or client_secret is None:
-            print("ERROR: AgentforceAdapter is NOT configured. Please check your parameters or environment variables.")
-            # The service is not configured. We cannot query the API, but we can still use mock responses.
-            self.is_configured = False
-        else:
-            # The service is configured. We can query the API.
-            self.is_configured = True
-            # Keep track of the params
-            self.my_domain_url = my_domain_url
-            self.agent_id = agent_id
-            self.client_id = client_id
-            self.client_secret = client_secret
+        if None in (my_domain_url, agent_id, client_id, client_secret):
+            raise EnvironmentError(
+                "AgentforceAdapter is not configured. Set AGENTFORCE_MY_DOMAIN_URL, AGENTFORCE_AGENT_ID, "
+                "AGENTFORCE_CLIENT_ID and AGENTFORCE_CLIENT_SECRET environment variables."
+            )
+
+        self.is_configured = True
+        self.my_domain_url = my_domain_url
+        self.agent_id = agent_id
+        self.client_id = client_id
+        self.client_secret = client_secret
 
     @staticmethod
     def _get_env_variable(env_variable_name: str) -> str:

--- a/coded_tools/agentforce/agentforce_api.py
+++ b/coded_tools/agentforce/agentforce_api.py
@@ -6,112 +6,75 @@
 # License by purchasing a commercial license.
 # Purchase of a commercial license is mandatory for any use of the
 # neuro-san-studio SDK Software in commercial settings.
-#
-import json
-from typing import Any
-from typing import Dict
-from typing import Optional
+
+"""Agentforce coded tool."""
+
+from typing import Any, Dict, Optional
 
 from neuro_san.interfaces.coded_tool import CodedTool
 
 from coded_tools.agentforce.agentforce_adapter import AgentforceAdapter
 
-MOCK_SESSION_ID = "06518755-b897-4311-afea-2aab1df77314"
-MOCK_SECRET = "1234567890"
-MOCK_RESPONSE_MESSAGE_1 = """
-{"messages": [{"type": "Inform", "id": "04d35a5d-6011-4eb9-88a9-2897f49a6bdc", "feedbackId": "7d92a297-dc95-4306-b638-42f6e36ddfab", "planId": "7d92a297-dc95-4306-b638-42f6e36ddfab", "isContentSafe": true, "message": "Sure, I can help with that. Could you please provide Jane Doe's email address to look up her cases?", "result": [], "citedReferences": []}], "_links": {"self": null, "messages": {"href": "https://api.salesforce.com/einstein/ai-agent/v1/sessions/06518755-b897-4311-afea-2aab1df77314/messages"}, "messagesStream": {"href": "https://api.salesforce.com/einstein/ai-agent/v1/sessions/06518755-b897-4311-afea-2aab1df77314/messages/stream"}, "session": {"href": "https://api.salesforce.com/einstein/ai-agent/v1/agents/0XxKc000000kvtXKAQ/sessions"}, "end": {"href": "https://api.salesforce.com/einstein/ai-agent/v1/sessions/06518755-b897-4311-afea-2aab1df77314"}}}
-"""  # noqa E501
-MOCK_RESPONSE_MESSAGE_2 = """
-{"messages": [{"type": "Inform", "id": "caf90c84-a150-4ccd-8430-eb29189696ac", "feedbackId": "e24505db-1edd-4b76-b5f5-908be083fc67", "planId": "e24505db-1edd-4b76-b5f5-908be083fc67", "isContentSafe": true, "message": "It looks like there are no recent cases associated with Jane Doe's email address. Is there anything else I can assist you with?", "result": [], "citedReferences": []}], "_links": {"self": null, "messages": {"href": "https://api.salesforce.com/einstein/ai-agent/v1/sessions/06518755-b897-4311-afea-2aab1df77314/messages"}, "messagesStream": {"href": "https://api.salesforce.com/einstein/ai-agent/v1/sessions/06518755-b897-4311-afea-2aab1df77314/messages/stream"}, "session": {"href": "https://api.salesforce.com/einstein/ai-agent/v1/agents/0XxKc000000kvtXKAQ/sessions"}, "end": {"href": "https://api.salesforce.com/einstein/ai-agent/v1/sessions/06518755-b897-4311-afea-2aab1df77314"}}}
-"""  # noqa E501
-MOCK_RESPONSE_1 = {
-    "session_id": MOCK_SESSION_ID,
-    "access_token": MOCK_SECRET,
-    "response": json.loads(MOCK_RESPONSE_MESSAGE_1),
-}
-MOCK_RESPONSE_2 = {
-    "session_id": MOCK_SESSION_ID,
-    "access_token": MOCK_SECRET,
-    "response": json.loads(MOCK_RESPONSE_MESSAGE_2),
-}
-
 
 class AgentforceAPI(CodedTool):
-    """
-    A tool to interact with Agentforce agents using the Agentforce API.
-    Example usage: See tests/coded_tools/agentforce/test_agentforce_api.py
-    """
+    """Interact with Agentforce agents using the Agentforce API."""
 
-    def __init__(self):
+    def __init__(self, agentforce: Optional[AgentforceAdapter] = None) -> None:
+        """Construct the tool.
+
+        Parameters
+        ----------
+        agentforce:
+            Optional pre-configured :class:`AgentforceAdapter` instance. If not
+            provided, an instance will be created using environment variables.
         """
-        Constructs an AgentforceAPI object.
-        """
-        # Construct an AgentforceAdapter object using environment variables
-        self.agentforce = AgentforceAdapter()
+
+        self.agentforce = agentforce or AgentforceAdapter()
 
     def invoke(self, args: Dict[str, Any], sly_data: Dict[str, Any]) -> str:
+        """Call the Agentforce API.
+
+        Parameters
+        ----------
+        args:
+            Dictionary containing the user's inquiry under the ``"inquiry"``
+            key.
+        sly_data:
+            Dictionary containing ``session_id`` and ``access_token`` used to
+            continue an existing conversation. The dictionary is updated with
+            the latest values.
+
+        Returns
+        -------
+        str
+            The response message from Agentforce.
+
+        Raises
+        ------
+        RuntimeError
+            If the underlying adapter is not configured.
         """
-        Calls the Agentforce API to get a response to the user's inquiry. If no session was provided in the sly_data,
-        a new session is created. Otherwise, the existing session is reused to keep the conversation going.
-        WARNING: The AgentforceAdapter constructor reads the AGENTFORCE_CLIENT_ID and AGENTFORCE_CLIENT_SECRET
-        environment variables. If they are NOT provided, this `invoke` call will return mock responses.
 
-        :param args: A dictionary with the following keys:
-                    "inquiry": the user request to the Agentforce API, as a string.
-
-
-        :param sly_data: A dictionary containing parameters that should be kept out of the chat stream.
-                         Keys expected for this implementation are:
-                         "session_id": (optional) the ID of the session to reuse to keep the conversation going, if any.
-                                       If None, a new session is created which means a new conversation is started.
-                         "access_token": (optional) the access token corresponding to the session_id. Can only be None if
-                                         session_id is None.
-
-        :return: The response message from Agentforce. Note that sly_data dictionary gets updated
-        with the Agentforce session_id and access_token.
-        """  # noqa E501
-        # Parse the arguments
-        print(f"args: {args}")
         inquiry: str = args.get("inquiry")
-        # Get the session_id and access_token from the sly_data. Having a session_id means the user has already started
-        # a conversation with Agentforce and wants to continue it.
-        print(f"sly_data: {sly_data}")
-        session_id: Optional[str] = sly_data.get("session_id", None)
-        access_token: Optional[str] = sly_data.get("access_token", None)
+        session_id: Optional[str] = sly_data.get("session_id")
+        access_token: Optional[str] = sly_data.get("access_token")
 
-        tool_name = self.__class__.__name__
-        print(f"========== Calling {tool_name} ==========")
-        print(f"    Inquiry: {inquiry}")
-        print(f"    Session ID: {session_id}")
+        if not getattr(self.agentforce, "is_configured", True):
+            raise RuntimeError(
+                "AgentforceAdapter is not configured. Set AGENTFORCE_* environment variables."
+            )
 
-        if self.agentforce.is_configured:
-            print("AgentforceAdapter is configured. Fetching response...")
-            response = self.agentforce.post_message(inquiry, session_id, access_token)
-        else:
-            print("WARNING: AgentforceAdapter is NOT configured. Using a mock response")
-            if session_id in (None, "None"):
-                # No session yet. This is the first request the user makes
-                response = MOCK_RESPONSE_1
-            else:
-                # The user has a session. This is a follow-up request
-                response = MOCK_RESPONSE_2
+        response = self.agentforce.post_message(inquiry, session_id, access_token)
 
-        # Update the sly_data
         sly_data["session_id"] = response["session_id"]
         sly_data["access_token"] = response["access_token"]
-        tool_response = response["response"]["messages"][0]["message"]
-
-        print("-----------------------")
-        print(f"{tool_name} tool response: ", tool_response)
-        print(f"Updated sly_data: {sly_data}")
-        print(f"========== Done with {tool_name} ==========")
-        return tool_response
+        return response["response"]["messages"][0]["message"]
 
     async def async_invoke(self, args: Dict[str, Any], sly_data: Dict[str, Any]) -> str:
-        """
-        Delegates to the synchronous invoke method for now.
-        """
+        """Delegates to :meth:`invoke`."""
+
         return self.invoke(args, sly_data)
 
 
 # Example usage: See tests/coded_tools/agentforce/test_agentforce_api.py
+

--- a/coded_tools/agentic_rag/slack.py
+++ b/coded_tools/agentic_rag/slack.py
@@ -84,65 +84,14 @@ class Slack(CodedTool):
         # a following format:
         # '[{"user": "WU0JH", "text": "Yes", "ts": "1744677036.155459"}, ...]'
         try:
-            # Get a str of channel ids and names
             channel_id_name_str: str = await SlackGetChannel().ainvoke(input=EMPTY)
-            # Convert the str to list
             channel_id_name_list: list = ast.literal_eval(channel_id_name_str)
-            # Make a lookup table with channel names as keys and ids as values
             channel_id_name_dict: dict = {channel["name"]: channel["id"] for channel in channel_id_name_list}
 
-            # Get channel id and return the messages if possible.
             channel_id: str = channel_id_name_dict.get(channel_name)
             if channel_id:
                 return await SlackGetMessage().ainvoke(channel_id)
             return f"The {channel_name} channel not found."
 
-        # If slack-sdk is not installed, PydanticUserError is triggered
-        # Return a mock message depending on the channel_name
-        except PydanticUserError:
-            if channel_name == "higher_education":
-                return """Opportunity Areas:
-
-Adaptive learning and AI-powered personalization
-
-Migration tools for digital-first course content
-
-Analytics for student engagement and success
-
-Microcredentials aligned with workforce skills
-
-Accessibility innovations for inclusive learning
-
-Ideal Partners: EdTech startups, AI developers, instructional design firms"""
-
-            if channel_name == "retail":
-                return """Opportunity Areas:
-
-AI-driven demand forecasting and inventory optimization
-
-Personalized shopping experiences via customer data insights
-
-Seamless omnichannel integration (in-store, mobile, online)
-
-Sustainable packaging and supply chain solutions
-
-Retail media and monetization of customer engagement
-
-Ideal Partners: SaaS providers, AI/ML startups, logistics tech firms,
-CX platforms"""
-
-            return """Opportunity Areas:
-
-Process automation and workflow optimization
-
-Data analytics for strategic decision-making
-
-Employee experience and engagement platforms
-
-ESG tracking and sustainability reporting tools
-
-Cybersecurity and compliance automation
-
-Ideal Partners: B2B SaaS companies, AI/analytics startups, HR tech,
-
-fintech solutions"""
+        except PydanticUserError as err:
+            raise RuntimeError("Slack SDK is not installed or configured") from err

--- a/coded_tools/intranet_agents_with_tools/absence_manager.py
+++ b/coded_tools/intranet_agents_with_tools/absence_manager.py
@@ -6,68 +6,46 @@ TIMEOUT_SECONDS = 10
 
 
 class AbsenceManager:
-    """
-    Absence Manager for company's intranet.
-
-    Refer to the following link for the full API
-    https://docs.oracle.com/en/cloud/saas/human-resources/25b/farws/index.html
-    """
+    """Absence Manager for company's intranet."""
 
     def __init__(self, client_id, client_secret, associate_id):
-        """
-        Constructs an Absence Manager for company's intranet.
-        @param client_id: The API client ID.
-        @param client_secret: The API client secret.
-        @param associate_id: an associate ID.
-        """
-        self.base_url = os.environ.get("MI_BASE_URL", None)
-        print(f"BASE_URL: {self.base_url}")
+        """Construct an Absence Manager for company's intranet.
 
-        self.app_url = os.environ.get("MI_APP_URL", None)
-        print(f"APP_URL: {self.app_url}")
+        Parameters
+        ----------
+        client_id: str
+            API client ID or ``None`` to read from ``ABSENCE_MANAGER_CLIENT_ID``.
+        client_secret: str
+            API client secret or ``None`` to read from ``ABSENCE_MANAGER_CLIENT_SECRET``.
+        associate_id: str
+            Associate identifier or ``None`` to read from ``ASSOCIATE_ID``.
+        """
 
-        # Get the client_id, client_secret, and associate_id from the environment variables
+        self.base_url = os.environ.get("MI_BASE_URL")
+        self.app_url = os.environ.get("MI_APP_URL")
+
         if client_id is None:
-            print("AbsenceManager: no client_id provided, checking environment variables")
-            client_id = os.getenv("ABSENCE_MANAGER_CLIENT_ID", None)
-            if client_id is None:
-                print("AbsenceManager: ABSENCE_MANAGER_CLIENT_ID is NOT defined")
-            else:
-                print("AbsenceManager: client_id found in environment variables")
+            client_id = os.getenv("ABSENCE_MANAGER_CLIENT_ID")
         if client_secret is None:
-            print("AbsenceManager: no client_secret provided, checking environment variables")
-            client_secret = os.getenv("ABSENCE_MANAGER_CLIENT_SECRET", None)
-            if client_secret is None:
-                print("AbsenceManager: ABSENCE_MANAGER_CLIENT_SECRET is NOT defined")
-            else:
-                print("AbsenceManager: client_secret found in environment variables")
+            client_secret = os.getenv("ABSENCE_MANAGER_CLIENT_SECRET")
         if associate_id is None:
-            print("AbsenceManager: no associate_id provided, checking environment variables")
-            associate_id = os.getenv("ASSOCIATE_ID", None)
-            if associate_id is None:
-                print("AbsenceManager: ASSOCIATE_ID is NOT defined")
-            else:
-                print("AbsenceManager: associate_id found in environment variables")
+            associate_id = os.getenv("ASSOCIATE_ID")
 
-        if client_id is None or client_secret is None or associate_id is None:
-            print("ERROR: AbsenceManager is NOT configured. Please check your parameters or environment variables.")
-            # The service is not configured. We cannot query the API, but we can still use a mock response.
-            self.is_configured = False
-        else:
-            # The service is configured. We can query the API.
-            self.is_configured = True
-            # Keep track of the params
-            self.client_id = client_id
-            self.client_secret = client_secret
-            self.associate_id = associate_id
-            # Get an access token
-            access_token = self.get_access_token()
-            # Set the headers
-            self.headers = {
-                "Authorization": f"Bearer {access_token}",
-                "Content-Type": "application/json",
-                "SourceType": "Web",
-            }
+        if None in (self.base_url, self.app_url, client_id, client_secret, associate_id):
+            raise EnvironmentError(
+                "AbsenceManager is not configured. Set MI_BASE_URL, MI_APP_URL, "
+                "ABSENCE_MANAGER_CLIENT_ID, ABSENCE_MANAGER_CLIENT_SECRET and ASSOCIATE_ID."
+            )
+
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.associate_id = associate_id
+        access_token = self.get_access_token()
+        self.headers = {
+            "Authorization": f"Bearer {access_token}",
+            "Content-Type": "application/json",
+            "SourceType": "Web",
+        }
 
     def get_access_token(self):
         """

--- a/coded_tools/intranet_agents_with_tools/check_leave_balances_tool.py
+++ b/coded_tools/intranet_agents_with_tools/check_leave_balances_tool.py
@@ -1,98 +1,31 @@
-from typing import Any
-from typing import Dict
-from typing import Union
+"""Tool to check leave balances."""
+
+from typing import Any, Dict, Union
 
 from neuro_san.interfaces.coded_tool import CodedTool
 
 from coded_tools.intranet_agents_with_tools.absence_manager import AbsenceManager
 
-MOCK_RESPONSE = {
-    "Absencemodel": [
-        {"AbsenceName": "Jury Duty", "AbsPin": "10081", "Balance": "10.00"},
-        {"AbsenceName": "Time to Vote", "AbsPin": "21582", "Balance": "0.00"},
-        {"AbsenceName": "Sick Time", "AbsPin": "10097", "Balance": "0.00"},
-        {"AbsenceName": "Vacation Time", "AbsPin": "10102", "Balance": "12.73"},
-        {"AbsenceName": "Bereavement Leave", "AbsPin": "10114", "Balance": "5.00"},
-        {"AbsenceName": "Floating Holiday", "AbsPin": "22716", "Balance": "0.00"},
-    ],
-    "Warning": "Applying backdated leave beyond 14 days is non-compliance as per our leave policy."
-    " However, you can proceed with backdated leave application for up to a maximum of 2 times."
-    " You shall not be eligible to record past dated leave beyond 14 days from third instance"
-    " onwards. A trigger will be sent to your home manager to ensure that you are applying"
-    " leave on time henceforth. Kindly apply / cancel leave on time to be compliant.",
-}
-
 
 class CheckLeaveBalancesTool(CodedTool):
-    """
-    CodedTool implementation which checks the Leave Balances for an employee.
-    """
+    """Check leave balances for an employee."""
 
-    def __init__(self):
-        """
-        Constructs a Leave Balances Checker for company's intranet.
-        """
-        # Construct an AbsenceManager object using environment variables
-        self.absence_manager = AbsenceManager(None, None, None)
+    def __init__(self, absence_manager: AbsenceManager | None = None) -> None:
+        self.absence_manager = absence_manager or AbsenceManager(None, None, None)
 
     def invoke(self, args: Dict[str, Any], sly_data: Dict[str, Any]) -> Union[Dict[str, Any], str]:
-        """
-        :param args: An argument dictionary whose keys are the parameters
-                to the coded tool and whose values are the values passed for them
-                by the calling agent. This dictionary is to be treated as read-only.
-
-                The argument dictionary expects the following keys:
-                    "start_date" the date on which to check the balances (format: 'YYYY-MM-DD')
-
-        :param sly_data: A dictionary whose keys are defined by the agent hierarchy,
-                but whose values are meant to be kept out of the chat stream.
-
-                This dictionary is largely to be treated as read-only.
-                It is possible to add key/value pairs to this dict that do not
-                yet exist as a bulletin board, as long as the responsibility
-                for which coded_tool publishes new entries is well understood
-                by the agent chain implementation and the coded_tool implementation
-                adding the data is not invoke()-ed more than once.
-
-                Keys expected for this implementation are:
-                    None
-
-        :return:
-            In case of successful execution:
-                An Absence Entitlement Balances dictionary with string keys that represent the Entitlement Name
-                and the string values that contain the Current Balances in Days.
-            otherwise:
-                a text string an error message in the format:
-                "Error: <error message>"
-        """
         start_date: str = args.get("start_date", "need-start-date")
-        print(">>>>>>>>>>>>>>>>>>> Checking Leave Balances >>>>>>>>>>>>>>>>>>")
-        print(f"Start date: {start_date}")
-        if self.absence_manager.is_configured:
-            print("AbsenceManager is configured. Fetching absence types...")
-            absence_types = self.absence_manager.get_absence_types(start_date)
-        else:
-            print("WARNING: AbsenceManager is not configured. Using mock response")
-            absence_types = MOCK_RESPONSE
+        absence_types = self.absence_manager.get_absence_types(start_date)
         absence_types["app_name"] = "Absence Management"
         absence_types["app_url"] = self.absence_manager.app_url
-        print("-----------------------")
-        print("Absence Types:", absence_types)
-        print(">>>>>>>>>>>>>>>>>>>DONE !!!>>>>>>>>>>>>>>>>>>")
         return absence_types
 
     async def async_invoke(self, args: Dict[str, Any], sly_data: Dict[str, Any]) -> Union[Dict[str, Any], str]:
-        """
-        Delegates to the synchronous invoke method for now.
-        """
         return self.invoke(args, sly_data)
 
 
-# Example usage:
 if __name__ == "__main__":
     check_leave_balances_tool = CheckLeaveBalancesTool()
-
-    # Get absence types
     START_DATE = "2024-11-22"
-    an_absence_types = check_leave_balances_tool.invoke(args={"start_date": START_DATE}, sly_data={})
-    print(an_absence_types)
+    print(check_leave_balances_tool.invoke(args={"start_date": START_DATE}, sly_data={}))
+

--- a/tests/coded_tools/agentforce/test_agentforce_api.py
+++ b/tests/coded_tools/agentforce/test_agentforce_api.py
@@ -9,10 +9,8 @@
 #
 from unittest import TestCase
 
-from coded_tools.agentforce.agentforce_api import MOCK_RESPONSE_1
-from coded_tools.agentforce.agentforce_api import MOCK_RESPONSE_2
-from coded_tools.agentforce.agentforce_api import MOCK_SECRET
-from coded_tools.agentforce.agentforce_api import MOCK_SESSION_ID
+from unittest.mock import patch
+
 from coded_tools.agentforce.agentforce_api import AgentforceAPI
 
 
@@ -22,33 +20,42 @@ class TestAgentforceAPI(TestCase):
     """
 
     def test_invoke(self):
-        """
-        Tests the invoke method of the AgentforceAPI CodedTool.
-        The AgentforceAPI CodedTool should query the Agentforce agent and return a response.
-        Environment variables are NOT set for this test, so we expect the responses to be mocked.
-        """
-        agentforce_tool = AgentforceAPI()
-        # Ask a first question
-        inquiry_1 = "Can you give me a list of Jane Doe's most recent cases?"
-        sly_data = {}
-        # Get the response
-        response_1 = agentforce_tool.invoke(args={"inquiry": inquiry_1}, sly_data=sly_data)
-        # Check the response contains the expected string.
-        self.assertEqual(MOCK_RESPONSE_1["response"]["messages"][0]["message"], response_1)
-        # Check the sly_data dictionary has been updated and now contains the session_id and access_token
-        self.assertEqual(MOCK_SESSION_ID, sly_data.get("session_id", None))
-        self.assertEqual(MOCK_SECRET, sly_data.get("access_token", None))
+        """Agentforce API invokes the adapter and updates sly_data."""
 
-        # Follow up with what Agentforce asked for. Session exists now, reuse it to continue the conversation instead
-        # of starting a new one
-        inquiry_2 = "jdoe@example.com"
-        params = {"inquiry": inquiry_2}
-        response_2 = agentforce_tool.invoke(args=params, sly_data=sly_data)
-        # Check the response contains the expected string.
-        self.assertEqual(MOCK_RESPONSE_2["response"]["messages"][0]["message"], response_2)
-        # Check the session is still the same
-        self.assertEqual(MOCK_SESSION_ID, sly_data.get("session_id", None))
-        self.assertEqual(MOCK_SECRET, sly_data.get("access_token", None))
+        class FakeAgentforceAdapter:
+            def __init__(self):
+                self.is_configured = True
+                self.calls = 0
 
-        # Close the session
-        agentforce_tool.agentforce.close_session(sly_data.get("session_id", None), sly_data.get("access_token", None))
+            def post_message(self, message, session_id=None, access_token=None):
+                self.calls += 1
+                if self.calls == 1:
+                    return {
+                        "session_id": "sess-1",
+                        "access_token": "token-1",
+                        "response": {"messages": [{"message": "resp-1"}]},
+                    }
+                return {
+                    "session_id": "sess-1",
+                    "access_token": "token-1",
+                    "response": {"messages": [{"message": "resp-2"}]},
+                }
+
+            @staticmethod
+            def close_session(session_id, access_token):
+                return None
+
+        with patch("coded_tools.agentforce.agentforce_api.AgentforceAdapter", FakeAgentforceAdapter):
+            agentforce_tool = AgentforceAPI()
+            sly_data = {}
+            response_1 = agentforce_tool.invoke(args={"inquiry": "q1"}, sly_data=sly_data)
+            self.assertEqual("resp-1", response_1)
+            self.assertEqual("sess-1", sly_data["session_id"])
+            self.assertEqual("token-1", sly_data["access_token"])
+
+            response_2 = agentforce_tool.invoke(args={"inquiry": "q2"}, sly_data=sly_data)
+            self.assertEqual("resp-2", response_2)
+            self.assertEqual("sess-1", sly_data["session_id"])
+            self.assertEqual("token-1", sly_data["access_token"])
+
+            agentforce_tool.agentforce.close_session(sly_data["session_id"], sly_data["access_token"])

--- a/tests/coded_tools/intranet_agents_with_tools/test_check_leave_balances_tool.py
+++ b/tests/coded_tools/intranet_agents_with_tools/test_check_leave_balances_tool.py
@@ -1,0 +1,22 @@
+from unittest import TestCase
+
+from coded_tools.intranet_agents_with_tools.check_leave_balances_tool import (
+    CheckLeaveBalancesTool,
+)
+
+
+class FakeAbsenceManager:
+    app_url = "http://example.com"
+
+    def get_absence_types(self, start_date):
+        return {"Absencemodel": ["foo"], "Start_date": start_date}
+
+
+class TestCheckLeaveBalancesTool(TestCase):
+    def test_invoke_uses_absence_manager(self):
+        tool = CheckLeaveBalancesTool(absence_manager=FakeAbsenceManager())
+        result = tool.invoke({"start_date": "2024-01-01"}, {})
+        self.assertEqual("Absence Management", result["app_name"])
+        self.assertEqual("http://example.com", result["app_url"])
+        self.assertEqual(["foo"], result["Absencemodel"])
+


### PR DESCRIPTION
## Summary
- remove internal mock responses from agentforce and intranet tools
- raise informative errors when Slack SDK or other services are missing
- test agentforce API and leave balance tool with injected mocks

## Testing
- `pytest tests/coded_tools/agentforce/test_agentforce_api.py tests/coded_tools/intranet_agents_with_tools/test_check_leave_balances_tool.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a522b91c888333a32f0733d6a0033a