### PR TITLE
feat: hybrid hippo query with llm ranking

### DIFF
--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -1074,3 +1074,7 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 ## Update 2025-10-06T13:30Z
 - Regenerated package-lock.json via npm ci to lock frontend dependencies.
 - Next: ensure CI uses package-lock for consistent builds.
+
+## Update 2025-10-06T14:45Z
+- Added entity-linked Hippo query combining Neo4j PPR, Chroma search and cross-encoder/LLM re-ranking.
+- Next: surface score breakdown in the dashboard and broaden ranking tests.


### PR DESCRIPTION
## Summary
- entity-link Hippo queries seed Neo4j PPR and Chroma searches
- merge graph and dense candidates by segment and re-rank via cross-encoder or LLM
- log update in legal discovery module guide

## Testing
- `pytest tests/apps/test_hippo_query.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a65cc412e48333bb6065c8c800b596