### PR TITLE
Allow Legal Discovery to start without preset secrets

### DIFF
--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -1129,3 +1129,7 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 ## Update 2025-08-25T20:56Z
 - Dropped local CUDA packages and switched torch to CPU-only wheel for easier installs.
 - Next: confirm legal_discovery runs without GPU drivers.
+
+## Update 2025-08-26T05:34Z
+- Auto-generated Flask and JWT secrets when missing to ensure the dashboard loads.
+- Next: document secret defaults and verify container startup.

--- a/apps/legal_discovery/README.md
+++ b/apps/legal_discovery/README.md
@@ -29,6 +29,11 @@ Docker Compose reads `NEO4J_PASSWORD` for both the app and database services so
 they always share the same credentials. If the variable is empty, the database
 starts without authentication which is convenient for local testing.
 
+If `FLASK_SECRET_KEY` or `JWT_SECRET` are omitted, the server now generates
+ephemeral values at startup so the dashboard still loads. Sessions and tokens
+will reset whenever the container restarts, so set explicit secrets in
+production environments.
+
 ## Compiling Requirements.txt
 
 To convert a requirements.in file into a requirements.txt with Python, you typically use pip-tools, which provides the pip-compile command. This tool resolves and pins all dependencies (including sub-dependencies) into a fully locked requirements.txt.

--- a/apps/legal_discovery/interface_flask.py
+++ b/apps/legal_discovery/interface_flask.py
@@ -6,6 +6,7 @@ import json
 import logging
 import os
 import re
+import secrets
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, TimeoutError
@@ -140,8 +141,12 @@ if config_path and (not secret_key or not jwt_secret):
     cfg = ConfigFactory.parse_file(config_path)
     secret_key = secret_key or cfg.get("flask.secret_key", None)
     jwt_secret = jwt_secret or cfg.get("flask.jwt_secret", None)
-if not secret_key or not jwt_secret:
-    raise RuntimeError("FLASK_SECRET_KEY and JWT_SECRET must be set")
+if not secret_key:
+    secret_key = secrets.token_hex(32)
+    logger.warning("FLASK_SECRET_KEY not set; using ephemeral value")
+if not jwt_secret:
+    jwt_secret = secrets.token_hex(32)
+    logger.warning("JWT_SECRET not set; using ephemeral value")
 app.config["SECRET_KEY"] = secret_key
 app.config["JWT_SECRET"] = jwt_secret
 # Configure rate limiting storage (Redis in production).


### PR DESCRIPTION
## Summary
- generate Flask and JWT secrets automatically when env vars missing
- document that ephemeral secrets are created if unset
- note secret handling update in module log

## Testing
- `pytest tests/apps/test_health_endpoint.py` *(fails: heavy dependency import, interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68ad1c272590833386b16d3be4ad9142