### PR TITLE
fix: pin networkx to hipporag requirement

### DIFF
--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -1108,3 +1108,7 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 ## Update 2025-08-24T10:10Z
 - Pinned legal_discovery requirements and added requirements.in to avoid pip backtracking.
 - Next: rebuild Docker image with new pinned requirements.
+
+## Update 2025-10-07T00:00Z
+- Pinned `networkx` to 3.4.2 to satisfy `hipporag` dependencies.
+- Next: regenerate `requirements.txt` via `pip-compile` and validate install.

--- a/apps/legal_discovery/requirements.in
+++ b/apps/legal_discovery/requirements.in
@@ -14,7 +14,7 @@ hipporag
 langchain-google-genai
 more-itertools
 neo4j
-networkx
+networkx==3.4.2
 neuro-san
 opentelemetry-instrumentation-flask
 opentelemetry-sdk

--- a/apps/legal_discovery/requirements.txt
+++ b/apps/legal_discovery/requirements.txt
@@ -13,7 +13,7 @@ hipporag
 langchain-google-genai==2.1.9
 more-itertools==10.7.0
 neo4j==5.28.2
-networkx==3.5
+networkx==3.4.2
 neuro-san==0.5.52
 opentelemetry-instrumentation-flask==0.57b0
 opentelemetry-sdk==1.36.0


### PR DESCRIPTION
## Summary
- pin networkx to 3.4.2 for hipporag compatibility
- document dependency pin in legal discovery agent log

## Testing
- `pip-compile requirements.in` *(fails: Aborted!)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aaea9e07488333a6281bdcd312bb38