### PR TITLE
Improve task status error handling

### DIFF
--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -1081,3 +1081,8 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 ## Update 2025-10-06T14:45Z
 - Added entity-linked Hippo query combining Neo4j PPR, Chroma search and cross-encoder/LLM re-ranking.
 - Next: surface score breakdown in the dashboard and broaden ranking tests.
+
+## Update 2025-08-21T11:09Z
+- Improved task status endpoint with explicit error responses and logging.
+- Added tests covering missing and malformed task IDs.
+- Next: audit remaining task handlers for consistent error reporting.

--- a/tests/apps/test_task_status.py
+++ b/tests/apps/test_task_status.py
@@ -1,0 +1,52 @@
+import os
+import pytest
+from flask import Flask
+
+from apps.legal_discovery import tasks
+
+os.environ.setdefault("FLASK_SECRET_KEY", "test")
+os.environ.setdefault("JWT_SECRET", "test")
+
+
+@pytest.fixture
+def client():
+    app = Flask(__name__)
+    app.secret_key = "test"
+    app.config["JWT_SECRET"] = "test"
+    app.register_blueprint(tasks.tasks_bp)
+    client = app.test_client()
+    with client.session_transaction() as sess:
+        sess["user"] = "tester"
+    return client
+
+
+def test_task_status_missing_id(client, monkeypatch):
+    monkeypatch.setattr(tasks, "queue", object())
+    monkeypatch.setattr(tasks, "redis_conn", object())
+
+    class MissingJob:
+        @classmethod
+        def fetch(cls, job_id, connection=None):
+            raise tasks.NoSuchJobError
+
+    monkeypatch.setattr(tasks, "Job", MissingJob)
+    resp = client.get("/api/tasks/does-not-exist")
+    assert resp.status_code == 404
+    assert resp.get_json() == {"status": "unknown", "error": "task not found"}
+
+
+def test_task_status_malformed_id(client, monkeypatch):
+    monkeypatch.setattr(tasks, "queue", object())
+    monkeypatch.setattr(tasks, "redis_conn", object())
+
+    class BadJob:
+        @classmethod
+        def fetch(cls, job_id, connection=None):
+            raise ValueError("bad id")
+
+    monkeypatch.setattr(tasks, "Job", BadJob)
+    resp = client.get("/api/tasks/!!!")
+    assert resp.status_code == 500
+    data = resp.get_json()
+    assert data["status"] == "unknown"
+    assert data["error"] == "lookup failed"


### PR DESCRIPTION
## Summary
- return explicit error codes when queued task lookup fails
- log unexpected task status lookup failures
- cover missing and malformed task IDs in tests

## Testing
- `pytest tests/apps/test_task_status.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6fcc4ca388333ab90dd5762a00e62