### PR TITLE
Improve Postgres health check error handling

### DIFF
--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -1189,3 +1189,7 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 - Added dedicated handling for Chroma connection and timeout errors with clearer messages in the health check.
 - Extended health endpoint tests to cover these failure modes.
 - Next: ensure deployment config sets CHROMA_HOST/PORT to a reachable service.
+
+## Update 2025-10-09T01:00Z
+- Scoped Postgres health check exceptions to `SQLAlchemyError` and added unit test for failure path.
+- Next: review remaining health tests for coverage gaps.

--- a/apps/legal_discovery/hippo_routes.py
+++ b/apps/legal_discovery/hippo_routes.py
@@ -9,6 +9,7 @@ import uuid
 
 import requests
 from sqlalchemy import text
+from sqlalchemy.exc import SQLAlchemyError
 from flask import Blueprint, jsonify, request
 from .auth import auth_required
 
@@ -102,7 +103,11 @@ def health() -> "flask.Response":
     try:  # pragma: no cover - external service
         db.session.execute(text("SELECT 1"))
         db.session.commit()
-    except Exception as exc:
+    except SQLAlchemyError as exc:
+        logger.exception("Postgres health check failed")
+        postgres_status = "fail"
+        postgres_error = str(exc)
+    except Exception as exc:  # pragma: no cover - unexpected DB error
         logger.exception("Postgres health check failed")
         postgres_status = "fail"
         postgres_error = str(exc)

--- a/tests/apps/test_health_endpoint.py
+++ b/tests/apps/test_health_endpoint.py
@@ -3,6 +3,7 @@
 import logging
 
 import requests
+from sqlalchemy.exc import SQLAlchemyError
 from flask import Flask
 
 from apps.legal_discovery import hippo_routes
@@ -138,3 +139,27 @@ def test_health_reports_chroma_timeout(monkeypatch):
     payload = resp.get_json()
     assert payload["data"]["chroma"] == "fail"
     assert "timeout" in payload.get("meta", {}).get("chroma_error", "").lower()
+
+
+def test_health_reports_postgres_failure(monkeypatch, caplog):
+    app = Flask(__name__)
+    app.register_blueprint(health_bp)
+    client = app.test_client()
+
+    def failing_execute(*args, **kwargs):  # pragma: no cover - monkeypatched
+        raise SQLAlchemyError("boom")
+
+    monkeypatch.setattr(hippo_routes.db.session, "execute", failing_execute)
+    monkeypatch.setattr(hippo_routes.db.session, "commit", lambda *a, **kw: None)
+    monkeypatch.setattr(hippo_routes.db.session, "close", lambda *a, **kw: None)
+
+    with caplog.at_level(logging.ERROR):
+        resp = client.get("/api/health")
+
+    assert resp.status_code == 503
+    payload = resp.get_json()
+    data = payload["data"]
+    meta = payload.get("meta", {})
+    assert data["postgres"] == "fail"
+    assert "postgres_error" in meta and "boom" in meta["postgres_error"]
+    assert "Postgres health check failed" in caplog.text


### PR DESCRIPTION
## Summary
- catch SQLAlchemy-specific and generic errors during Postgres health check
- add regression test for Postgres failure scenario
- log update in AGENTS instructions

## Testing
- `npm run build`
- `pytest tests/apps/test_health_endpoint.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5ede35da08333ac747fc054b51a62