### PR TITLE
Handle HippoRAG openai conflict with fallback installer

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,13 +36,17 @@ services:
       interval: 30s
       timeout: 5s
       retries: 5
-    command: >-
-      bash -c "pip install --no-cache-dir hipporag==2.0.0a3 \
-      openai==1.58.1 tiktoken==0.7.0 torch==2.5.1 \
-      pydantic==2.10.4 tenacity==8.5.0 transformers==4.45.2 \
-      litellm==1.73.1 gritlm==1.0.2 python-igraph==0.11.8 \
-      vllm==0.6.6.post1 einops==0.8.1 && \
-      python -m gunicorn -k eventlet -w 1 -b 0.0.0.0:5001 apps.legal_discovery.startup:app"
+      command: >-
+        bash -c "pip install --no-cache-dir hipporag==2.0.0a3 tiktoken==0.7.0 torch==2.5.1 \
+        pydantic==2.10.4 tenacity==8.5.0 transformers==4.45.2 \
+        litellm==1.73.1 gritlm==1.0.2 python-igraph==0.11.8 \
+        vllm==0.6.6.post1 einops==0.8.1 || \
+        (echo 'Primary install failed; falling back' && \
+         pip install --no-cache-dir litellm==1.73.1 tiktoken==0.7.0 torch==2.5.1 \
+         pydantic==2.10.4 tenacity==8.5.0 transformers==4.45.2 \
+         gritlm==1.0.2 python-igraph==0.11.8 vllm==0.6.6.post1 einops==0.8.1 && \
+         pip install --no-cache-dir hipporag==2.0.0a3 --no-deps) && \
+        python -m gunicorn -k eventlet -w 1 -b 0.0.0.0:5001 apps.legal_discovery.startup:app"
 
   postgres:
     image: postgres:16-alpine


### PR DESCRIPTION
## Summary
- Remove fixed `openai` version from runtime install
- Add fallback install path that installs HippoRAG without deps if initial resolution fails

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad6d4fd99c8333a1f336b1959b15ea