### PR TITLE
feat: add chroma heartbeat fallback

### DIFF
--- a/agents--features and memory/condensed_agents.md
+++ b/agents--features and memory/condensed_agents.md
@@ -316,3 +316,8 @@ WE STARTED ON #3, INSTEAD OF #1. DEAL WITH IT, FINISH IMPLEMENTING #3, AND THEN 
 ## Update 2025-08-24T10:10Z
 - Pinned legal_discovery dependencies and added requirements.in for deterministic builds.
 - Next: run Docker build to confirm faster installs.
+
+## Update 2025-10-09T03:30Z
+- Added fallback to legacy `/api/heartbeat` when `/api/v1/heartbeat` returns 404 to keep health checks green across Chroma versions.
+- Introduced spacing between navigation tabs for cleaner layout.
+- Next: monitor production logs and re-evaluate once all deployments expose the v1 heartbeat.

--- a/apps/legal_discovery/hippo_routes.py
+++ b/apps/legal_discovery/hippo_routes.py
@@ -83,12 +83,20 @@ def health() -> "flask.Response":
     try:  # pragma: no cover - external service
         host = os.environ.get("CHROMA_HOST", "localhost")
         port = int(os.environ.get("CHROMA_PORT", "8000"))
-        resp = requests.get(f"http://{host}:{port}/api/v1/heartbeat", timeout=2)
+        base = f"http://{host}:{port}"
+        resp = requests.get(f"{base}/api/v1/heartbeat", timeout=2)
         logger.debug(
             "Chroma heartbeat response %s: %s",
             resp.status_code,
             getattr(resp, "text", ""),
         )
+        if resp.status_code == 404:  # fallback for older Chroma versions
+            resp = requests.get(f"{base}/api/heartbeat", timeout=2)
+            logger.debug(
+                "Chroma legacy heartbeat response %s: %s",
+                resp.status_code,
+                getattr(resp, "text", ""),
+            )
         if resp.status_code != 200:
             raise RuntimeError("chroma heartbeat failed")
     except requests.exceptions.ConnectionError as exc:

--- a/apps/legal_discovery/src/tokens.css
+++ b/apps/legal_discovery/src/tokens.css
@@ -33,6 +33,7 @@ body {
 .tab-buttons {
   overflow-x: auto;
   flex-wrap: wrap;
+  gap: var(--space-xs);
 }
 
 .tab-button {

--- a/tests/apps/test_health_endpoint.py
+++ b/tests/apps/test_health_endpoint.py
@@ -107,6 +107,64 @@ def test_health_reports_chroma_failure(monkeypatch, caplog):
     assert "Chroma health check failed" in caplog.text
 
 
+def test_health_fallbacks_to_legacy_chroma(monkeypatch):
+    app = Flask(__name__)
+    app.register_blueprint(health_bp)
+    client = app.test_client()
+
+    class DummySession:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            pass
+
+        def run(self, query):
+            return None
+
+    class DummyDriver:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            pass
+
+        def session(self, database=None):
+            return DummySession()
+
+    class DummyGraphDB:
+        @staticmethod
+        def driver(*args, **kwargs):
+            return DummyDriver()
+
+    monkeypatch.setattr(hippo_routes, "GraphDatabase", DummyGraphDB)
+
+    class R:
+        def __init__(self, code):
+            self.status_code = code
+            self.text = ""
+
+    def fake_get(url, timeout=0):
+        if url.endswith("/api/v1/heartbeat"):
+            return R(404)
+        return R(200)
+
+    monkeypatch.setattr(hippo_routes.requests, "get", fake_get)
+    monkeypatch.setattr(hippo_routes.db.session, "execute", lambda *a, **kw: None)
+    monkeypatch.setattr(hippo_routes.db.session, "commit", lambda *a, **kw: None)
+    monkeypatch.setattr(hippo_routes.db.session, "close", lambda *a, **kw: None)
+
+    class DummyRedis:
+        def ping(self):
+            return None
+
+    monkeypatch.setattr(hippo_routes, "redis_client", DummyRedis())
+
+    resp = client.get("/api/health")
+    assert resp.status_code == 200
+    assert resp.get_json()["data"]["chroma"] == "ok"
+
+
 def test_health_reports_chroma_connection_error(monkeypatch):
     app = Flask(__name__)
     app.register_blueprint(health_bp)


### PR DESCRIPTION
## Summary
- fall back to legacy /api/heartbeat when /api/v1/heartbeat responds 404
- space out dashboard tabs for clearer navigation
- exercise new chroma heartbeat fallback in health endpoint tests

## Testing
- `npm --prefix apps/legal_discovery run build`
- `pytest tests/apps/test_health_endpoint.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b652bacffc83338c781911402b20ef