### PR TITLE
Remove invalid Neo4j URI configuration

### DIFF
--- a/condensed AGENTS.md
+++ b/condensed AGENTS.md
@@ -227,3 +227,7 @@ we are now working on implementing a major feature, so stand by, this is  A GDDM
 ## Update 2025-08-25T20:56Z
 - Removed CUDA-specific nvidia dependencies and pinned torch to CPU wheel.
 - Next: verify CPU-only install across modules.
+
+## Update 2025-10-21T00:00Z
+- Dropped `.env` inheritance from Neo4j service so `NEO4J_URI` doesn't break startup.
+- Next: confirm docker-compose spins up cleanly without URI config errors.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,9 +61,8 @@ services:
     ports:
       - "7474:7474"
       - "7687:7687"
-    env_file:
-      - .env
     environment:
+      # Only pass authentication to avoid exposing app-specific vars like NEO4J_URI
       - NEO4J_AUTH=neo4j/${NEO4J_PASSWORD}
     volumes:
       - ./docker_volumes/neo4j/data:/data


### PR DESCRIPTION
## Summary
- avoid passing `NEO4J_URI` to the Neo4j container to stop strict validation errors
- log progress in condensed AGENTS file

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ad13b394208333930680d3d8875498