### PR TITLE
Add installation script and deployment docs

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,34 @@
+# Deployment
+
+This project is deployed with Docker Compose. The core API and frontend run in the `legal_discovery` service, with supporting databases and caches.
+
+## Port mappings
+
+| Service | Host Port | Container Port | Description |
+|---------|-----------|----------------|-------------|
+| legal_discovery | 8080 | 5001 | Flask API and web dashboard |
+| postgres | 5432 | 5432 | PostgreSQL database |
+| neo4j | 7474 / 7687 | 7474 / 7687 | Neo4j HTTP and Bolt ports |
+| chromadb | 8000 | 8000 | Chroma vector store |
+| redis | 6379 | 6379 | Redis cache and task queue |
+
+## SSL termination
+
+The stack exposes plain HTTP. To serve HTTPS, place a reverse proxy such as Nginx or Traefik in front of the `legal_discovery` service:
+
+1. Terminate TLS at the proxy with certificates from Let's Encrypt or another CA.
+2. Forward incoming requests on port 443 to `legal_discovery` on port `8080`.
+3. Optionally, redirect port 80 to 443 for all HTTP traffic.
+
+## Environment variables
+
+`docker-compose.yml` reads configuration from environment variables, typically provided via a `.env` file. Key variables include:
+
+- `FLASK_SECRET_KEY`
+- `JWT_SECRET`
+- `DATABASE_URL` (default `postgresql+psycopg2://postgres:postgres@postgres:5432/legal_discovery`)
+- `CHROMA_HOST` / `CHROMA_PORT`
+- `NEO4J_URI`, `NEO4J_USER`, `NEO4J_PASSWORD`
+- `REDIS_URL`
+
+Adjust these values for your deployment. After updating the `.env` file, rerun `install.sh` to apply changes.

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Check prerequisites
+if ! command -v docker >/dev/null 2>&1; then
+  echo "Docker is required. Please install Docker." >&2
+  exit 1
+fi
+
+if docker compose version >/dev/null 2>&1; then
+  COMPOSE="docker compose"
+elif command -v docker-compose >/dev/null 2>&1; then
+  COMPOSE="docker-compose"
+else
+  echo "Docker Compose is required. Please install docker compose." >&2
+  exit 1
+fi
+
+# Pull and build images
+$COMPOSE pull
+$COMPOSE build
+
+# Start dependencies for migrations
+$COMPOSE up -d postgres neo4j chromadb redis
+
+# Run database migrations (Alembic or Flask-Migrate)
+set +e
+$COMPOSE run --rm legal_discovery alembic upgrade head 2>/dev/null
+if [ $? -ne 0 ]; then
+  $COMPOSE run --rm -e FLASK_APP=apps.legal_discovery.startup:app legal_discovery flask db upgrade
+fi
+set -e
+
+# Launch full stack
+$COMPOSE up -d
+
+echo "Stack is running. Access the app at http://localhost:8080"


### PR DESCRIPTION
## Summary
- add install.sh to bootstrap Docker stack with migrations
- document deployment ports, SSL, and env vars

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a6d54b54d88333baa9bc9750414303