### PR TITLE
Ensure objection events reference retrieval trace IDs

### DIFF
--- a/apps/legal_discovery/database.py
+++ b/apps/legal_discovery/database.py
@@ -127,6 +127,11 @@ def log_objection_event(
     confidence: int,
     extracted_phrase: str,
     suggested_cures: List[str] | None = None,
+    trace_id: str | None = None,
+    refs: List[Dict] | None = None,
+    path: Dict | List | None = None,
+    action_taken: str | None = None,
+    outcome: str | None = None,
 ) -> "ObjectionEvent":
     """Persist and return an objection event."""
 
@@ -136,11 +141,16 @@ def log_objection_event(
         evt = ObjectionEvent(
             session_id=session_id,
             segment_id=segment_id,
+            trace_id=trace_id,
             type=type,
             ground=ground,
             confidence=confidence,
             extracted_phrase=extracted_phrase,
             suggested_cures=suggested_cures or [],
+            refs=refs,
+            path=path,
+            action_taken=action_taken,
+            outcome=outcome,
         )
         db.session.add(evt)
         db.session.commit()

--- a/apps/legal_discovery/trial_assistant/__init__.py
+++ b/apps/legal_discovery/trial_assistant/__init__.py
@@ -44,7 +44,6 @@ def handle_segment(data):
         },
         room=session_id,
     )
-    events = engine.analyze_segment(session_id, seg)
     refs: list = []
     trace_id = None
     sess = db.session.get(TrialSession, session_id)
@@ -71,11 +70,13 @@ def handle_segment(data):
             )
         except Exception:  # pragma: no cover - best effort
             pass
-    for e in events:
-        e.refs = refs
-        e.trace_id = trace_id
-        e.path = refs[0]["path"] if refs else None
-    db.session.commit()
+    events = engine.analyze_segment(
+        session_id,
+        seg,
+        trace_id=trace_id,
+        refs=refs,
+        path=refs[0]["path"] if refs else None,
+    )
     for e in events:
         emit(
             "objection_event",

--- a/apps/legal_discovery/trial_assistant/services/objection_engine.py
+++ b/apps/legal_discovery/trial_assistant/services/objection_engine.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import re
-from typing import List
+from typing import Any, Dict, List
 
 import yaml
 
@@ -30,7 +30,15 @@ class ObjectionEngine:
                 responses = counter.get("cures", [])
                 self.counter_compiled.append((name, cpats, responses))
 
-    def analyze_segment(self, session_id: str, seg: TranscriptSegment) -> List[ObjectionEvent]:
+    def analyze_segment(
+        self,
+        session_id: str,
+        seg: TranscriptSegment,
+        *,
+        trace_id: str | None = None,
+        refs: List[Dict] | None = None,
+        path: Any | None = None,
+    ) -> List[ObjectionEvent]:
         text = seg.text or ""
         found: List[ObjectionEvent] = []
         for ground, patterns, cures in self.compiled:
@@ -43,6 +51,9 @@ class ObjectionEngine:
                     confidence=85,
                     extracted_phrase=text[:160],
                     suggested_cures=cures,
+                    trace_id=trace_id,
+                    refs=refs,
+                    path=path,
                 )
                 if evt:
                     found.append(evt)
@@ -56,6 +67,9 @@ class ObjectionEngine:
                     confidence=80,
                     extracted_phrase=text[:160],
                     suggested_cures=cures,
+                    trace_id=trace_id,
+                    refs=refs,
+                    path=path,
                 )
                 if evt:
                     found.append(evt)


### PR DESCRIPTION
## Summary
- propagate trace IDs, references and paths when logging objection events
- update task and realtime handlers to query retrievals before objection analysis
- allow objection engine to persist trace metadata for each event

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6e789db3883339380f561553e929c