### PR TITLE
Log health check failures and test error responses

### DIFF
--- a/tests/apps/test_health_endpoint.py
+++ b/tests/apps/test_health_endpoint.py
@@ -1,7 +1,10 @@
 """Unit tests for health endpoint."""
 
+import logging
+
 from flask import Flask
 
+from apps.legal_discovery import hippo_routes
 from apps.legal_discovery.hippo_routes import health_bp
 
 
@@ -12,4 +15,44 @@ def test_health_endpoint_returns_status_keys():
     resp = client.get("/api/health")
     assert resp.status_code == 200
     data = resp.get_json()
-    assert set(data.keys()) == {"neo4j", "chroma", "blocked_requests", "cache"}
+    assert {"neo4j", "chroma", "blocked_requests", "cache"}.issubset(data)
+
+
+def test_health_reports_neo4j_failure(monkeypatch, caplog):
+    app = Flask(__name__)
+    app.register_blueprint(health_bp)
+    client = app.test_client()
+
+    class FailingGraphDB:
+        @staticmethod
+        def driver(*args, **kwargs):  # pragma: no cover - monkeypatched
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(hippo_routes, "GraphDatabase", FailingGraphDB)
+
+    with caplog.at_level(logging.ERROR):
+        resp = client.get("/api/health")
+
+    data = resp.get_json()
+    assert data["neo4j"] == "fail"
+    assert "neo4j_error" in data and "boom" in data["neo4j_error"]
+    assert "Neo4j health check failed" in caplog.text
+
+
+def test_health_reports_chroma_failure(monkeypatch, caplog):
+    app = Flask(__name__)
+    app.register_blueprint(health_bp)
+    client = app.test_client()
+
+    def failing_get(*args, **kwargs):  # pragma: no cover - monkeypatched
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(hippo_routes.requests, "get", failing_get)
+
+    with caplog.at_level(logging.ERROR):
+        resp = client.get("/api/health")
+
+    data = resp.get_json()
+    assert data["chroma"] == "fail"
+    assert "chroma_error" in data and "boom" in data["chroma_error"]
+    assert "Chroma health check failed" in caplog.text


### PR DESCRIPTION
## Summary
- log Neo4j and Chroma health-check exceptions with stack traces
- include brief `*_error` strings in `/api/health` responses
- add tests for failing Neo4j and Chroma services

## Testing
- `pytest tests/apps/test_health_endpoint.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6fc8cf2a4833381136221c805ccb3