### PR TITLE
fix: make requirements cross-platform

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -36,7 +36,9 @@ python-pptx
 psycopg2-binary
 rfc3987
 more_itertools
-gunicorn
+gunicorn ; platform_system != "Windows"
+uvicorn[standard] ; platform_system != "Windows"
+uvicorn ; platform_system == "Windows"
 eventlet
 pillow
 weasyprint

--- a/requirements.txt
+++ b/requirements.txt
@@ -284,7 +284,7 @@ grpcio-tools==1.74.0
     # via
     #   leaf-server-common
     #   neuro-san
-gunicorn==23.0.0
+gunicorn==23.0.0 ; platform_system != "Windows"
     # via -r requirements.in
 h11==0.16.0
     # via
@@ -295,7 +295,7 @@ hf-xet==1.1.8
     # via huggingface-hub
 httpcore==1.0.9
     # via httpx
-httptools==0.6.4
+httptools==0.6.4 ; platform_system != "Windows"
     # via uvicorn
 httpx==0.28.1
     # via
@@ -1219,12 +1219,17 @@ urllib3==2.5.0
     #   kubernetes
     #   neuro-san
     #   requests
-uvicorn[standard]==0.35.0
+uvicorn[standard]==0.35.0 ; platform_system != "Windows"
     # via
     #   chromadb
     #   mcp
     #   nsflow
-uvloop==0.21.0
+uvicorn==0.35.0 ; platform_system == "Windows"
+    # via
+    #   chromadb
+    #   mcp
+    #   nsflow
+uvloop==0.21.0 ; platform_system != "Windows"
     # via uvicorn
 validators==0.35.0
     # via neuro-san
@@ -1235,7 +1240,7 @@ wasabi==1.1.3
     #   weasel
 watchdog==6.0.0
     # via neuro-san
-watchfiles==1.1.0
+watchfiles==1.1.0 ; platform_system != "Windows"
     # via uvicorn
 wcwidth==0.2.13
     # via


### PR DESCRIPTION
## Summary
- guard uvicorn, gunicorn and low-level networking deps with platform checks so Windows and Linux get appropriate packages
- add Windows-friendly uvicorn pin so Windows installs avoid POSIX-only extras

## Testing
- `pytest tests/stubs -q` *(fails: KeyboardInterrupt while importing large deps)*

------
https://chatgpt.com/codex/tasks/task_e_68a7f09202648333b954a1bd828e6461