### PR TITLE
fix: use auth-free neo4j health check

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,7 +69,7 @@ services:
       - ./docker_volumes/neo4j/data:/data
     healthcheck:
       # Ensure Bolt is up
-      test: ["CMD-SHELL", "cypher-shell -u neo4j -p \"\" -a bolt://localhost:7687 \"RETURN 1\" | grep -q 1"]
+      test: ["CMD-SHELL", "cypher-shell -a bolt://localhost:7687 --format plain \"RETURN 1\" | grep -q 1"]
       interval: 10s
       timeout: 5s
       retries: 20


### PR DESCRIPTION
## Summary
- ensure neo4j health check works with auth disabled

## Testing
- `pytest -q` *(fails: KeyboardInterrupt during torch import)*

------
https://chatgpt.com/codex/tasks/task_e_68b0076b34f483338ed335399f15abf0