### PR TITLE
Streamline legal_discovery docker for CPU

### DIFF
--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -1141,3 +1141,7 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 ## Update 2025-08-26T08:30Z
 - Disabled Postgres password and JWT auth to simplify local setup.
 - Next: re-enable security for production.
+
+## Update 2025-08-26T23:56Z
+- Streamlined Docker build for CPU-only hosts with uv pip and direct torch wheel download; removed GPU-only packages from docker-compose startup.
+- Next: verify legal_discovery container builds and runs on CPU-only machines.

--- a/apps/legal_discovery/Dockerfile
+++ b/apps/legal_discovery/Dockerfile
@@ -37,14 +37,18 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Upgrade pip/setuptools first
-RUN python -m pip install --upgrade pip setuptools wheel
+# Upgrade pip/setuptools and install uv for faster dependency resolution
+RUN python -m pip install --upgrade pip setuptools wheel \
+    && python -m pip install uv
 
 # Install Python deps early to leverage Docker layer cache
 COPY apps/legal_discovery/requirements.txt ./requirements.txt
 
-RUN python -m pip install -r requirements.txt \
-    && python -m pip install openai-whisper
+# Use uv pip and install the CPU-only torch wheel directly
+RUN uv pip install --no-cache-dir \
+      https://download.pytorch.org/whl/cpu/torch-2.5.1%2Bcpu-cp311-cp311-linux_x86_64.whl \
+    && uv pip install --no-cache-dir -r requirements.txt \
+    && uv pip install --no-cache-dir openai-whisper
 
 # Optional: If you rely on spaCy model via `spacy download`, you can skip this
 # because your requirements already install the model wheel from GitHub.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,15 +32,11 @@ services:
       - ./docker_volumes/legal_discovery/audio_cache:/usr/src/app/audio_cache
     restart: unless-stopped
     command: >-
-      bash -c "pip install --no-cache-dir hipporag==2.0.0a3 tiktoken==0.7.0 torch==2.5.1 \
+      bash -c "uv pip install --no-cache-dir hipporag==2.0.0a3 tiktoken==0.7.0 \
       pydantic==2.10.4 tenacity==8.5.0 transformers==4.45.2 \
       litellm==1.73.1 gritlm==1.0.2 python-igraph==0.11.8 \
-      vllm==0.6.6.post1 einops==0.8.1 || \
-      (echo 'Primary install failed; falling back' && \
-       pip install --no-cache-dir litellm==1.73.1 tiktoken==0.7.0 torch==2.5.1 \
-       pydantic==2.10.4 tenacity==8.5.0 transformers==4.45.2 \
-       gritlm==1.0.2 python-igraph==0.11.8 vllm==0.6.6.post1 einops==0.8.1 && \
-       pip install --no-cache-dir hipporag==2.0.0a3 --no-deps) && \
+      einops==0.8.1 \
+      https://download.pytorch.org/whl/cpu/torch-2.5.1%2Bcpu-cp311-cp311-linux_x86_64.whl && \
       python -m gunicorn -k eventlet -w 1 -b 0.0.0.0:5001 apps.legal_discovery.startup:app"
     healthcheck:
       test: ["CMD", "curl", "-fsS", "http://localhost:5001/api/health"]


### PR DESCRIPTION
## Summary
- use uv pip in the legal_discovery Dockerfile and install PyTorch CPU wheel directly
- simplify docker-compose startup by using uv and removing GPU-only deps
- log docker changes in module AGENTS file

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae482b3b588333b0d0b36bc02f3601