### PR TITLE
feat: ensure idempotent hippo ingestion

### DIFF
--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -945,3 +945,8 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 - Consolidated Neo4j schema bootstrap via shared `bootstrap_graph` helper and removed legacy `ensure_graph_constraints`.
 - `hippo_routes` and `interface_flask` now invoke `bootstrap_graph` on load.
 - Next: verify redundant calls are trimmed once live Neo4j integration is confirmed.
+
+## Update 2025-09-23T18:00Z
+- Switched Hippo ingestion to upsert segments in Chroma with deterministic IDs.
+- Added composite index for `ingestion_logs` lookups.
+- Next: validate ingestion telemetry with live Postgres and vector stores.

--- a/apps/legal_discovery/database.py
+++ b/apps/legal_discovery/database.py
@@ -13,6 +13,7 @@ class IngestionLog(db.Model):
     """Tracks document ingestions to ensure idempotency."""
 
     __tablename__ = "ingestion_logs"
+    __table_args__ = (db.Index("ix_ingestion_case_path", "case_id", "path"),)
 
     id = db.Column(db.Integer, primary_key=True)
     case_id = db.Column(db.String(64), nullable=False)

--- a/apps/legal_discovery/hippo.py
+++ b/apps/legal_discovery/hippo.py
@@ -244,9 +244,11 @@ def ingest_document(
 ) -> str:
     """Index ``text`` for ``case_id`` and return the generated ``doc_id``.
 
-    The function accepts optional ``graph_db`` and ``vector_db`` managers to
-    perform bulk upserts to Neo4j and Chroma respectively.  Callers may also
-    supply a custom ``entity_extractor`` for legal information extraction.
+    ``doc_id`` and ``segment_hash`` values are deterministically derived from
+    ``(case_id, path)`` and the segment contents so that repeated ingestions
+    are idempotent.  Optional ``graph_db`` and ``vector_db`` managers allow
+    bulk upserts to Neo4j and Chroma.  Callers may also provide a pluggable
+    ``entity_extractor`` for richer legal information extraction.
     """
 
     start = time.perf_counter()
@@ -268,20 +270,22 @@ def ingest_document(
 
     if vector_db:
         try:  # pragma: no cover - best effort
-            vector_db.add_documents(
-                documents=[s.text for s in segments],
-                metadatas=[
-                    {
-                        "doc_id": doc_id,
-                        "case_id": case_id,
-                        "segment_id": s.segment_id,
-                        "segment_hash": s.segment_hash,
-                        "path": path,
-                    }
-                    for s in segments
-                ],
-                ids=[s.segment_hash for s in segments],
-            )
+            docs = [s.text for s in segments]
+            metas = [
+                {
+                    "doc_id": doc_id,
+                    "case_id": case_id,
+                    "segment_id": s.segment_id,
+                    "segment_hash": s.segment_hash,
+                    "path": path,
+                }
+                for s in segments
+            ]
+            ids = [s.segment_hash for s in segments]
+            if hasattr(vector_db, "upsert"):
+                vector_db.upsert(documents=docs, metadatas=metas, ids=ids)
+            else:
+                vector_db.add_documents(documents=docs, metadatas=metas, ids=ids)
         except Exception as e:
             errors.append(f"vector: {e}")
 


### PR DESCRIPTION
## Summary
- ensure Hippo ingestion derives deterministic doc and segment identifiers
- upsert Chroma segments when available to avoid duplicates
- track ingestion attempts with indexed Postgres log table

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4cafdef6c83339e71e5b69c988971