### PR TITLE
fix neo4j healthcheck

### DIFF
--- a/condensed AGENTS.md
+++ b/condensed AGENTS.md
@@ -244,3 +244,7 @@ we are now working on implementing a major feature, so stand by, this is  A GDDM
 ## Update 2025-08-26T08:30Z
 - Removed Postgres passwords and disabled JWT checks so services run unauthenticated for local testing.
 - Next: restore authentication before production use.
+
+## Update 2025-08-28T07:15Z
+- Added Neo4j health check with explicit user and blank password to avoid unhealthy container state.
+- Next: confirm docker-compose brings Neo4j up healthy on Windows.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,7 +69,7 @@ services:
       - ./docker_volumes/neo4j/data:/data
     healthcheck:
       # Ensure Bolt is up
-      test: ["CMD-SHELL", "cypher-shell -a bolt://localhost:7687 \"RETURN 1\" | grep -q 1"]
+      test: ["CMD-SHELL", "cypher-shell -u neo4j -p \"\" -a bolt://localhost:7687 \"RETURN 1\" | grep -q 1"]
       interval: 10s
       timeout: 5s
       retries: 20


### PR DESCRIPTION
## Summary
- use explicit `neo4j` user and blank password in Neo4j healthcheck to avoid unhealthy container
- log project progress in condensed AGENTS file

## Testing
- `pytest -q` *(fails: KeyboardInterrupt while importing fitz/torch)*

------
https://chatgpt.com/codex/tasks/task_e_68b000b18e2c83338e178470b9674263