### PR TITLE
Fix timeline endpoint indentation

### DIFF
--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -1158,3 +1158,7 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 - Refined dashboard layout with scrollable tab bar and centered content panels to reduce squashed sections.
 - Expanded card grid spacing and minimum widths for clearer separation.
 - Next: review mobile navigation icons and optimize remaining component spacing.
+
+## Update 2025-10-07T16:00Z
+- Removed stray indented block causing `interface_flask.py` to throw an IndentationError during startup.
+- Next: confirm timeline generation runs cleanly after container launch.

--- a/apps/legal_discovery/interface_flask.py
+++ b/apps/legal_discovery/interface_flask.py
@@ -1270,22 +1270,6 @@ def generate_timeline_endpoint():
     socketio.start_background_task(_generate_timeline_overview, case_id)
     return ok({"case_id": case_id})
 
-        try:
-            db.session.commit()
-        except Exception as exc:  # pragma: no cover - best effort
-            db.session.rollback()
-            app.logger.error("Batch commit failed: %s", exc)
-
-        VectorDatabaseManager().persist()
-
-        if batch_processed:
-            reinitialize_legal_discovery_session()
-            user_input_queue.put(
-                "process all files ingested within your scope and produce a basic overview and report."
-            )
-
-    return jsonify({"status": "ok", "processed": processed, "skipped": skipped})
-
 
 @app.route("/api/export", methods=["GET"])
 def export_files():


### PR DESCRIPTION
## Summary
- remove stray block after `/api/timeline/generate` endpoint to resolve IndentationError
- note update in module guide log

## Testing
- `python -m py_compile apps/legal_discovery/interface_flask.py`
- `pytest tests -q` *(failed: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68b355b41fd08333aeec6d54ca8c2aa9