### PR TITLE
Use Python 3.11 for legal discovery build

### DIFF
--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -1092,3 +1092,8 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 - Theme toggle now cycles through all themes and settings menu lists them dynamically.
 - Added smooth theme transitions, global focus outlines, smoother scrolling and button hover lift for better UX.
 - Next: gather user feedback on new themes and refine remaining components.
+
+## Update 2025-08-22T00:00Z
+- Switched backend Docker base image to Python 3.11 because Coqui TTS lacks
+  Python 3.12 wheels, breaking Docker builds.
+- Next: watch for upstream Python 3.12 support and revert the base image when available.

--- a/apps/legal_discovery/Dockerfile
+++ b/apps/legal_discovery/Dockerfile
@@ -12,7 +12,10 @@ RUN npm run build --silent
 
 
 # ---------- Backend (Python) ----------
-FROM python:3.12-slim
+# Coqui TTS does not yet provide wheels for Python 3.12, which caused
+# `pip install` to fail during the image build.  Use Python 3.11 until
+# upstream support is available.
+FROM python:3.11-slim
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \


### PR DESCRIPTION
## Summary
- Use Python 3.11 base image for legal discovery service since TTS lacks Python 3.12 wheels, preventing Docker builds.
- Document the change in AGENTS log.

## Testing
- `pytest -q tests/apps/test_voice_command_routing.py`

------
https://chatgpt.com/codex/tasks/task_e_68a8934d65b08333a941120cb2cc53cf