### PR TITLE
Improve dashboard layout and background task handling

### DIFF
--- a/apps/legal_discovery/src/Dashboard.jsx
+++ b/apps/legal_discovery/src/Dashboard.jsx
@@ -36,8 +36,8 @@ const ChainLogSection = React.lazy(()=>import('./components/ChainLogSection'));
 const TABS = [
   {id:'network', label:'Agent Network', icon:'fa-sitemap', Component: AgentNetworkSection},
   {id:'overview', label:'Overview', icon:'fa-home', Component: OverviewSection},
-  {id:'pipeline', label:'Team Pipeline', icon:'fa-route', Component: PipelineSection},
   {id:'chat', label:'Orchestrator', icon:'fa-comments', Component: ChatSection},
+  {id:'pipeline', label:'Team Pipeline', icon:'fa-route', Component: PipelineSection},
   {id:'stats', label:'Stats', icon:'fa-chart-bar', Component: StatsSection},
   {id:'upload', label:'Ingestion', icon:'fa-upload', Component: UploadSection},
   {id:'review', label:'Doc Review', icon:'fa-list', Component: DocumentReviewSection},
@@ -67,14 +67,25 @@ const render = (Comp) => (
   </ErrorBoundary>
 );
 
-const DocsRoute = () => (
-  <div className="card-grid">
-    <DocToolsSection/>
-    <VersionHistorySection/>
-    <DocumentDraftSection/>
-    <AutoDraftSection/>
-  </div>
-);
+const DOC_TABS = [
+  { id: 'tools', label: 'Document Tools', Component: DocToolsSection },
+  { id: 'versions', label: 'Version History', Component: VersionHistorySection },
+  { id: 'draft', label: 'Document Draft', Component: DocumentDraftSection },
+  { id: 'auto', label: 'Auto Draft', Component: AutoDraftSection },
+];
+
+const DocsRoute = () => {
+  const [selected, setSelected] = useState('tools');
+  const Active = DOC_TABS.find(t => t.id === selected).Component;
+  return (
+    <div>
+      <select value={selected} onChange={e=>setSelected(e.target.value)} className="mb-4 p-2 rounded">
+        {DOC_TABS.map(t => <option key={t.id} value={t.id}>{t.label}</option>)}
+      </select>
+      <Active />
+    </div>
+  );
+};
 
 function Dashboard() {
   const [showSettings,setShowSettings] = useState(false);

--- a/apps/legal_discovery/src/components/TasksSection.jsx
+++ b/apps/legal_discovery/src/components/TasksSection.jsx
@@ -3,7 +3,12 @@ import { alertResponse } from "../utils";
 function TasksSection() {
   const [task,setTask] = useState('');
   const [list,setList] = useState('');
-  const add = () => fetch('/api/tasks',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({task})}).then(r=>r.json()).then(alertResponse);
+  const add = () => fetch('/api/tasks',{
+    method:'POST',
+    headers:{'Content-Type':'application/json'},
+    body:JSON.stringify({task}),
+    keepalive:true
+  }).then(r=>r.json()).then(alertResponse);
   const listAll = () => fetch('/api/tasks').then(r=>r.json()).then(d=>setList(d.data||''));
   const clear = () => fetch('/api/tasks',{method:'DELETE'}).then(r=>r.json()).then(d=>{setList('');alert(d.message||'Cleared');});
   return (

--- a/apps/legal_discovery/static/style.css
+++ b/apps/legal_discovery/static/style.css
@@ -344,6 +344,8 @@ h2 {
     grid-template-areas:
         "tabs"
         "content";
+    grid-template-rows: auto 1fr;
+    min-height: 100vh;
 }
 .tab-buttons { grid-area: tabs; }
 .tab-panels {
@@ -359,6 +361,7 @@ h2 {
     .dashboard-grid {
         grid-template-columns: 220px 1fr;
         grid-template-areas: "tabs content";
+        grid-template-rows: 1fr;
     }
     .tab-buttons {
         flex-direction: column;
@@ -579,7 +582,7 @@ footer {
 .modal {
     display: flex;
     position: fixed;
-    z-index: 1;
+    z-index: 1000;
     left: 0;
     top: 0;
     width: 100%;

--- a/tests/apps/test_health_endpoint.py
+++ b/tests/apps/test_health_endpoint.py
@@ -14,7 +14,7 @@ def test_health_endpoint_returns_status_keys():
     client = app.test_client()
     resp = client.get("/api/health")
     assert resp.status_code == 200
-    data = resp.get_json()
+    data = resp.get_json()["data"]
     assert {"neo4j", "chroma", "blocked_requests", "cache"}.issubset(data)
 
 
@@ -33,9 +33,11 @@ def test_health_reports_neo4j_failure(monkeypatch, caplog):
     with caplog.at_level(logging.ERROR):
         resp = client.get("/api/health")
 
-    data = resp.get_json()
+    payload = resp.get_json()
+    data = payload["data"]
+    meta = payload.get("meta", {})
     assert data["neo4j"] == "fail"
-    assert "neo4j_error" in data and "boom" in data["neo4j_error"]
+    assert "neo4j_error" in meta and "boom" in meta["neo4j_error"]
     assert "Neo4j health check failed" in caplog.text
 
 
@@ -52,7 +54,9 @@ def test_health_reports_chroma_failure(monkeypatch, caplog):
     with caplog.at_level(logging.ERROR):
         resp = client.get("/api/health")
 
-    data = resp.get_json()
+    payload = resp.get_json()
+    data = payload["data"]
+    meta = payload.get("meta", {})
     assert data["chroma"] == "fail"
-    assert "chroma_error" in data and "boom" in data["chroma_error"]
+    assert "chroma_error" in meta and "boom" in meta["chroma_error"]
     assert "Chroma health check failed" in caplog.text


### PR DESCRIPTION
## Summary
- Move chat tab to third position and add dropdown selector for document tools
- Ensure tasks keep running via keepalive requests and make settings modal overlay prominent
- Adjust dashboard grid for full-height layout and update health endpoint tests for nested data

## Testing
- `npm run build`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b503f47ccc8333a5afeb619dd8feba