### PR TITLE
Improve health checks and SQLAlchemy probe

### DIFF
--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -1171,3 +1171,8 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 - Exposed Redis cache hit/miss metrics in `/api/metrics` and dashboard Stats/Overview cards.
 - Cache TTLs configurable via `CACHE_TTL` and `CACHE_TTL_<PREFIX>`.
 - Next: visualise cache performance trends and fine-tune TTL values.
+
+## Update 2025-10-08T00:00Z
+- Hardened `/api/health` endpoint with explicit Chroma/Postgres probes and SQLAlchemy `text` fix.
+- HTTP status now returns 503 with detailed errors when dependencies fail.
+- Next: extend checks to Neo4j and Redis for parity with previous implementation.


### PR DESCRIPTION
## Summary
- Harden `/api/health` to surface Chroma and Postgres errors and return 503 when dependencies fail
- Use SQLAlchemy `text("SELECT 1")` for Postgres probe
- Log progress in legal discovery AGENTS.md

## Testing
- `python -m py_compile apps/legal_discovery/hippo_routes.py`
- `pytest -q` *(fails: KeyboardInterrupt while importing spacy)*

------
https://chatgpt.com/codex/tasks/task_e_68b5421088f48333928883fd71387352