### PR TITLE
Return 503 when health checks fail

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,7 +422,7 @@ Containers expose `/api/health` so orchestrators can verify service status. A he
 }
 ```
 
-Any non-`200` response indicates the service is unhealthy and should be restarted.
+If any dependency check fails the endpoint returns HTTP `503` alongside diagnostic details. Any non-`200` response indicates the service is unhealthy and should be restarted.
 
 ---
 

--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -1180,3 +1180,7 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 ## Update 2025-10-08T00:00Z
 - Updated Postgres health check to use SQLAlchemy `text` and ensure sessions close cleanly.
 - Next: audit remaining health checks for consistent session management.
+
+## Update 2025-10-08T00:30Z
+- Health endpoint returns HTTP 503 when any dependency fails and readiness propagates the status; tests and docs updated.
+- Next: audit dashboard polling to ensure it handles non-200 health responses.

--- a/apps/legal_discovery/hippo_routes.py
+++ b/apps/legal_discovery/hippo_routes.py
@@ -136,7 +136,14 @@ def health() -> "flask.Response":
     if redis_error:
         meta["redis_error"] = redis_error
 
-    return ok(data=data, meta=meta if meta else None)
+    status_code = 200
+    if any(
+        s == "fail"
+        for s in (neo4j_status, chroma_status, postgres_status, redis_status)
+    ):
+        status_code = 503
+
+    return ok(data=data, meta=meta if meta else None, status=status_code)
 
 
 @health_bp.get("/readiness")
@@ -148,13 +155,15 @@ def readiness() -> "flask.Response":
     try:
         payload = res.get_json() or {}
         data = payload.get("data", {})
-        ready = all(data.get(k) == "ok" for k in ("neo4j", "chroma", "postgres", "redis"))
+        ready = all(
+            data.get(k) == "ok" for k in ("neo4j", "chroma", "postgres", "redis")
+        )
     except Exception:
         ready = False
     if not ready:
         # Return original payload with a 503 status to signal not-ready.
-        return res[0], 503
-    return res
+        return res, 503
+    return res, status
 
 
 @bp.post("/index")

--- a/apps/legal_discovery/openapi_docs.py
+++ b/apps/legal_discovery/openapi_docs.py
@@ -28,7 +28,7 @@ def openapi_spec() -> Response:
                     "summary": "Service health",
                     "responses": {
                         "200": {
-                            "description": "Health status",
+                            "description": "All services healthy",
                             "content": {
                                 "application/json": {
                                     "schema": {
@@ -49,7 +49,8 @@ def openapi_spec() -> Response:
                                     }
                                 }
                             },
-                        }
+                        },
+                        "503": {"description": "One or more services unhealthy"}
                     },
                 }
             },

--- a/tests/apps/test_health_endpoint.py
+++ b/tests/apps/test_health_endpoint.py
@@ -8,10 +8,51 @@ from apps.legal_discovery import hippo_routes
 from apps.legal_discovery.hippo_routes import health_bp
 
 
-def test_health_endpoint_returns_status_keys():
+def test_health_endpoint_returns_status_keys(monkeypatch):
     app = Flask(__name__)
     app.register_blueprint(health_bp)
     client = app.test_client()
+
+    class DummySession:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            pass
+
+        def run(self, query):
+            return None
+
+    class DummyDriver:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            pass
+
+        def session(self, database=None):
+            return DummySession()
+
+    class DummyGraphDB:
+        @staticmethod
+        def driver(*args, **kwargs):
+            return DummyDriver()
+
+    monkeypatch.setattr(hippo_routes, "GraphDatabase", DummyGraphDB)
+    monkeypatch.setattr(
+        hippo_routes.requests, "get", lambda *a, **kw: type("R", (), {"status_code": 200})()
+    )
+    monkeypatch.setattr(hippo_routes.db.session, "execute", lambda *a, **kw: None)
+    monkeypatch.setattr(hippo_routes.db.session, "commit", lambda *a, **kw: None)
+    monkeypatch.setattr(hippo_routes.db.session, "close", lambda *a, **kw: None)
+    class DummyRedis:
+        def ping(self):
+            return None
+    monkeypatch.setattr(hippo_routes, "redis_client", DummyRedis())
+
     resp = client.get("/api/health")
     assert resp.status_code == 200
     data = resp.get_json()["data"]
@@ -33,6 +74,7 @@ def test_health_reports_neo4j_failure(monkeypatch, caplog):
     with caplog.at_level(logging.ERROR):
         resp = client.get("/api/health")
 
+    assert resp.status_code == 503
     payload = resp.get_json()
     data = payload["data"]
     meta = payload.get("meta", {})
@@ -54,6 +96,7 @@ def test_health_reports_chroma_failure(monkeypatch, caplog):
     with caplog.at_level(logging.ERROR):
         resp = client.get("/api/health")
 
+    assert resp.status_code == 503
     payload = resp.get_json()
     data = payload["data"]
     meta = payload.get("meta", {})


### PR DESCRIPTION
## Summary
- Signal unhealthy services with HTTP 503 from `/api/health`
- Propagate health status through `/api/readiness`
- Document and test new failure semantics

## Testing
- `pytest tests/apps/test_health_endpoint.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b57b98fef88333a0b03193ce08362a