### PR TITLE
Disable Neo4j authentication for local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,8 +268,8 @@ Copy `config/.env.sample` to `.env` and set the required keys:
 - `GOOGLE_API_KEY`
 - `FLASK_SECRET_KEY`
 - `JWT_SECRET`
-- `NEO4J_PASSWORD`
 
+Neo4j authentication is disabled by default; set `NEO4J_PASSWORD` and update `docker-compose.yml` if credentials are required.
 For testing the API keys, please refer to this [documentation](./docs/api_key.md)
 
 ---
@@ -384,7 +384,6 @@ The `apps/legal_discovery` stack runs a Flask frontend backed by PostgreSQL, Neo
     ```bash
     FLASK_SECRET_KEY=<output from script>
     JWT_SECRET=<output from script>
-    NEO4J_PASSWORD=neo4jPass123
     EMBED_MODEL=sentence-transformers/all-MiniLM-L6-v2
     CROSS_ENCODER_MODEL=cross-encoder/ms-marco-MiniLM-L-6-v2
     ```
@@ -393,7 +392,6 @@ The `apps/legal_discovery` stack runs a Flask frontend backed by PostgreSQL, Neo
 
 Docker Compose mounts the `.env` file into the application container so `config.py` can read it.
     Docker Compose mounts the `.env` file into the application container so `config.py` can read it.
-    - `NEO4J_PASSWORD` sets the admin password for the Neo4j instance and must match the value used by `docker-compose.yml`.
     - `EMBED_MODEL` selects the sentence embedding model for vector storage.
     - `CROSS_ENCODER_MODEL` sets the cross-encoder used to re-rank search results.
 
@@ -409,7 +407,7 @@ the `neo4j` service (`env_file: []`), keeping `NEO4J_URI` available only to the 
    docker compose up
    ```
 
-The web UI is available at <http://localhost:8080>. Neo4j exposes its browser on port 7474 and the Bolt protocol on 7687; both use the password specified in `NEO4J_PASSWORD`.
+The web UI is available at <http://localhost:8080>. Neo4j exposes its browser on port 7474 and the Bolt protocol on 7687 with authentication disabled by default.
 
 ### Health Check Endpoint
 

--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -1133,3 +1133,7 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 ## Update 2025-08-26T05:34Z
 - Auto-generated Flask and JWT secrets when missing to ensure the dashboard loads.
 - Next: document secret defaults and verify container startup.
+
+## Update 2025-08-26T07:18Z
+- Clarified Neo4j authentication in README; default stack runs without credentials.
+- Next: restore secure auth before production use.

--- a/apps/legal_discovery/README.md
+++ b/apps/legal_discovery/README.md
@@ -12,8 +12,7 @@ powered by Google's Gemini 2.5 models.
 - A running PostgreSQL instance (the provided `docker-compose.yml` spins one up automatically)
 - API keys configured in `.env` (set `GOOGLE_API_KEY` for Gemini 2.5)
 
-Make a copy of `config/.env.sample` to `.env` and fill in the required values. In
-particular generate secrets for Flask sessions and JWTs, then set a password for Neo4j:
+Make a copy of `config/.env.sample` to `.env` and fill in the required values. Generate secrets for Flask sessions and JWTs; Neo4j runs without authentication by default, but you may set a password if desired:
 
 ```bash
 cp config/.env.sample .env  # if you haven't created one
@@ -22,7 +21,7 @@ python -c 'import secrets; print(secrets.token_hex(32))'
 # then edit .env and set:
 # FLASK_SECRET_KEY=<output>
 # JWT_SECRET=<output>
-# NEO4J_PASSWORD=your_password (leave blank to disable auth)
+# NEO4J_PASSWORD=your_password  # optional; leave blank for no auth
 ```
 
 Docker Compose reads `NEO4J_PASSWORD` for both the app and database services so

--- a/condensed AGENTS.md
+++ b/condensed AGENTS.md
@@ -236,3 +236,7 @@ we are now working on implementing a major feature, so stand by, this is  A GDDM
 - Added explicit `env_file: []` to the Neo4j service to block `.env` variables.
 - Documented the configuration in the README and verified the database container starts without the "URI" error.
 - Next: monitor Compose startup and extend docs with any additional troubleshooting tips.
+
+## Update 2025-08-26T07:18Z
+- Disabled Neo4j authentication across config and docker-compose to ease local development.
+- Next: re-enable secure credentials before deployment.

--- a/config/config.py
+++ b/config/config.py
@@ -16,8 +16,8 @@ DATABASE_URL = os.getenv(
 CHROMA_HOST = os.getenv("CHROMA_HOST", "chromadb")
 CHROMA_PORT = int(os.getenv("CHROMA_PORT", 8000))
 NEO4J_URI = os.getenv("NEO4J_URI", "bolt://neo4j:7687")
-NEO4J_USER = os.getenv("NEO4J_USER", "neo4j")
-NEO4J_PASSWORD = os.getenv("NEO4J_PASSWORD", "neo4jPass123")
+NEO4J_USER = os.getenv("NEO4J_USER", "")
+NEO4J_PASSWORD = os.getenv("NEO4J_PASSWORD", "")
 REDIS_URL = os.getenv("REDIS_URL", "redis://redis:6379/0")
 
 # Model configuration

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,8 +12,8 @@ services:
       - CHROMA_HOST=${CHROMA_HOST:-chromadb}
       - CHROMA_PORT=${CHROMA_PORT:-8000}
       - NEO4J_URI=${NEO4J_URI:-bolt://neo4j:7687}
-      - NEO4J_USER=${NEO4J_USER:-neo4j}
-      - NEO4J_PASSWORD=${NEO4J_PASSWORD}
+      - NEO4J_USER=
+      - NEO4J_PASSWORD=
       - REDIS_URL=${REDIS_URL:-redis://redis:6379/0}
       - FLASK_SECRET_KEY=${FLASK_SECRET_KEY}
       - JWT_SECRET=${JWT_SECRET}
@@ -63,13 +63,13 @@ services:
       - "7687:7687"
     env_file: []  # prevent .env vars like NEO4J_URI from reaching Neo4j
     environment:
-      # Only pass authentication to avoid exposing app-specific vars like NEO4J_URI
-      - NEO4J_AUTH=neo4j/${NEO4J_PASSWORD}
+      # Disable authentication for local development
+      - NEO4J_AUTH=none
     volumes:
       - ./docker_volumes/neo4j/data:/data
     healthcheck:
-      # Ensure Bolt is up AND auth works
-      test: ["CMD-SHELL", "cypher-shell -a bolt://localhost:7687 -u neo4j -p \"$${NEO4J_PASSWORD}\" \"RETURN 1\" | grep -q 1"]
+      # Ensure Bolt is up
+      test: ["CMD-SHELL", "cypher-shell -a bolt://localhost:7687 \"RETURN 1\" | grep -q 1"]
       interval: 10s
       timeout: 5s
       retries: 20

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -28,7 +28,7 @@ The stack exposes plain HTTP. To serve HTTPS, place a reverse proxy such as Ngin
 - `JWT_SECRET`
 - `DATABASE_URL` (default `postgresql+psycopg2://postgres:postgres@postgres:5432/legal_discovery`)
 - `CHROMA_HOST` / `CHROMA_PORT`
-- `NEO4J_URI`, `NEO4J_USER`, `NEO4J_PASSWORD`
+- `NEO4J_URI` (authentication disabled by default)
 - `REDIS_URL`
 
 Adjust these values for your deployment. After updating the `.env` file, rerun `install.sh` to apply changes.

--- a/docs/memory_bank.md
+++ b/docs/memory_bank.md
@@ -35,7 +35,7 @@ This compiles React files in `src/` into `static/bundle.js`. The bundle is ignor
 
 ## Docker Compose
 
-Copy `config/.env.sample` to `.env` and set `NEO4J_PASSWORD`. Then execute:
+Copy `config/.env.sample` to `.env`. Neo4j auth is disabled by default, so no password is required. Then execute:
 ```bash
 docker-compose build
 docker-compose up


### PR DESCRIPTION
## Summary
- Default Neo4j credentials removed so the app connects without authentication
- Docker Compose sets `NEO4J_AUTH=none` and clears Neo4j user/password
- Updated documentation to note authentication is disabled by default

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ad52488f888333abd82ff9194774e4