### PR TITLE
Pin reportlab dependency in legal discovery requirements

### DIFF
--- a/apps/legal_discovery/requirements.txt
+++ b/apps/legal_discovery/requirements.txt
@@ -35,7 +35,7 @@ python-socketio
 pyttsx3
 pyvis==0.3.2
 redis
-reportlab
+reportlab==4.4.3
 requests
 rfc3987
 rq


### PR DESCRIPTION
## Summary
- pin reportlab to 4.4.3 to avoid invalid requirement during Docker builds

## Testing
- `pytest tests/coded_tools/legal_discovery/test_exhibit_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_68aa8396f22483339aeb6ee3f1cdfbff