### PR TITLE
Add container health check for deploy image

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,6 +403,21 @@ The `apps/legal_discovery` stack runs a Flask frontend backed by PostgreSQL, Neo
 
 The web UI is available at <http://localhost:8080>. Neo4j exposes its browser on port 7474 and the Bolt protocol on 7687; both use the password specified in `NEO4J_PASSWORD`.
 
+### Health Check Endpoint
+
+Containers expose `/api/health` so orchestrators can verify service status. A healthy instance returns HTTP `200` with a JSON body similar to:
+
+```json
+{
+  "neo4j": "ok",
+  "chroma": "ok",
+  "blocked_requests": {},
+  "cache": { "hits": 0, "misses": 0 }
+}
+```
+
+Any non-`200` response indicates the service is unhealthy and should be restarted.
+
 ---
 
 ## Developer Guide

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -55,8 +55,9 @@ FROM python:3.12-slim AS final
 # Set the shell and options in each FROM section per hadolint recommendations
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-# Install runtime dependencies for graph processing
-RUN apt-get update && apt-get install -y --no-install-recommends graphviz && rm -rf /var/lib/apt/lists/*
+# Install runtime dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    graphviz curl && rm -rf /var/lib/apt/lists/*
 
 # Set up user for app running in container
 ENV USERNAME=neuro-san
@@ -90,6 +91,9 @@ EXPOSE 30011
 # This default port number is also mentioned as AGENT_HTTP_PORT below
 # and ServiceAgentSession.DEFAULT_HTTP_PORT
 EXPOSE 8080
+
+# Ensure orchestrators can verify container health
+HEALTHCHECK --interval=30s --timeout=5s --retries=5 CMD curl -fsS http://localhost:8080/api/health || exit 1
 
 # Copy installed dependencies from the builder stage
 COPY --from=builder /install /usr/local


### PR DESCRIPTION
## Summary
- add health check to deploy Dockerfile probing `/api/health`
- document health check responses in README for orchestrators

## Testing
- `python -m pytest tests/apps/test_health_endpoint.py -q` *(fails: KeyboardInterrupt during dependency import)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f1e4f8f48333ac3756322a420006