### PR TITLE
feat: add structured logging metrics and tracing

### DIFF
--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -1037,3 +1037,7 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 - Introduced RQ task queue with Redis and async routes for binder generation, indexing and transcript analysis.
 - Added /api/tasks/<id> for polling.
 - Next: hook frontend to poll task status and handle long-running jobs.
+
+## Update 2025-09-28T06:00Z
+- Enabled structured JSON logging, Prometheus metrics and OpenTelemetry tracing in the backend.
+- Next: expand tracing coverage across additional routes and export spans to an OTLP backend.

--- a/apps/legal_discovery/extensions.py
+++ b/apps/legal_discovery/extensions.py
@@ -1,12 +1,20 @@
 """Shared Flask extensions for the legal discovery app."""
 
+import logging
+import os
 from collections import Counter
 
 import jwt
+import structlog
 from flask import current_app, request, session
 from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
 from flask_socketio import SocketIO
+from opentelemetry import trace
+from opentelemetry.instrumentation.flask import FlaskInstrumentor
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter
+from prometheus_flask_exporter import PrometheusMetrics
 
 
 def user_limit_key() -> str:
@@ -32,6 +40,39 @@ def user_limit_key() -> str:
 
 socketio = SocketIO()
 limiter = Limiter(key_func=get_remote_address)
+metrics = PrometheusMetrics.for_app_factory()
+
+
+def configure_logging() -> None:
+    """Configure structlog for JSON-formatted logs."""
+
+    log_level = os.environ.get("LOG_LEVEL", "INFO").upper()
+    logging.basicConfig(format="%(message)s", level=log_level)
+    structlog.configure(
+        processors=[
+            structlog.processors.TimeStamper(fmt="iso"),
+            structlog.stdlib.add_log_level,
+            structlog.processors.StackInfoRenderer(),
+            structlog.processors.format_exc_info,
+            structlog.processors.JSONRenderer(),
+        ],
+        context_class=dict,
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        wrapper_class=structlog.stdlib.BoundLogger,
+        cache_logger_on_first_use=True,
+    )
+
+
+def init_tracing(app) -> None:
+    """Initialize OpenTelemetry tracing for the Flask app."""
+
+    provider = TracerProvider()
+    provider.add_span_processor(BatchSpanProcessor(ConsoleSpanExporter()))
+    trace.set_tracer_provider(provider)
+    FlaskInstrumentor().instrument_app(app)
+
+
+tracer = trace.get_tracer(__name__)
 
 # Track how many requests were blocked by rate limiting.
 blocked_requests: Counter[str] = Counter()
@@ -39,6 +80,10 @@ blocked_requests: Counter[str] = Counter()
 __all__ = [
     "socketio",
     "limiter",
+    "metrics",
     "user_limit_key",
     "blocked_requests",
+    "configure_logging",
+    "init_tracing",
+    "tracer",
 ]

--- a/apps/legal_discovery/interface_flask.py
+++ b/apps/legal_discovery/interface_flask.py
@@ -18,7 +18,7 @@ import schedule
 import spacy
 from flask import Flask, Response, jsonify, render_template, request, send_file
 from more_itertools import chunked
-from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
+import structlog
 from pyhocon import ConfigFactory
 from spacy.cli import download as spacy_download
 from weasyprint import HTML
@@ -31,7 +31,15 @@ from .chat_state import user_input_queue
 from .chain_logger import ChainEventType, log_event
 from .database import db
 from .exhibit_routes import exhibits_bp
-from .extensions import limiter, socketio, blocked_requests
+from .extensions import (
+    blocked_requests,
+    configure_logging,
+    init_tracing,
+    limiter,
+    metrics,
+    socketio,
+    tracer,
+)
 from .feature_flags import FEATURE_FLAGS
 from .hippo_routes import bp as hippo_bp, objections_bp, health_bp
 from .tasks import tasks_bp
@@ -87,8 +95,10 @@ except Exception:  # pragma: no cover - optional dependency
     def tear_down_legal_discovery_assistant(*args, **kwargs):
         return None
 
-# Configure logging before any other setup so early steps are captured
-logging.basicConfig(level=os.environ.get("LOG_LEVEL", "INFO"))
+
+# Configure logging and tracing before any other setup
+configure_logging()
+logger = structlog.get_logger(__name__)
 
 bates_service = BatesNumberingService()
 
@@ -110,12 +120,13 @@ os.environ["AGENT_LLM_INFO_FILE"] = os.environ.get(
 STATIC_DIR = os.path.join(os.path.dirname(__file__), "static")
 BUNDLE_PATH = os.path.join(STATIC_DIR, "bundle.js")
 if not os.path.exists(BUNDLE_PATH):
-    logging.warning(
+    logger.warning(
         "Frontend bundle missing at %s; run `npm --prefix apps/legal_discovery run build` before starting the server.",
         BUNDLE_PATH,
     )
 app = Flask(__name__)
-logger = app.logger
+metrics.init_app(app)
+init_tracing(app)
 config_path = os.environ.get("LEGAL_DISCOVERY_CONFIG")
 secret_key = os.environ.get("FLASK_SECRET_KEY")
 jwt_secret = os.environ.get("JWT_SECRET")
@@ -172,18 +183,14 @@ atexit.register(executor.shutdown)
 thread_started = False  # pylint: disable=invalid-name
 
 
-@app.route("/metrics")
-def metrics() -> Response:
-    """Expose Prometheus metrics."""
-    return Response(generate_latest(), mimetype=CONTENT_TYPE_LATEST)
-
-
 @app.errorhandler(429)
 def rate_limit_handler(exc):
     """Increment blocked request metrics and return a JSON error."""
-    endpoint = request.endpoint or request.path
-    blocked_requests[endpoint] += 1
-    return jsonify({"error": "rate limit exceeded"}), 429
+    with tracer.start_as_current_span("rate_limit_handler"):
+        endpoint = request.endpoint or request.path
+        blocked_requests[endpoint] += 1
+        return jsonify({"error": "rate limit exceeded"}), 429
+
 
 # Shared crawler instance for legal references
 legal_crawler = LegalCrawler()
@@ -212,6 +219,7 @@ def _initialize_agent() -> None:
         app.logger.info("Setting up legal discovery assistant...")
         legal_discovery_session, legal_discovery_thread = set_up_legal_discovery_assistant(_gather_upload_paths())
         app.logger.info("...legal discovery assistant set up.")
+
 
 threading.Thread(target=_initialize_agent, daemon=True).start()
 
@@ -826,9 +834,7 @@ def ingest_document(
         db.session.add(DocumentMetadata(document_id=doc_id, schema="evidence_scorecard", data=scores))
         try:
             sanctions = SanctionsRiskAnalyzer().assess(redacted_text, scorecard=scores)
-            db.session.add(
-                DocumentMetadata(document_id=doc_id, schema="sanctions_risk", data=sanctions)
-            )
+            db.session.add(DocumentMetadata(document_id=doc_id, schema="sanctions_risk", data=sanctions))
         except Exception as exc:
             logger.exception("sanctions risk analysis failed", exc_info=exc)
         db.session.commit()

--- a/apps/legal_discovery/requirements.txt
+++ b/apps/legal_discovery/requirements.txt
@@ -15,9 +15,12 @@ more-itertools
 neo4j
 networkx
 neuro-san
+opentelemetry-instrumentation-flask
+opentelemetry-sdk
 pandas
 Pillow
 prometheus-client>=0.20.0
+prometheus-flask-exporter
 psycopg2-binary
 pydantic
 pyhocon
@@ -39,5 +42,6 @@ schedule
 scikit-learn
 sentence-transformers
 spacy
+structlog
 TTS
 weasyprint

--- a/requirements.txt
+++ b/requirements.txt
@@ -75,3 +75,7 @@ en-core-web-sm @ https://github.com/explosion/spacy-models/releases/download/en_
 
 Flask-Limiter
 PyJWT
+prometheus-flask-exporter
+structlog
+opentelemetry-sdk
+opentelemetry-instrumentation-flask


### PR DESCRIPTION
## Summary
- configure structlog JSON logging and OpenTelemetry tracing helpers
- expose Prometheus metrics via prometheus_flask_exporter
- wire metrics, logging, and tracing into Flask interface

## Testing
- `python -m black apps/legal_discovery/extensions.py apps/legal_discovery/interface_flask.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5a13dd0148333b14e925d2b1584e5