### PR TITLE
Add release packaging script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,9 @@ frontend-build: ## Install deps and build the legal discovery React dashboard
 	npm --prefix apps/legal_discovery ci
 	npm --prefix apps/legal_discovery run build
 
+release: ## Build backend wheel, frontend assets, and bundle into tarball
+	python package_release.py
+
 test: lint lint-tests ## Run tests with coverage
        PYTHONPATH=$(CURDIR) python -m pytest tests/ -v --cov=coded_tools,run.py
 
@@ -71,7 +74,7 @@ compose-up: ## Build images and start all services with seed data
 	docker-compose up --build -d
 	python deploy/seed_postgres.py
 
-.PHONY: help venv install activate stt-service tts-service lint lint-tests test
+.PHONY: help venv install activate stt-service tts-service lint lint-tests test release
 .DEFAULT_GOAL := help
 
 help: ## Show this help message and exit

--- a/README.md
+++ b/README.md
@@ -450,3 +450,19 @@ python package_windows_exe.py
 
 The resulting `neuro-san-studio.exe` will be created under the `dist`
 directory for easy launching.
+
+### Packaging backend wheel and frontend assets
+
+To distribute the Flask backend and React dashboard together, build the
+wheel and frontend assets and bundle them into a tarball:
+
+```bash
+pip install -r requirements-build.txt
+python package_release.py
+```
+
+The script creates a Python wheel via `python -m build`, compiles the
+dashboard, and writes a `release-<version>.tar.gz` file under `dist/`. Set
+`GITHUB_REPOSITORY` and `GITHUB_TOKEN` to upload the tarball to a GitHub
+release or configure `INTERNAL_REGISTRY_URL` to push to an internal
+registry.

--- a/condensed AGENTS.md
+++ b/condensed AGENTS.md
@@ -191,3 +191,7 @@ we are now working on implementing a major feature, so stand by, this is  A GDDM
 - Ensured HippoRAG, sentence-transformers and scikit-learn dependencies are present.
 - Added README section covering `EMBED_MODEL`, `CROSS_ENCODER_MODEL` and Docker compose usage.
 - Next: rebuild the Docker image and verify retrieval models load successfully.
+
+## Update 2025-09-25T10:27Z
+- Added packaging script to build backend wheel and bundle frontend assets into a release tarball.
+- Next: wire the script into CI to publish artifacts automatically.

--- a/package_release.py
+++ b/package_release.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Build backend wheel and frontend assets, then bundle into a tarball.
+
+If environment variables for an internal registry or GitHub are provided,
+artifacts are uploaded for external access.
+"""
+from __future__ import annotations
+
+import os
+import pathlib
+import subprocess
+import tarfile
+
+import requests
+
+ROOT = pathlib.Path(__file__).parent.resolve()
+DIST = ROOT / "dist"
+FRONTEND = ROOT / "apps" / "legal_discovery"
+FRONTEND_DIST = FRONTEND / "dist"
+
+
+def build_backend() -> pathlib.Path:
+    """Build the backend wheel using python -m build."""
+    subprocess.run(
+        ["python", "-m", "build", "--wheel", "--outdir", str(DIST)], check=True
+    )
+    wheel = next(DIST.glob("*.whl"))
+    return wheel
+
+
+def build_frontend() -> None:
+    """Install frontend dependencies and build assets using npm."""
+    subprocess.run(["npm", "--prefix", str(FRONTEND), "ci"], check=True)
+    subprocess.run(["npm", "--prefix", str(FRONTEND), "run", "build"], check=True)
+
+
+def create_tarball(wheel: pathlib.Path) -> pathlib.Path:
+    """Package the wheel and frontend assets into a gzip tarball."""
+    tar_path = DIST / f"release-{wheel.stem}.tar.gz"
+    with tarfile.open(tar_path, "w:gz") as tar:
+        tar.add(wheel, arcname=wheel.name)
+        tar.add(FRONTEND_DIST, arcname="frontend")
+    return tar_path
+
+
+def upload_internal_registry(tar_path: pathlib.Path) -> None:
+    """Upload artifact to an internal registry if configured."""
+    url = os.environ.get("INTERNAL_REGISTRY_URL")
+    token = os.environ.get("INTERNAL_REGISTRY_TOKEN")
+    if not url:
+        return
+    headers = {"Authorization": f"Bearer {token}"} if token else {}
+    with tar_path.open("rb") as fh:
+        requests.put(f"{url.rstrip('/')}/{tar_path.name}", headers=headers, data=fh)
+
+
+def upload_github_release(tar_path: pathlib.Path, wheel: pathlib.Path) -> None:
+    """Upload artifact to GitHub Releases if credentials are present."""
+    repo = os.environ.get("GITHUB_REPOSITORY")
+    token = os.environ.get("GITHUB_TOKEN")
+    if not (repo and token):
+        return
+    version = wheel.name.split("-")[1]
+    tag = f"v{version}"
+    api = "https://api.github.com"
+    headers = {
+        "Authorization": f"token {token}",
+        "Accept": "application/vnd.github+json",
+    }
+    # Create or fetch release
+    r = requests.get(f"{api}/repos/{repo}/releases/tags/{tag}", headers=headers)
+    if r.status_code == 404:
+        r = requests.post(
+            f"{api}/repos/{repo}/releases",
+            headers=headers,
+            json={"tag_name": tag, "name": tag},
+        )
+    r.raise_for_status()
+    upload_url = r.json()["upload_url"].split("{")[0]
+    with tar_path.open("rb") as fh:
+        headers_update = headers.copy()
+        headers_update["Content-Type"] = "application/gzip"
+        requests.post(
+            f"{upload_url}?name={tar_path.name}",
+            headers=headers_update,
+            data=fh,
+        )
+
+
+def main() -> None:
+    DIST.mkdir(exist_ok=True)
+    wheel = build_backend()
+    build_frontend()
+    tar_path = create_tarball(wheel)
+    upload_internal_registry(tar_path)
+    upload_github_release(tar_path, wheel)
+    print(f"Created {tar_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,16 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "neuro-san-studio"
+version = "0.1.0"
+description = "Neuro SAN Studio backend"
+readme = "README.md"
+requires-python = ">=3.9"
+authors = [{name = "Cognizant AI Lab"}]
+dependencies = []
+
 [tool.isort]
 profile = "black"
 src_paths = ["apps", "coded_tools", "tests"]

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -18,5 +18,6 @@ isort==5.13.2
 pylint==3.3.1
 
 # Packaging
+build==1.2.1
 pyinstaller==6.4.0
 


### PR DESCRIPTION
## Summary
- add build metadata and release script bundling frontend assets and backend wheel
- document packaging and add Makefile target for releases
- log progress in condensed AGENTS

## Testing
- `isort run.py apps/ coded_tools/ --force-single-line --check-only` *(fails: many imports unsorted)*
- `black run.py apps/ coded_tools/ --check` *(fails: 44 files would be reformatted)*
- `flake8 run.py apps/ coded_tools/` *(fails: many style errors)*
- `pylint run.py apps/ coded_tools/` *(fails: unused imports and naming issues)*
- `pymarkdown --config ./.pymarkdownlint.yaml scan ./docs ./README.md` *(fails: line length and fenced block warnings)*
- `isort tests/ --force-single-line --check-only` *(fails: imports not sorted)*
- `black tests/ --check` *(fails: 32 files would be reformatted)*
- `flake8 tests/` *(fails: multiple style errors)*
- `pylint tests/` *(fails: docstring and other warnings)*
- `PYTHONPATH=$(pwd) python -m pytest tests/ -v --cov=coded_tools,run.py` *(fails: interrupted by KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f1c8980883339b2b509766de502e