### PR TITLE
Switch to CPU torch and drop CUDA dependencies

### DIFF
--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -1125,3 +1125,7 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 ## Update 2025-08-24T15:14Z
 - Scoped CUDA, Triton, gunicorn, and uvloop packages to Linux-only to avoid Windows install failures.
 - Next: confirm cross-platform tests.
+
+## Update 2025-08-25T20:56Z
+- Dropped local CUDA packages and switched torch to CPU-only wheel for easier installs.
+- Next: confirm legal_discovery runs without GPU drivers.

--- a/apps/legal_discovery/requirements.txt
+++ b/apps/legal_discovery/requirements.txt
@@ -3,6 +3,7 @@
 # by the following command:
 #
 #    pip-compile requirements.in
+--extra-index-url https://download.pytorch.org/whl/cpu
 #
 aiohappyeyeballs==2.6.1
     # via aiohttp
@@ -416,43 +417,12 @@ numpy==1.26.4
     #   spacy
     #   thinc
     #   transformers
-nvidia-cublas-cu12==12.8.4.1 ; platform_system == "Linux"
     # via
-    #   nvidia-cudnn-cu12
-    #   nvidia-cusolver-cu12
     #   torch
-nvidia-cuda-cupti-cu12==12.8.90 ; platform_system == "Linux"
-    # via torch
-nvidia-cuda-nvrtc-cu12==12.8.93 ; platform_system == "Linux"
-    # via torch
-nvidia-cuda-runtime-cu12==12.8.90 ; platform_system == "Linux"
-    # via torch
-nvidia-cudnn-cu12==9.10.2.21 ; platform_system == "Linux"
-    # via torch
-nvidia-cufft-cu12==11.3.3.83 ; platform_system == "Linux"
-    # via torch
-nvidia-cufile-cu12==1.13.1.3 ; platform_system == "Linux"
-    # via torch
-nvidia-curand-cu12==10.3.9.90 ; platform_system == "Linux"
-    # via torch
-nvidia-cusolver-cu12==11.7.3.90 ; platform_system == "Linux"
-    # via torch
-nvidia-cusparse-cu12==12.5.8.93 ; platform_system == "Linux"
     # via
-    #   nvidia-cusolver-cu12
     #   torch
-nvidia-cusparselt-cu12==0.7.1 ; platform_system == "Linux"
-    # via torch
-nvidia-nccl-cu12==2.27.3 ; platform_system == "Linux"
-    # via torch
-nvidia-nvjitlink-cu12==12.8.93 ; platform_system == "Linux"
     # via
-    #   nvidia-cufft-cu12
-    #   nvidia-cusolver-cu12
-    #   nvidia-cusparse-cu12
     #   torch
-nvidia-nvtx-cu12==12.8.90 ; platform_system == "Linux"
-    # via torch
 oauthlib==3.3.1
     # via
     #   kubernetes
@@ -855,7 +825,7 @@ tokenizers==0.21.4
     # via
     #   chromadb
     #   transformers
-torch==2.8.0
+torch==2.8.0+cpu
     # via sentence-transformers
 tornado==6.5.2
     # via neuro-san
@@ -873,8 +843,6 @@ traitlets==5.14.3
     #   matplotlib-inline
 transformers==4.55.4
     # via sentence-transformers
-triton==3.4.0 ; platform_system == "Linux"
-    # via torch
 typer==0.16.1
     # via
     #   chromadb

--- a/condensed AGENTS.md
+++ b/condensed AGENTS.md
@@ -223,3 +223,7 @@ we are now working on implementing a major feature, so stand by, this is  A GDDM
 ## Update 2025-08-24T15:14Z
 - Restricted CUDA, Triton, and uvloop dependencies to Linux to support Windows installs.
 - Next: verify cross-platform builds in Docker.
+
+## Update 2025-08-25T20:56Z
+- Removed CUDA-specific nvidia dependencies and pinned torch to CPU wheel.
+- Next: verify CPU-only install across modules.

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@
 # by the following command:
 #
 #    pip-compile --output-file=requirements.txt requirements.in
+--extra-index-url https://download.pytorch.org/whl/cpu
 #
 aiofiles==24.1.0
     # via -r requirements.in
@@ -583,43 +584,12 @@ numpy==1.26.4
     #   spacy
     #   thinc
     #   transformers
-nvidia-cublas-cu12==12.8.4.1 ; platform_system == "Linux"
     # via
-    #   nvidia-cudnn-cu12
-    #   nvidia-cusolver-cu12
     #   torch
-nvidia-cuda-cupti-cu12==12.8.90 ; platform_system == "Linux"
-    # via torch
-nvidia-cuda-nvrtc-cu12==12.8.93 ; platform_system == "Linux"
-    # via torch
-nvidia-cuda-runtime-cu12==12.8.90 ; platform_system == "Linux"
-    # via torch
-nvidia-cudnn-cu12==9.10.2.21 ; platform_system == "Linux"
-    # via torch
-nvidia-cufft-cu12==11.3.3.83 ; platform_system == "Linux"
-    # via torch
-nvidia-cufile-cu12==1.13.1.3 ; platform_system == "Linux"
-    # via torch
-nvidia-curand-cu12==10.3.9.90 ; platform_system == "Linux"
-    # via torch
-nvidia-cusolver-cu12==11.7.3.90 ; platform_system == "Linux"
-    # via torch
-nvidia-cusparse-cu12==12.5.8.93 ; platform_system == "Linux"
     # via
-    #   nvidia-cusolver-cu12
     #   torch
-nvidia-cusparselt-cu12==0.7.1 ; platform_system == "Linux"
-    # via torch
-nvidia-nccl-cu12==2.27.3 ; platform_system == "Linux"
-    # via torch
-nvidia-nvjitlink-cu12==12.8.93 ; platform_system == "Linux"
     # via
-    #   nvidia-cufft-cu12
-    #   nvidia-cusolver-cu12
-    #   nvidia-cusparse-cu12
     #   torch
-nvidia-nvtx-cu12==12.8.90 ; platform_system == "Linux"
-    # via torch
 oauthlib==3.3.1
     # via
     #   kubernetes
@@ -1127,7 +1097,7 @@ tomlkit==0.13.3
     # via pylint
 toolz==1.0.0
     # via columnar
-torch==2.8.0
+torch==2.8.0+cpu
     # via sentence-transformers
 tornado==6.5.2
     # via
@@ -1160,8 +1130,6 @@ traitlets==5.14.3
     #   nbformat
 transformers==4.55.3
     # via sentence-transformers
-triton==3.4.0 ; platform_system == "Linux"
-    # via torch
 typer==0.16.1
     # via
     #   chromadb


### PR DESCRIPTION
## Summary
- use PyTorch CPU wheel by adding PyTorch CPU index and pinning `torch==2.8.0+cpu`
- remove CUDA/NVIDIA and Triton packages from requirements
- update legal_discovery requirements to match
- log progress in AGENTS files

## Testing
- `pip install --dry-run -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_68accd9a896c833392958c1f5307eb38