### PR TITLE
Remove unsupported Coqui TTS dependency

### DIFF
--- a/apps/legal_discovery/requirements.txt
+++ b/apps/legal_discovery/requirements.txt
@@ -44,5 +44,4 @@ scikit-learn
 sentence-transformers
 spacy
 structlog
-TTS
 weasyprint


### PR DESCRIPTION
## Summary
- Drop Coqui TTS package from legal_discovery requirements to avoid Python 3.12 build errors
- Register Coqui engine only when `TTS` library is installed, defaulting to gTTS otherwise

## Testing
- `python -m black apps/legal_discovery/voice.py`
- `pytest tests/apps/test_voice_command_routing.py tests/apps/test_chat_audit.py -q` *(fails: missing or incompatible dependencies)*
- `python - <<'PY'
import importlib.util
from apps.legal_discovery import voice
print('coqui available?', importlib.util.find_spec('TTS') is not None)
print('engine map keys', sorted(voice._ENGINE_MAP.keys()))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a8266af9d08333ad2e945cafe30655