### PR TITLE
Persist theme setting

### DIFF
--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -1061,3 +1061,7 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 - Introduced design tokens for typography, spacing and accent scale with global CSS variables.
 - Refactored GraphSection and ExhibitTab to consume spacing and font tokens for consistent theming.
 - Next: migrate remaining components to the new theme system and expand color usage.
+
+## Update 2025-10-06T12:30Z
+- Persisted theme selection in user settings and applied body class.
+- Next: sync remaining components with theme preference.

--- a/apps/legal_discovery/interface_flask.py
+++ b/apps/legal_discovery/interface_flask.py
@@ -374,6 +374,7 @@ def manage_settings():
                 "gcp_vertex_ai_data_store_id": user_settings.gcp_vertex_ai_data_store_id,
                 "gcp_vertex_ai_search_app": user_settings.gcp_vertex_ai_search_app,
                 "gcp_service_account_key": user_settings.gcp_service_account_key,
+                "theme": user_settings.theme,
             }
         flags = settings.get_feature_flags()
         for key in FEATURE_FLAGS:

--- a/apps/legal_discovery/models.py
+++ b/apps/legal_discovery/models.py
@@ -328,6 +328,7 @@ class UserSetting(db.Model):
     gcp_vertex_ai_data_store_id = db.Column(db.String(255), nullable=True)
     gcp_vertex_ai_search_app = db.Column(db.String(255), nullable=True)
     gcp_service_account_key = db.Column(db.Text, nullable=True)
+    theme = db.Column(db.String(20), nullable=True)
     feature_flags = db.Column(db.JSON, nullable=False, default=dict)
 
 

--- a/apps/legal_discovery/settings.py
+++ b/apps/legal_discovery/settings.py
@@ -37,6 +37,7 @@ def save_user_settings(data, user_id=1):
     settings.gcp_vertex_ai_data_store_id = data.get("gcp_vertex_ai_data_store_id")
     settings.gcp_vertex_ai_search_app = data.get("gcp_vertex_ai_search_app")
     settings.gcp_service_account_key = data.get("gcp_service_account_key")
+    settings.theme = data.get("theme")
     db.session.add(settings)
     db.session.commit()
     return settings

--- a/apps/legal_discovery/src/AppContext.jsx
+++ b/apps/legal_discovery/src/AppContext.jsx
@@ -10,13 +10,39 @@ export function AppProvider({ children }) {
 
   useEffect(() => {
     document.documentElement.dataset.theme = theme;
+    document.body.classList.remove('light', 'dark');
+    document.body.classList.add(theme);
     localStorage.setItem('theme', theme);
   }, [theme]);
+
+  useEffect(() => {
+    fetch('/api/settings')
+      .then(r => r.json())
+      .then(data => {
+        setSettings(data);
+        if (data.theme) setTheme(data.theme);
+      })
+      .catch(() => {});
+    fetch('/api/feature-flags')
+      .then(r => r.json())
+      .then(setFeatureFlags)
+      .catch(() => {});
+  }, []);
 
   const toggleTheme = () => setTheme(t => (t === 'dark' ? 'light' : 'dark'));
 
   const value = useMemo(
-    () => ({ settings, setSettings, session, setSession, featureFlags, setFeatureFlags, theme, toggleTheme }),
+    () => ({
+      settings,
+      setSettings,
+      session,
+      setSession,
+      featureFlags,
+      setFeatureFlags,
+      theme,
+      setTheme,
+      toggleTheme,
+    }),
     [settings, session, featureFlags, theme]
   );
 

--- a/apps/legal_discovery/src/components/SettingsModal.jsx
+++ b/apps/legal_discovery/src/components/SettingsModal.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef } from "react";
 import { useAppContext } from "../AppContext";
 
 function SettingsModal({open,onClose}) {
-  const { setSettings, setFeatureFlags } = useAppContext();
+  const { setSettings, setFeatureFlags, theme, setTheme } = useAppContext();
   const [form,setForm] = useState({});
   const ref = useRef();
   const firstFieldRef = useRef();
@@ -14,7 +14,7 @@ function SettingsModal({open,onClose}) {
       Promise.all([
         fetch('/api/settings').then(r=>r.json()),
         fetch('/api/feature-flags').then(r=>r.json())
-      ]).then(([settings, flags]) => setForm({...settings, ...flags}));
+      ]).then(([settings, flags]) => setForm({ theme, ...settings, ...flags }));
       setTimeout(()=>firstFieldRef.current && firstFieldRef.current.focus(),0);
     } else if(previousFocus.current) {
       previousFocus.current.focus();
@@ -36,6 +36,7 @@ function SettingsModal({open,onClose}) {
     ]).then(()=>{
       setSettings(rest);
       setFeatureFlags(flags);
+      if(rest.theme) setTheme(rest.theme);
       onClose();
     });
   };
@@ -80,6 +81,12 @@ function SettingsModal({open,onClose}) {
           <label>GCP Vertex Data Store<input type="text" name="gcp_vertex_ai_data_store_id" value={form.gcp_vertex_ai_data_store_id||''} onChange={update} className="w-full p-2 rounded"/></label>
           <label>GCP Search App<input type="text" name="gcp_vertex_ai_search_app" value={form.gcp_vertex_ai_search_app||''} onChange={update} className="w-full p-2 rounded"/></label>
           <label>GCP Service Account Key<textarea name="gcp_service_account_key" value={form.gcp_service_account_key||''} onChange={update} className="w-full p-2 rounded" rows="2"/></label>
+          <label>Theme
+            <select name="theme" value={form.theme||'dark'} onChange={update} className="w-full p-2 rounded">
+              <option value="dark">Dark</option>
+              <option value="light">Light</option>
+            </select>
+          </label>
           <label className="flex items-center space-x-2"><input type="checkbox" name="theories" checked={form.theories||false} onChange={update}/><span>Enable Legal Theories</span></label>
           <label className="flex items-center space-x-2"><input type="checkbox" name="binder" checked={form.binder||false} onChange={update}/><span>Enable Binder</span></label>
           <label className="flex items-center space-x-2"><input type="checkbox" name="chat" checked={form.chat||false} onChange={update}/><span>Enable Chat</span></label>


### PR DESCRIPTION
## Summary
- Save the user's theme preference with `/api/settings` and expose it via the Settings modal.
- Apply light/dark class to `<body>` and load saved settings on app startup.
- Extend `UserSetting` model and API responses to include theme field.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5d23e594483338b50a689a3c3219c