### PR TITLE
feat: refine dashboard layout

### DIFF
--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -1153,3 +1153,8 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 ## Update 2025-08-28T08:02Z
 - Aligned requirements with HippoRAG by downgrading transformer stack and core deps; docker-compose now installs hipporag and litellm without version pins.
 - Next: build the container to confirm clean installs and runtime stability.
+
+## Update 2025-08-28T13:22Z
+- Refined dashboard layout with scrollable tab bar and centered content panels to reduce squashed sections.
+- Expanded card grid spacing and minimum widths for clearer separation.
+- Next: review mobile navigation icons and optimize remaining component spacing.

--- a/apps/legal_discovery/src/Dashboard.jsx
+++ b/apps/legal_discovery/src/Dashboard.jsx
@@ -93,7 +93,7 @@ function Dashboard() {
   return (
     <div className="dashboard-grid">
       <Tour />
-      <div className="tab-buttons" role="tablist" onKeyDown={handleKeyDown} ref={tabListRef}>
+      <nav className="tab-buttons" role="tablist" onKeyDown={handleKeyDown} ref={tabListRef}>
         {TABS.map(t => (
           <NavLink id={`tab-${t.id}`} key={t.id} to={t.id} className={({isActive})=>`tab-button${isActive?' active':''}`} role="tab" aria-label={t.label}>
             <i className={`fa ${t.icon} mr-1`} aria-hidden="true"></i>{t.label}
@@ -103,8 +103,8 @@ function Dashboard() {
           <i className="fa fa-cog"></i>
         </button>
         <ThemeToggle />
-      </div>
-      <div className="tab-panels">
+      </nav>
+      <main className="tab-panels">
         <Routes>
           {TABS.filter(t=>t.Component).map(t => (
             <Route key={t.id} path={t.id} element={render(t.Component)} />
@@ -112,7 +112,7 @@ function Dashboard() {
           <Route path="docs" element={render(DocsRoute)} />
           <Route index element={render(OverviewSection)} />
         </Routes>
-      </div>
+      </main>
       <SettingsModal open={showSettings} onClose={()=>setShowSettings(false)}/>
     </div>
   );

--- a/apps/legal_discovery/static/style.css
+++ b/apps/legal_discovery/static/style.css
@@ -271,8 +271,9 @@ h2 {
 
 .card-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-    gap: 24px;
+    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+    gap: 32px;
+    align-items: stretch;
 }
 
 .network-grid {
@@ -291,13 +292,25 @@ h2 {
 /* Simple tabbed interface */
 .tab-buttons {
     display: flex;
-    flex-wrap: wrap;
-    gap: 8px;
-    margin-bottom: 20px;
+    flex-wrap: nowrap;
+    gap: var(--space-sm);
+    margin-bottom: var(--space-sm);
+    overflow-x: auto;
+    padding: var(--space-sm);
+    scrollbar-width: thin;
 }
+.tab-buttons::-webkit-scrollbar {
+    height: 4px;
+}
+.tab-buttons::-webkit-scrollbar-thumb {
+    background: var(--color-accent-700);
+    border-radius: 2px;
+}
+
 
 .tab-button {
     padding: 8px 16px;
+    flex: 0 0 auto;
     background: var(--card-bg);
     border: 1px solid var(--border-colour);
     border-radius: 6px;
@@ -333,7 +346,14 @@ h2 {
         "content";
 }
 .tab-buttons { grid-area: tabs; }
-.tab-panels { grid-area: content; }
+.tab-panels {
+    grid-area: content;
+    padding: var(--space-lg);
+    width: 100%;
+    max-width: 1600px;
+    margin: 0 auto;
+    box-sizing: border-box;
+}
 
 @media (min-width: 768px) {
     .dashboard-grid {


### PR DESCRIPTION
## Summary
- make dashboard tabs horizontally scrollable and center content panels
- expand card-grid spacing and minimum widths for less cramped UI
- log progress in AGENTS notes

## Testing
- `npm run lint`
- `npm run build`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b05782cac48333ba8d9ec35c12daa1