### PR TITLE
M2: Live upload progress via Socket.IO

### DIFF
--- a/apps/legal_discovery/interface_flask.py
+++ b/apps/legal_discovery/interface_flask.py
@@ -208,6 +208,15 @@ def _set_status(job_id: str | None, state: str, **kwargs) -> None:
         return
     payload = {"state": state, "updated": time.time()} | kwargs
     _status_set(job_id, payload)
+    # Broadcast progress to connected clients
+    try:  # pragma: no cover - best effort
+        socketio.emit(
+            "upload_progress",
+            {"job_id": job_id, **payload},
+            namespace="/ws/upload",
+        )
+    except Exception:
+        pass
 # Allow the primary relational store to be configured at runtime. Default to
 # SQLite for local development but override with an environment-provided
 # PostgreSQL connection string when available so the application scales under

--- a/apps/legal_discovery/src/components/UploadSection.jsx
+++ b/apps/legal_discovery/src/components/UploadSection.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from "react";
 import ErrorBoundary from "./ErrorBoundary";
+import { io } from "socket.io-client";
 import Spinner from "./common/Spinner";
 import ErrorBanner from "./common/ErrorBanner";
 
@@ -34,6 +35,15 @@ function UploadSection() {
         setLoading(false);
       });
   };
+  useEffect(() => {
+    const s = io('/ws/upload', { transports: ["websocket"] });
+    s.on('upload_progress', (ev) => {
+      if (!ev || !ev.job_id) return;
+      // Event-driven updates are supplemental; polling remains the source of truth
+    });
+    return () => s.disconnect();
+  }, []);
+
   const upload = async () => {
     const files = Array.from(inputRef.current.files);
     if (!files.length) return;


### PR DESCRIPTION
- Emit 'upload_progress' events on /ws/upload namespace at each ingestion stage
- UploadSection subscribes to /ws/upload (socket.io-client) to react to events
- Keep polling as fallback for aggregated progress