### PR TITLE
Fix hipporag/litellm install conflicts

### DIFF
--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -1149,3 +1149,7 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 ## Update 2025-08-27T00:30Z
 - Removed uv dependency in Dockerfile and docker-compose, reverting to standard pip installs for reliability.
 - Next: test image build to ensure dependencies resolve correctly.
+
+## Update 2025-08-28T08:02Z
+- Aligned requirements with HippoRAG by downgrading transformer stack and core deps; docker-compose now installs hipporag and litellm without version pins.
+- Next: build the container to confirm clean installs and runtime stability.

--- a/apps/legal_discovery/requirements.in
+++ b/apps/legal_discovery/requirements.in
@@ -15,6 +15,7 @@ more-itertools
 neo4j
 networkx==3.4.2
 neuro-san
+openai==1.58.1
 opentelemetry-instrumentation-flask
 opentelemetry-sdk
 pandas
@@ -44,4 +45,6 @@ scikit-learn
 sentence-transformers
 spacy
 structlog
+tenacity==8.5.0
+transformers==4.45.2
 weasyprint

--- a/apps/legal_discovery/requirements.txt
+++ b/apps/legal_discovery/requirements.txt
@@ -431,7 +431,7 @@ ollama==0.5.3
     # via langchain-ollama
 onnxruntime==1.22.1
     # via chromadb
-openai==1.101.0
+openai==1.58.1
     # via
     #   langchain-openai
     #   neuro-san
@@ -580,7 +580,7 @@ pybase64==1.4.2
     # via chromadb
 pycparser==2.22
     # via cffi
-pydantic==2.11.7
+pydantic==2.10.4
     # via
     #   -r requirements.in
     #   anthropic
@@ -600,7 +600,7 @@ pydantic==2.11.7
     #   spacy
     #   thinc
     #   weasel
-pydantic-core==2.33.2
+pydantic-core==2.27.2
     # via pydantic
 pydantic-settings==2.10.1
     # via langchain-community
@@ -799,7 +799,7 @@ sympy==1.14.0
     # via
     #   onnxruntime
     #   torch
-tenacity==9.1.2
+tenacity==8.5.0
     # via
     #   chromadb
     #   google-genai
@@ -821,11 +821,11 @@ tinycss2==1.4.0
     #   weasyprint
 tinyhtml5==2.0.0
     # via weasyprint
-tokenizers==0.21.4
+tokenizers==0.20.3
     # via
     #   chromadb
     #   transformers
-torch==2.8.0+cpu
+torch==2.5.1+cpu
     # via sentence-transformers
 tornado==6.5.2
     # via neuro-san
@@ -841,7 +841,7 @@ traitlets==5.14.3
     # via
     #   ipython
     #   matplotlib-inline
-transformers==4.55.4
+transformers==4.45.2
     # via sentence-transformers
 typer==0.16.1
     # via

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,11 +32,7 @@ services:
       - ./docker_volumes/legal_discovery/audio_cache:/usr/src/app/audio_cache
     restart: unless-stopped
     command: >-
-      bash -c "pip install --no-cache-dir hipporag==2.0.0a3 tiktoken==0.7.0 \
-      pydantic==2.10.4 tenacity==8.5.0 transformers==4.45.2 \
-      litellm==1.73.1 gritlm==1.0.2 python-igraph==0.11.8 \
-      einops==0.8.1 \
-      https://download.pytorch.org/whl/cpu/torch-2.5.1%2Bcpu-cp311-cp311-linux_x86_64.whl && \
+      bash -c "pip install --no-cache-dir hipporag litellm && \
       python -m gunicorn -k eventlet -w 1 -b 0.0.0.0:5001 apps.legal_discovery.startup:app"
     healthcheck:
       test: ["CMD", "curl", "-fsS", "http://localhost:5001/api/health"]


### PR DESCRIPTION
## Summary
- align legal_discovery dependency versions for HippoRAG compatibility
- install hipporag and litellm at runtime without version pins
- document dependency update in AGENTS log

## Testing
- `pytest`
- `pip-compile apps/legal_discovery/requirements.in --extra-index-url https://download.pytorch.org/whl/cpu -o apps/legal_discovery/requirements.txt --resolver=backtracking` *(fails: Cannot install requirement due to conflicting dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68b00b14a9e083338a1f5d0d5ab6772b