### PR TITLE
feat(ui): add themes and polish UX

### DIFF
--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -1086,3 +1086,9 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 - Improved task status endpoint with explicit error responses and logging.
 - Added tests covering missing and malformed task IDs.
 - Next: audit remaining task handlers for consistent error reporting.
+
+## Update 2025-08-21T11:40Z
+- Added ocean, forest and rose theme packages with accent palettes.
+- Theme toggle now cycles through all themes and settings menu lists them dynamically.
+- Added smooth theme transitions, global focus outlines, smoother scrolling and button hover lift for better UX.
+- Next: gather user feedback on new themes and refine remaining components.

--- a/apps/legal_discovery/src/AppContext.jsx
+++ b/apps/legal_discovery/src/AppContext.jsx
@@ -3,6 +3,7 @@ import React, { createContext, useContext, useState, useEffect, useMemo } from '
 const AppContext = createContext();
 
 export function AppProvider({ children }) {
+  const themes = ['dark', 'light', 'ocean', 'forest', 'rose'];
   const [settings, setSettings] = useState({});
   const [session, setSession] = useState(null);
   const [featureFlags, setFeatureFlags] = useState({});
@@ -10,7 +11,7 @@ export function AppProvider({ children }) {
 
   useEffect(() => {
     document.documentElement.dataset.theme = theme;
-    document.body.classList.remove('light', 'dark');
+    document.body.classList.remove(...themes);
     document.body.classList.add(theme);
     localStorage.setItem('theme', theme);
   }, [theme]);
@@ -29,7 +30,11 @@ export function AppProvider({ children }) {
       .catch(() => {});
   }, []);
 
-  const toggleTheme = () => setTheme(t => (t === 'dark' ? 'light' : 'dark'));
+  const toggleTheme = () =>
+    setTheme(t => {
+      const idx = themes.indexOf(t);
+      return themes[(idx + 1) % themes.length];
+    });
 
   const value = useMemo(
     () => ({
@@ -42,6 +47,7 @@ export function AppProvider({ children }) {
       theme,
       setTheme,
       toggleTheme,
+      themes,
     }),
     [settings, session, featureFlags, theme]
   );

--- a/apps/legal_discovery/src/components/SettingsModal.jsx
+++ b/apps/legal_discovery/src/components/SettingsModal.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef } from "react";
 import { useAppContext } from "../AppContext";
 
 function SettingsModal({open,onClose}) {
-  const { setSettings, setFeatureFlags, theme, setTheme } = useAppContext();
+  const { setSettings, setFeatureFlags, theme, setTheme, themes } = useAppContext();
   const [form,setForm] = useState({});
   const ref = useRef();
   const firstFieldRef = useRef();
@@ -83,8 +83,11 @@ function SettingsModal({open,onClose}) {
           <label>GCP Service Account Key<textarea name="gcp_service_account_key" value={form.gcp_service_account_key||''} onChange={update} className="w-full p-2 rounded" rows="2"/></label>
           <label>Theme
             <select name="theme" value={form.theme||'dark'} onChange={update} className="w-full p-2 rounded">
-              <option value="dark">Dark</option>
-              <option value="light">Light</option>
+              {themes.map(t => (
+                <option key={t} value={t}>
+                  {t.charAt(0).toUpperCase() + t.slice(1)}
+                </option>
+              ))}
             </select>
           </label>
           <label className="flex items-center space-x-2"><input type="checkbox" name="theories" checked={form.theories||false} onChange={update}/><span>Enable Legal Theories</span></label>

--- a/apps/legal_discovery/src/components/ThemeToggle.jsx
+++ b/apps/legal_discovery/src/components/ThemeToggle.jsx
@@ -3,9 +3,10 @@ import { useAppContext } from '../AppContext';
 
 export default function ThemeToggle() {
   const { theme, toggleTheme } = useAppContext();
+  const icons = { dark: 'moon', light: 'sun', ocean: 'water', forest: 'leaf', rose: 'heart' };
   return (
     <button onClick={toggleTheme} className="tab-button" aria-label="Toggle theme">
-      <i className={`fa fa-${theme === 'dark' ? 'sun' : 'moon'}`}></i>
+      <i className={`fa fa-${icons[theme] || 'palette'}`}></i>
     </button>
   );
 }

--- a/apps/legal_discovery/static/style.css
+++ b/apps/legal_discovery/static/style.css
@@ -81,6 +81,79 @@
     --nav-text: #111827;
 }
 
+:root[data-theme='ocean'] {
+    --color-bg: #001f3f;
+    --color-bg-alt: #003f5c;
+    --color-surface: rgba(0,31,63,0.6);
+    --color-surface-hover: rgba(0,31,63,0.8);
+    --color-border: rgba(255,255,255,0.08);
+    --color-accent: #00aaff;
+    --color-accent-glow: rgba(0,170,255,0.7);
+    --color-accent-100: #ccf5ff;
+    --color-accent-200: #99eaff;
+    --color-accent-300: #66e0ff;
+    --color-accent-400: #33d5ff;
+    --color-accent-500: #00aaff;
+    --color-accent-600: #0088cc;
+    --color-accent-700: #006699;
+    --color-accent-800: #004466;
+    --color-accent-900: #002233;
+    --color-text: #e5e7eb;
+    --color-text-muted: #9ca3af;
+    --nav-bg: rgba(0,23,43,0.85);
+    --nav-text: var(--color-text);
+}
+
+:root[data-theme='forest'] {
+    --color-bg: #011a10;
+    --color-bg-alt: #062d1a;
+    --color-surface: rgba(6,45,26,0.6);
+    --color-surface-hover: rgba(6,45,26,0.8);
+    --color-border: rgba(255,255,255,0.08);
+    --color-accent: #00cc66;
+    --color-accent-glow: rgba(0,204,102,0.7);
+    --color-accent-100: #ccffe5;
+    --color-accent-200: #99ffcc;
+    --color-accent-300: #66ffb2;
+    --color-accent-400: #33ff99;
+    --color-accent-500: #00cc66;
+    --color-accent-600: #00a653;
+    --color-accent-700: #008040;
+    --color-accent-800: #005a2d;
+    --color-accent-900: #003319;
+    --color-text: #e5e7eb;
+    --color-text-muted: #9ca3af;
+    --nav-bg: rgba(2,25,15,0.85);
+    --nav-text: var(--color-text);
+}
+
+:root[data-theme='rose'] {
+    --color-bg: #1f0029;
+    --color-bg-alt: #330044;
+    --color-surface: rgba(51,0,68,0.6);
+    --color-surface-hover: rgba(51,0,68,0.8);
+    --color-border: rgba(255,255,255,0.08);
+    --color-accent: #ff007f;
+    --color-accent-glow: rgba(255,0,127,0.7);
+    --color-accent-100: #ffd6eb;
+    --color-accent-200: #ffadd7;
+    --color-accent-300: #ff85c3;
+    --color-accent-400: #ff5caf;
+    --color-accent-500: #ff007f;
+    --color-accent-600: #cc0066;
+    --color-accent-700: #99004c;
+    --color-accent-800: #660033;
+    --color-accent-900: #330019;
+    --color-text: #f5e5eb;
+    --color-text-muted: #d1a5b5;
+    --nav-bg: rgba(31,0,41,0.85);
+    --nav-text: var(--color-text);
+}
+
+html {
+    scroll-behavior: smooth;
+}
+
 html, body {
     height: 100%;
     margin: 0;
@@ -90,6 +163,12 @@ html, body {
     color: var(--text-colour);
     min-height: 100vh;
     background: radial-gradient(circle at 50% 0%, var(--background-end), var(--background-start) 80%);
+    transition: background 0.3s, color 0.3s;
+}
+
+:focus-visible {
+    outline: 2px solid var(--color-accent);
+    outline-offset: 2px;
 }
 
 .main-container {
@@ -234,6 +313,11 @@ h2 {
 .tab-button:hover {
     box-shadow: 0 0 6px var(--color-accent-glow);
     transform: translateY(-1px);
+}
+
+.tab-button:focus-visible {
+    outline: 2px solid var(--color-accent);
+    outline-offset: 2px;
 }
 
 .tab-button.active {
@@ -413,6 +497,7 @@ textarea:focus {
 .button-secondary:hover, .button-secondary:focus {
     background: var(--color-surface-hover);
     box-shadow: 0 0 8px var(--color-accent-glow);
+    transform: translateY(-1px) scale(1.02);
 }
 
 .skeleton {


### PR DESCRIPTION
## Summary
- add ocean, forest and rose theme options
- cycle through multiple themes with icons and dynamic settings list
- smooth theme transitions, focus outlines and hover polish for better UX

## Testing
- `pytest` *(fails: KeyboardInterrupt during PyPDF2 import)*

------
https://chatgpt.com/codex/tasks/task_e_68a703a0ec1c83338df65ae0fbd4a1ab