### PR TITLE
Expose cache metrics and configurable TTLs

### DIFF
--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -1166,3 +1166,8 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 ## Update 2025-08-30T22:05Z
 - Added flex wrapping and horizontal scroll to tab navigation; buttons now keep their width for better responsiveness.
 - Next: tune card spacing for narrow viewports.
+
+## Update 2025-08-31T00:00Z
+- Exposed Redis cache hit/miss metrics in `/api/metrics` and dashboard Stats/Overview cards.
+- Cache TTLs configurable via `CACHE_TTL` and `CACHE_TTL_<PREFIX>`.
+- Next: visualise cache performance trends and fine-tune TTL values.

--- a/apps/legal_discovery/README.md
+++ b/apps/legal_discovery/README.md
@@ -120,6 +120,12 @@ Dashboard components use `/api/metrics` to retrieve counts for uploads,
 vector documents, graph nodes, tasks, forensic logs and total cases in a single request.
 This reduces network traffic and keeps the UI responsive.
 
+Cache hits and misses are also included so you can monitor the effectiveness
+of Redis caching.  The dashboard displays raw counts and a hit percentage to
+help tune performance.  Adjust cache expiry times by setting `CACHE_TTL` for a
+global default or `CACHE_TTL_<PREFIX>` for specific caches such as
+`CACHE_TTL_VECTOR_SEARCH` or `CACHE_TTL_HIPPO_QUERY`.
+
 The dashboard tabs are labelled after the teams defined in
 `registries/legal_discovery.hocon`. Outputs from each coded tool are shown
 directly within their respective sections so you can track the work of each

--- a/apps/legal_discovery/hippo_routes.py
+++ b/apps/legal_discovery/hippo_routes.py
@@ -41,7 +41,11 @@ health_bp = Blueprint("health", __name__, url_prefix="/api")
 logger = logging.getLogger(__name__)
 
 
-@redis_cache("hippo_query", key_func=lambda case_id, query, k=10: f"{case_id}:{query}:{k}")
+@redis_cache(
+    "hippo_query",
+    ttl=600,
+    key_func=lambda case_id, query, k=10: f"{case_id}:{query}:{k}",
+)
 def _hippo_query_cached(case_id: str, query: str, k: int = 10):
     return hippo.hippo_query(case_id, query, k=k)
 

--- a/apps/legal_discovery/src/components/OverviewSection.jsx
+++ b/apps/legal_discovery/src/components/OverviewSection.jsx
@@ -7,6 +7,12 @@ function OverviewSection() {
     fetchJSON('/api/metrics').then(d=>setMetrics(d.data||{}));
   };
   useEffect(refresh, []);
+  const hitRate = (() => {
+    const hits = metrics.cache_hits || 0;
+    const misses = metrics.cache_misses || 0;
+    const total = hits + misses;
+    return total ? Math.round((hits * 100) / total) : 0;
+  })();
   return (
     <section className="card">
       <h2>Overview</h2>
@@ -16,6 +22,7 @@ function OverviewSection() {
           <MetricCard icon="fa-tasks" label="Tasks" value={metrics.task_count||0} />
           <MetricCard icon="fa-database" label="Vectors" value={metrics.vector_docs||0} />
           <MetricCard icon="fa-project-diagram" label="Graph" value={metrics.graph_nodes||0} />
+          <MetricCard icon="fa-bolt" label="Cache Hit %" value={hitRate} />
         </div>
       <button className="button-secondary" onClick={refresh}><i className="fa fa-sync mr-1"></i>Refresh</button>
     </section>

--- a/apps/legal_discovery/src/components/StatsSection.jsx
+++ b/apps/legal_discovery/src/components/StatsSection.jsx
@@ -6,6 +6,8 @@ function StatsSection() {
     fetchJSON('/api/metrics').then(d => setStats(d.data || {}));
   };
   useEffect(refresh, []);
+  const totalCache = (stats.cache_hits || 0) + (stats.cache_misses || 0);
+  const hitRate = totalCache ? Math.round((stats.cache_hits || 0) * 100 / totalCache) : 0;
   return (
     <section className="card" id="stats-card">
       <h2>Stats</h2>
@@ -13,6 +15,9 @@ function StatsSection() {
       <p className="mb-1">Uploaded files: <span>{stats.uploaded_files || 0}</span></p>
       <p className="mb-1">Vector documents: <span>{stats.vector_docs || 0}</span></p>
       <p className="mb-1">Graph nodes: <span>{stats.graph_nodes || 0}</span></p>
+      <p className="mb-1">Cache hits: <span>{stats.cache_hits || 0}</span></p>
+      <p className="mb-1">Cache misses: <span>{stats.cache_misses || 0}</span></p>
+      <p className="mb-1">Cache hit %: <span>{hitRate}</span></p>
       <p>Tasks: <span>{stats.task_count || 0}</span></p>
       <button className="button-secondary mt-2" onClick={refresh}><i className="fa fa-sync mr-1"></i>Refresh</button>
     </section>


### PR DESCRIPTION
## Summary
- show Redis cache hits/misses and hit rate in aggregated `/api/metrics`
- surface cache metrics in dashboard Overview and Stats cards
- allow cache TTL tuning via `CACHE_TTL` and `CACHE_TTL_<PREFIX>` env vars

## Testing
- `pytest`
- `npm --prefix apps/legal_discovery run build`


------
https://chatgpt.com/codex/tasks/task_e_68b50c1419848333ba578fe9d02d361b