### PR TITLE
chore: revert uv pip usage

### DIFF
--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -1145,3 +1145,7 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 ## Update 2025-08-26T23:56Z
 - Streamlined Docker build for CPU-only hosts with uv pip and direct torch wheel download; removed GPU-only packages from docker-compose startup.
 - Next: verify legal_discovery container builds and runs on CPU-only machines.
+
+## Update 2025-08-27T00:30Z
+- Removed uv dependency in Dockerfile and docker-compose, reverting to standard pip installs for reliability.
+- Next: test image build to ensure dependencies resolve correctly.

--- a/apps/legal_discovery/Dockerfile
+++ b/apps/legal_discovery/Dockerfile
@@ -37,18 +37,17 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Upgrade pip/setuptools and install uv for faster dependency resolution
-RUN python -m pip install --upgrade pip setuptools wheel \
-    && python -m pip install uv
+# Upgrade pip/setuptools for installation
+RUN python -m pip install --upgrade pip setuptools wheel
 
 # Install Python deps early to leverage Docker layer cache
 COPY apps/legal_discovery/requirements.txt ./requirements.txt
 
-# Use uv pip with --system to install into the base environment and pull the CPU-only torch wheel directly
-RUN uv pip install --system --no-cache-dir \
+# Install dependencies and pull the CPU-only torch wheel directly
+RUN pip install --no-cache-dir \
       https://download.pytorch.org/whl/cpu/torch-2.5.1%2Bcpu-cp311-cp311-linux_x86_64.whl \
-    && uv pip install --system --no-cache-dir -r requirements.txt \
-    && uv pip install --system --no-cache-dir openai-whisper
+    && pip install --no-cache-dir -r requirements.txt \
+    && pip install --no-cache-dir openai-whisper
 
 # Optional: If you rely on spaCy model via `spacy download`, you can skip this
 # because your requirements already install the model wheel from GitHub.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       - ./docker_volumes/legal_discovery/audio_cache:/usr/src/app/audio_cache
     restart: unless-stopped
     command: >-
-      bash -c "uv pip install --no-cache-dir hipporag==2.0.0a3 tiktoken==0.7.0 \
+      bash -c "pip install --no-cache-dir hipporag==2.0.0a3 tiktoken==0.7.0 \
       pydantic==2.10.4 tenacity==8.5.0 transformers==4.45.2 \
       litellm==1.73.1 gritlm==1.0.2 python-igraph==0.11.8 \
       einops==0.8.1 \


### PR DESCRIPTION
## Summary
- revert legal_discovery Dockerfile to use standard pip instead of uv
- update docker-compose startup to pip install packages
- log removal of uv in AGENTS notes

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68aff4c68f4c8333b810d49229d33a09