### PR TITLE
M2: Backpressure for upload ingestion + health metrics

### DIFF
--- a/apps/legal_discovery/hippo_routes.py
+++ b/apps/legal_discovery/hippo_routes.py
@@ -113,6 +113,13 @@ def health() -> "flask.Response":
         "blocked_requests": dict(blocked_requests),
         "cache": {"hits": cache_stats.get("hits", 0), "misses": cache_stats.get("misses", 0)},
     }
+    # Include ingestion queue depth if available
+    try:
+        from .interface_flask import _pending_count, MAX_PENDING  # type: ignore
+
+        data["queue"] = {"pending": _pending_count(), "max_pending": MAX_PENDING}
+    except Exception:
+        pass
     meta = {}
     if neo4j_error:
         meta["neo4j_error"] = neo4j_error

--- a/apps/legal_discovery/openapi_docs.py
+++ b/apps/legal_discovery/openapi_docs.py
@@ -95,7 +95,13 @@ def openapi_spec() -> Response:
                             }
                         }
                     },
-                    "responses": {"202": {"description": "Accepted", "content": {"application/json": {"schema": {"type": "object"}}}}},
+                    "responses": {
+                        "202": {
+                            "description": "Accepted",
+                            "content": {"application/json": {"schema": {"type": "object"}}},
+                        },
+                        "429": {"description": "Too many requests / busy"}
+                    },
                 }
             },
         },

--- a/apps/legal_discovery/src/components/UploadSection.jsx
+++ b/apps/legal_discovery/src/components/UploadSection.jsx
@@ -65,7 +65,12 @@ function UploadSection() {
       let data = {};
       try { data = await resp.json(); } catch {}
       const accepted = (data?.data?.accepted) || [];
+      const busy = !!(data?.meta?.busy);
       jobIds.push(...accepted);
+      if (busy) {
+        // Server signaled backpressure; wait briefly before next batch
+        await new Promise(r=>setTimeout(r, 2000));
+      }
     }
     // Poll status until all jobs complete
     const pending = new Set(jobIds);


### PR DESCRIPTION
- Track pending jobs and enforce INGESTION_MAX_PENDING (default 1000)
- Return 202 with meta {pending, max_pending, busy} from /api/upload
- /api/health now reports queue depth
- UI: respect busy flag and briefly back off between batches
- OpenAPI: document 429 for /api/upload