### PR TITLE
Pin pyvis dependency for Docker builds

### DIFF
--- a/apps/legal_discovery/requirements.txt
+++ b/apps/legal_discovery/requirements.txt
@@ -33,7 +33,7 @@ python-docx
 python-pptx
 python-socketio
 pyttsx3
-pyvis
+pyvis==0.3.2
 redis
 reportlab
 requests


### PR DESCRIPTION
## Summary
- Pin pyvis to 0.3.2 in legal_discovery requirements to avoid unresolved dependency during Docker builds.

## Testing
- `pytest tests/coded_tools/legal_discovery/test_chat_agent.py::test_privileged_messages_excluded -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa6a62c28c8333ae9737a7d54ec310