### PR TITLE
Handle Chroma request errors in health check

### DIFF
--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -1184,3 +1184,8 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 ## Update 2025-10-08T00:30Z
 - Health endpoint returns HTTP 503 when any dependency fails and readiness propagates the status; tests and docs updated.
 - Next: audit dashboard polling to ensure it handles non-200 health responses.
+
+## Update 2025-10-09T00:00Z
+- Added dedicated handling for Chroma connection and timeout errors with clearer messages in the health check.
+- Extended health endpoint tests to cover these failure modes.
+- Next: ensure deployment config sets CHROMA_HOST/PORT to a reachable service.

--- a/apps/legal_discovery/hippo_routes.py
+++ b/apps/legal_discovery/hippo_routes.py
@@ -85,6 +85,14 @@ def health() -> "flask.Response":
         resp = requests.get(f"http://{host}:{port}/api/v1/heartbeat", timeout=2)
         if resp.status_code != 200:
             raise RuntimeError("chroma heartbeat failed")
+    except requests.exceptions.ConnectionError as exc:
+        logger.exception("Chroma connection error")
+        chroma_status = "fail"
+        chroma_error = f"connection error: unable to reach {host}:{port} ({exc})"
+    except requests.exceptions.Timeout as exc:
+        logger.exception("Chroma request timed out")
+        chroma_status = "fail"
+        chroma_error = f"timeout contacting {host}:{port} ({exc})"
     except Exception as exc:
         logger.exception("Chroma health check failed")
         chroma_status = "fail"

--- a/tests/apps/test_health_endpoint.py
+++ b/tests/apps/test_health_endpoint.py
@@ -2,6 +2,7 @@
 
 import logging
 
+import requests
 from flask import Flask
 
 from apps.legal_discovery import hippo_routes
@@ -103,3 +104,37 @@ def test_health_reports_chroma_failure(monkeypatch, caplog):
     assert data["chroma"] == "fail"
     assert "chroma_error" in meta and "boom" in meta["chroma_error"]
     assert "Chroma health check failed" in caplog.text
+
+
+def test_health_reports_chroma_connection_error(monkeypatch):
+    app = Flask(__name__)
+    app.register_blueprint(health_bp)
+    client = app.test_client()
+
+    def failing_get(*args, **kwargs):  # pragma: no cover - monkeypatched
+        raise requests.exceptions.ConnectionError("no route")
+
+    monkeypatch.setattr(hippo_routes.requests, "get", failing_get)
+
+    resp = client.get("/api/health")
+    assert resp.status_code == 503
+    payload = resp.get_json()
+    assert payload["data"]["chroma"] == "fail"
+    assert "connection error" in payload.get("meta", {}).get("chroma_error", "").lower()
+
+
+def test_health_reports_chroma_timeout(monkeypatch):
+    app = Flask(__name__)
+    app.register_blueprint(health_bp)
+    client = app.test_client()
+
+    def failing_get(*args, **kwargs):  # pragma: no cover - monkeypatched
+        raise requests.exceptions.Timeout("slow")
+
+    monkeypatch.setattr(hippo_routes.requests, "get", failing_get)
+
+    resp = client.get("/api/health")
+    assert resp.status_code == 503
+    payload = resp.get_json()
+    assert payload["data"]["chroma"] == "fail"
+    assert "timeout" in payload.get("meta", {}).get("chroma_error", "").lower()


### PR DESCRIPTION
## Summary
- handle Chroma connection and timeout errors explicitly in health check with clearer messages
- test health endpoint for Chroma connection and timeout failures
- log health check update in legal discovery module guide

## Testing
- `pytest tests/apps/test_health_endpoint.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b582bdd7bc8333a181fd96cb2cac0f