### PR TITLE
Align Neo4j settings and document model env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,7 +389,10 @@ The `apps/legal_discovery` stack runs a Flask frontend backed by PostgreSQL, Neo
     CROSS_ENCODER_MODEL=cross-encoder/ms-marco-MiniLM-L-6-v2
     ```
 
-Docker Compose mounts the `.env` file into the application container so `config.py` can read it.
+    Docker Compose mounts the `.env` file into the application container so `config.py` can read it.  
+    - `NEO4J_PASSWORD` sets the admin password for the Neo4j instance and must match the value used by `docker-compose.yml`.
+    - `EMBED_MODEL` selects the sentence embedding model for vector storage.
+    - `CROSS_ENCODER_MODEL` sets the cross-encoder used to re-rank search results.
 
 2. Build and start the services:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - CHROMA_PORT=${CHROMA_PORT:-8000}
       - NEO4J_URI=${NEO4J_URI:-bolt://neo4j:7687}
       - NEO4J_USER=${NEO4J_USER:-neo4j}
-      - NEO4J_PASSWORD=${NEO4J_PASSWORD:-neo4jPass123}
+      - NEO4J_PASSWORD=${NEO4J_PASSWORD}
       - REDIS_URL=${REDIS_URL:-redis://redis:6379/0}
       - FLASK_SECRET_KEY=${FLASK_SECRET_KEY}
       - JWT_SECRET=${JWT_SECRET}
@@ -57,12 +57,12 @@ services:
     env_file:
       - .env
     environment:
-      - NEO4J_AUTH=neo4j/${NEO4J_PASSWORD:-neo4jPass123}
+      - NEO4J_AUTH=neo4j/${NEO4J_PASSWORD}
     volumes:
       - ./docker_volumes/neo4j/data:/data
     healthcheck:
       # Ensure Bolt is up AND auth works
-      test: ["CMD-SHELL", "cypher-shell -a bolt://localhost:7687 -u neo4j -p \"$${NEO4J_PASSWORD:-neo4jPass123}\" \"RETURN 1\" | grep -q 1"]
+      test: ["CMD-SHELL", "cypher-shell -a bolt://localhost:7687 -u neo4j -p \"$${NEO4J_PASSWORD}\" \"RETURN 1\" | grep -q 1"]
       interval: 10s
       timeout: 5s
       retries: 20


### PR DESCRIPTION
## Summary
- Read Neo4j password from the .env file in docker-compose and keep the service on 5.23 with an updated healthcheck.
- Clarify environment variables for retrieval models in the Legal Discovery README section.

## Testing
- `pytest`
- `docker-compose build legal_discovery` *(fails: Error while fetching server API version: ('Connection aborted.', FileNotFoundError(2, 'No such file or directory')))*

------
https://chatgpt.com/codex/tasks/task_e_68a6ebff1b40833384177faa58844be5