### PR TITLE
feat: add rate limiting and metrics

### DIFF
--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -1024,3 +1024,8 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 ## Update 2025-09-27T18:00Z
 - Converted dashboard tabs to React Router routes with responsive grid layout, global context and theme toggling. Added skeleton loaders, error boundaries and accessibility improvements.
 - Next: extend loading/error handling across remaining components and enhance test coverage.
+
+## Update 2025-09-27T19:00Z
+- Integrated Flask-Limiter with Redis backend and per-user/per-IP caps on chat and hippo queries.
+- `/api/health` now reports blocked request counts for monitoring.
+- Next: tune rate thresholds and expand rate-limit tests.

--- a/apps/legal_discovery/chat_routes.py
+++ b/apps/legal_discovery/chat_routes.py
@@ -5,7 +5,7 @@ from coded_tools.legal_discovery.timeline_manager import TimelineManager
 
 from .database import db
 from .models import MessageAuditLog
-from .extensions import socketio, limiter
+from .extensions import socketio, limiter, user_limit_key
 from .chat_state import user_input_queue
 from .voice import synthesize_voice, get_available_voices
 from .feature_flags import FEATURE_FLAGS
@@ -103,6 +103,8 @@ def _handle_transcript(transcript: str, data: dict) -> dict:
     }
 
 @chat_bp.post("/query")
+@limiter.limit("100/minute")
+@limiter.limit("50/minute", key_func=user_limit_key)
 @auth_required
 def query_agent():
     data = request.get_json() or {}

--- a/apps/legal_discovery/extensions.py
+++ b/apps/legal_discovery/extensions.py
@@ -1,8 +1,44 @@
-from flask_socketio import SocketIO
+"""Shared Flask extensions for the legal discovery app."""
+
+from collections import Counter
+
+import jwt
+from flask import current_app, request, session
 from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
+from flask_socketio import SocketIO
+
+
+def user_limit_key() -> str:
+    """Return a rate limit key based on the authenticated user.
+
+    Falls back to the remote IP when no user identifier is available.
+    """
+
+    auth_header = request.headers.get("Authorization", "")
+    if auth_header.startswith("Bearer "):
+        token = auth_header.split(" ", 1)[1]
+        try:
+            data = jwt.decode(token, current_app.config["JWT_SECRET"], algorithms=["HS256"])
+            user_id = data.get("sub")
+            if user_id is not None:
+                return f"user:{user_id}"
+        except jwt.PyJWTError:
+            pass
+    if session.get("user"):
+        return f"user:{session['user']}"
+    return get_remote_address()
+
 
 socketio = SocketIO()
 limiter = Limiter(key_func=get_remote_address)
 
-__all__ = ["socketio", "limiter"]
+# Track how many requests were blocked by rate limiting.
+blocked_requests: Counter[str] = Counter()
+
+__all__ = [
+    "socketio",
+    "limiter",
+    "user_limit_key",
+    "blocked_requests",
+]

--- a/apps/legal_discovery/hippo_routes.py
+++ b/apps/legal_discovery/hippo_routes.py
@@ -17,7 +17,7 @@ except Exception:  # pragma: no cover - driver may be absent
 
 from . import hippo
 from .database import db, log_retrieval_trace, log_objection_resolution
-from .extensions import socketio
+from .extensions import socketio, limiter, user_limit_key, blocked_requests
 from .models import ObjectionEvent, ObjectionResolution
 from .models_trial import TranscriptSegment, TrialSession
 from .trial_assistant.services.objection_engine import engine
@@ -60,7 +60,11 @@ def health() -> 'flask.Response':
     except Exception:
         chroma_status = "fail"
 
-    return jsonify({"neo4j": neo4j_status, "chroma": chroma_status})
+    return jsonify({
+        "neo4j": neo4j_status,
+        "chroma": chroma_status,
+        "blocked_requests": dict(blocked_requests),
+    })
 
 
 @bp.post("/index")
@@ -78,6 +82,8 @@ def index_document():
 
 
 @bp.post("/query")
+@limiter.limit("100/minute")
+@limiter.limit("50/minute", key_func=user_limit_key)
 @auth_required
 def query_document():
     data = request.get_json() or {}

--- a/apps/legal_discovery/interface_flask.py
+++ b/apps/legal_discovery/interface_flask.py
@@ -30,7 +30,7 @@ from .chat_state import user_input_queue
 from .chain_logger import ChainEventType, log_event
 from .database import db
 from .exhibit_routes import exhibits_bp
-from .extensions import limiter, socketio
+from .extensions import limiter, socketio, blocked_requests
 from .feature_flags import FEATURE_FLAGS
 from .hippo_routes import bp as hippo_bp, objections_bp, health_bp
 from .trial_assistant import bp as trial_assistant_bp
@@ -124,6 +124,8 @@ if not secret_key or not jwt_secret:
     raise RuntimeError("FLASK_SECRET_KEY and JWT_SECRET must be set")
 app.config["SECRET_KEY"] = secret_key
 app.config["JWT_SECRET"] = jwt_secret
+# Configure rate limiting storage (Redis in production).
+app.config["RATELIMIT_STORAGE_URI"] = os.environ.get("REDIS_URL", "memory://")
 # Allow the primary relational store to be configured at runtime. Default to
 # SQLite for local development but override with an environment-provided
 # PostgreSQL connection string when available so the application scales under
@@ -170,6 +172,14 @@ thread_started = False  # pylint: disable=invalid-name
 def metrics() -> Response:
     """Expose Prometheus metrics."""
     return Response(generate_latest(), mimetype=CONTENT_TYPE_LATEST)
+
+
+@app.errorhandler(429)
+def rate_limit_handler(exc):
+    """Increment blocked request metrics and return a JSON error."""
+    endpoint = request.endpoint or request.path
+    blocked_requests[endpoint] += 1
+    return jsonify({"error": "rate limit exceeded"}), 429
 
 # Shared crawler instance for legal references
 legal_crawler = LegalCrawler()

--- a/tests/apps/test_health_endpoint.py
+++ b/tests/apps/test_health_endpoint.py
@@ -12,4 +12,4 @@ def test_health_endpoint_returns_status_keys():
     resp = client.get("/api/health")
     assert resp.status_code == 200
     data = resp.get_json()
-    assert set(data.keys()) == {"neo4j", "chroma"}
+    assert set(data.keys()) == {"neo4j", "chroma", "blocked_requests"}


### PR DESCRIPTION
## Summary
- integrate Redis-backed flask-limiter and track blocked requests
- enforce per-user and per-IP limits on chat and hippo query routes
- report rate-limit blocks via `/api/health`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a59b798f288333acdb085130439130