### PR TITLE
Add startup scripts for data services and database seeding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,11 @@ frontend-build: ## Install deps and build the legal discovery React dashboard
 	npm --prefix apps/legal_discovery run build
 
 test: lint lint-tests ## Run tests with coverage
-        PYTHONPATH=$(CURDIR) python -m pytest tests/ -v --cov=coded_tools,run.py
+       PYTHONPATH=$(CURDIR) python -m pytest tests/ -v --cov=coded_tools,run.py
+
+compose-up: ## Build images and start all services with seed data
+	docker-compose up --build -d
+	python deploy/seed_postgres.py
 
 .PHONY: help venv install activate stt-service tts-service lint lint-tests test
 .DEFAULT_GOAL := help

--- a/agents--features and memory/condensed_agents.md
+++ b/agents--features and memory/condensed_agents.md
@@ -299,3 +299,8 @@ WE STARTED ON #3, INSTEAD OF #1. DEAL WITH IT, FINISH IMPLEMENTING #3, AND THEN 
 - Added ffmpeg and espeak packages to Dockerfile for STT/TTS libraries.
 - Extended docker-compose with Redis service and audio cache volume; documented build/run commands.
 - Next: verify audio cache persistence and message bus behaviour in the full stack.
+
+## Update 2025-08-20T22:57Z
+- Added scripts to seed PostgreSQL and launch Chroma/Neo4j containers.
+- Makefile now includes `compose-up` target to build stack and apply seed data.
+- Next: verify `compose-up` runs cleanly across environments.

--- a/deploy/seed_postgres.py
+++ b/deploy/seed_postgres.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""Seed PostgreSQL schema and default data for legal_discovery."""
+import os
+from apps.legal_discovery.interface_flask import app
+from apps.legal_discovery.models import Case
+from apps.legal_discovery.database import db
+
+# Default to local docker-compose settings if DATABASE_URL is unset
+os.environ.setdefault(
+    "DATABASE_URL",
+    "postgresql+psycopg2://postgres:postgres@localhost:5432/legal_discovery",
+)
+
+def main() -> None:
+    """Create tables and insert initial records."""
+    with app.app_context():
+        db.create_all()
+        if not Case.query.first():
+            db.session.add(Case(name="Default Case"))
+            db.session.commit()
+        print("PostgreSQL schema seeded.")
+
+if __name__ == "__main__":
+    main()

--- a/deploy/start_data_services.sh
+++ b/deploy/start_data_services.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+
+# Start PostgreSQL, Chroma and Neo4j containers
+# Requires docker-compose to be installed
+
+docker-compose up -d postgres chromadb neo4j


### PR DESCRIPTION
## Summary
- add script to seed PostgreSQL schema with default case
- provide shell helper to launch PostgreSQL, Chroma and Neo4j containers
- expose `compose-up` target in Makefile to build stack and apply seed data

## Testing
- `pytest`
- `bash -n deploy/start_data_services.sh`
- `python -m py_compile deploy/seed_postgres.py`


------
https://chatgpt.com/codex/tasks/task_e_68a65069aba0833382a4158ed326bfec