### PR TITLE
Update Chroma heartbeat endpoint

### DIFF
--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -1197,3 +1197,7 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 ## Update 2025-10-09T02:00Z
 - Chroma health check now uses `/api/heartbeat` and logs heartbeat responses for troubleshooting.
 - Next: monitor logs in production and adjust verbosity if needed.
+
+## Update 2025-10-09T02:30Z
+- Updated Chroma health check to `/api/v1/heartbeat`.
+- Next: consider falling back to the legacy endpoint if deployment requires it.

--- a/apps/legal_discovery/hippo_routes.py
+++ b/apps/legal_discovery/hippo_routes.py
@@ -83,7 +83,7 @@ def health() -> "flask.Response":
     try:  # pragma: no cover - external service
         host = os.environ.get("CHROMA_HOST", "localhost")
         port = int(os.environ.get("CHROMA_PORT", "8000"))
-        resp = requests.get(f"http://{host}:{port}/api/heartbeat", timeout=2)
+        resp = requests.get(f"http://{host}:{port}/api/v1/heartbeat", timeout=2)
         logger.debug(
             "Chroma heartbeat response %s: %s",
             resp.status_code,


### PR DESCRIPTION
## Summary
- Update legal discovery Chroma heartbeat check to `/api/v1/heartbeat`
- Log progress in module guide

## Testing
- `pytest tests/apps/test_health_endpoint.py::test_health_reports_chroma_failure tests/apps/test_health_endpoint.py::test_health_reports_chroma_connection_error -q --no-cov`

------
https://chatgpt.com/codex/tasks/task_e_68b64d406fe08333be6b98e03cc7f699