### PR TITLE
Scope CUDA dependencies to Linux for cross-platform builds

### DIFF
--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -1121,3 +1121,7 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 ## Update 2025-10-07T12:00Z
 - Enabled runtime installation of `hipporag` and core deps via `docker-compose`.
 - Next: verify container boot and integrate HippoRAG features.
+
+## Update 2025-08-24T15:14Z
+- Scoped CUDA, Triton, gunicorn, and uvloop packages to Linux-only to avoid Windows install failures.
+- Next: confirm cross-platform tests.

--- a/apps/legal_discovery/requirements.txt
+++ b/apps/legal_discovery/requirements.txt
@@ -221,7 +221,7 @@ grpcio-tools==1.74.0
     #   neuro-san
 gtts==2.5.4
     # via -r requirements.in
-gunicorn==23.0.0
+gunicorn==23.0.0 ; platform_system != "Windows"
     # via -r requirements.in
 h11==0.16.0
     # via
@@ -416,42 +416,42 @@ numpy==1.26.4
     #   spacy
     #   thinc
     #   transformers
-nvidia-cublas-cu12==12.8.4.1
+nvidia-cublas-cu12==12.8.4.1 ; platform_system == "Linux"
     # via
     #   nvidia-cudnn-cu12
     #   nvidia-cusolver-cu12
     #   torch
-nvidia-cuda-cupti-cu12==12.8.90
+nvidia-cuda-cupti-cu12==12.8.90 ; platform_system == "Linux"
     # via torch
-nvidia-cuda-nvrtc-cu12==12.8.93
+nvidia-cuda-nvrtc-cu12==12.8.93 ; platform_system == "Linux"
     # via torch
-nvidia-cuda-runtime-cu12==12.8.90
+nvidia-cuda-runtime-cu12==12.8.90 ; platform_system == "Linux"
     # via torch
-nvidia-cudnn-cu12==9.10.2.21
+nvidia-cudnn-cu12==9.10.2.21 ; platform_system == "Linux"
     # via torch
-nvidia-cufft-cu12==11.3.3.83
+nvidia-cufft-cu12==11.3.3.83 ; platform_system == "Linux"
     # via torch
-nvidia-cufile-cu12==1.13.1.3
+nvidia-cufile-cu12==1.13.1.3 ; platform_system == "Linux"
     # via torch
-nvidia-curand-cu12==10.3.9.90
+nvidia-curand-cu12==10.3.9.90 ; platform_system == "Linux"
     # via torch
-nvidia-cusolver-cu12==11.7.3.90
+nvidia-cusolver-cu12==11.7.3.90 ; platform_system == "Linux"
     # via torch
-nvidia-cusparse-cu12==12.5.8.93
+nvidia-cusparse-cu12==12.5.8.93 ; platform_system == "Linux"
     # via
     #   nvidia-cusolver-cu12
     #   torch
-nvidia-cusparselt-cu12==0.7.1
+nvidia-cusparselt-cu12==0.7.1 ; platform_system == "Linux"
     # via torch
-nvidia-nccl-cu12==2.27.3
+nvidia-nccl-cu12==2.27.3 ; platform_system == "Linux"
     # via torch
-nvidia-nvjitlink-cu12==12.8.93
+nvidia-nvjitlink-cu12==12.8.93 ; platform_system == "Linux"
     # via
     #   nvidia-cufft-cu12
     #   nvidia-cusolver-cu12
     #   nvidia-cusparse-cu12
     #   torch
-nvidia-nvtx-cu12==12.8.90
+nvidia-nvtx-cu12==12.8.90 ; platform_system == "Linux"
     # via torch
 oauthlib==3.3.1
     # via
@@ -873,7 +873,7 @@ traitlets==5.14.3
     #   matplotlib-inline
 transformers==4.55.4
     # via sentence-transformers
-triton==3.4.0
+triton==3.4.0 ; platform_system == "Linux"
     # via torch
 typer==0.16.1
     # via
@@ -925,7 +925,7 @@ urllib3==2.5.0
     #   requests
 uvicorn[standard]==0.35.0
     # via chromadb
-uvloop==0.21.0
+uvloop==0.21.0 ; platform_system != "Windows"
     # via uvicorn
 validators==0.35.0
     # via neuro-san

--- a/condensed AGENTS.md
+++ b/condensed AGENTS.md
@@ -219,3 +219,7 @@ we are now working on implementing a major feature, so stand by, this is  A GDDM
 ## Update 2025-10-07T12:00Z
 - Added runtime HippoRAG installation to `docker-compose.yml` with pinned core dependencies.
 - Next: validate container startup with new packages and monitor for conflicts.
+
+## Update 2025-08-24T15:14Z
+- Restricted CUDA, Triton, and uvloop dependencies to Linux to support Windows installs.
+- Next: verify cross-platform builds in Docker.

--- a/requirements.txt
+++ b/requirements.txt
@@ -583,42 +583,42 @@ numpy==1.26.4
     #   spacy
     #   thinc
     #   transformers
-nvidia-cublas-cu12==12.8.4.1
+nvidia-cublas-cu12==12.8.4.1 ; platform_system == "Linux"
     # via
     #   nvidia-cudnn-cu12
     #   nvidia-cusolver-cu12
     #   torch
-nvidia-cuda-cupti-cu12==12.8.90
+nvidia-cuda-cupti-cu12==12.8.90 ; platform_system == "Linux"
     # via torch
-nvidia-cuda-nvrtc-cu12==12.8.93
+nvidia-cuda-nvrtc-cu12==12.8.93 ; platform_system == "Linux"
     # via torch
-nvidia-cuda-runtime-cu12==12.8.90
+nvidia-cuda-runtime-cu12==12.8.90 ; platform_system == "Linux"
     # via torch
-nvidia-cudnn-cu12==9.10.2.21
+nvidia-cudnn-cu12==9.10.2.21 ; platform_system == "Linux"
     # via torch
-nvidia-cufft-cu12==11.3.3.83
+nvidia-cufft-cu12==11.3.3.83 ; platform_system == "Linux"
     # via torch
-nvidia-cufile-cu12==1.13.1.3
+nvidia-cufile-cu12==1.13.1.3 ; platform_system == "Linux"
     # via torch
-nvidia-curand-cu12==10.3.9.90
+nvidia-curand-cu12==10.3.9.90 ; platform_system == "Linux"
     # via torch
-nvidia-cusolver-cu12==11.7.3.90
+nvidia-cusolver-cu12==11.7.3.90 ; platform_system == "Linux"
     # via torch
-nvidia-cusparse-cu12==12.5.8.93
+nvidia-cusparse-cu12==12.5.8.93 ; platform_system == "Linux"
     # via
     #   nvidia-cusolver-cu12
     #   torch
-nvidia-cusparselt-cu12==0.7.1
+nvidia-cusparselt-cu12==0.7.1 ; platform_system == "Linux"
     # via torch
-nvidia-nccl-cu12==2.27.3
+nvidia-nccl-cu12==2.27.3 ; platform_system == "Linux"
     # via torch
-nvidia-nvjitlink-cu12==12.8.93
+nvidia-nvjitlink-cu12==12.8.93 ; platform_system == "Linux"
     # via
     #   nvidia-cufft-cu12
     #   nvidia-cusolver-cu12
     #   nvidia-cusparse-cu12
     #   torch
-nvidia-nvtx-cu12==12.8.90
+nvidia-nvtx-cu12==12.8.90 ; platform_system == "Linux"
     # via torch
 oauthlib==3.3.1
     # via
@@ -1160,7 +1160,7 @@ traitlets==5.14.3
     #   nbformat
 transformers==4.55.3
     # via sentence-transformers
-triton==3.4.0
+triton==3.4.0 ; platform_system == "Linux"
     # via torch
 typer==0.16.1
     # via
@@ -1226,7 +1226,7 @@ uvicorn[standard]==0.35.0 ; platform_system != "Windows"
     #   chromadb
     #   mcp
     #   nsflow
-uvloop==0.21.0
+uvloop==0.21.0 ; platform_system != "Windows"
     # via uvicorn
 validators==0.35.0
     # via neuro-san


### PR DESCRIPTION
## Summary
- Restrict CUDA and Triton packages to Linux and skip uvloop on Windows in root requirements
- Mirror platform constraints in legal_discovery requirements and gate gunicorn for non-Windows systems
- Log progress updates in AGENTS notes

## Testing
- `pytest` *(failed: KeyboardInterrupt after ~18s)*

------
https://chatgpt.com/codex/tasks/task_e_68ab2bf18ac083339670b9f2f8c6db6a