### PR TITLE
Use Chroma HTTP client for legal discovery

### DIFF
--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -1201,3 +1201,8 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 ## Update 2025-10-09T02:30Z
 - Updated Chroma health check to `/api/v1/heartbeat`.
 - Next: consider falling back to the legacy endpoint if deployment requires it.
+
+## Update 2025-10-09T03:00Z
+- Switched trial prep and Hippo vector search to `chromadb.HttpClient` using `CHROMA_HOST` and `CHROMA_PORT`.
+- Removed local `chromadb.Client` fallbacks so all interactions target the external service.
+- Next: verify external Chroma deployment in staging.

--- a/apps/legal_discovery/hippo.py
+++ b/apps/legal_discovery/hippo.py
@@ -25,8 +25,10 @@ except Exception:  # pragma: no cover - fallback when driver unavailable
 
 try:  # pragma: no cover - optional chroma dependency
     import chromadb  # type: ignore
+    from chromadb.config import Settings  # type: ignore
 except Exception:  # pragma: no cover - chroma not installed
     chromadb = None
+    Settings = None
 
 try:  # pragma: no cover - optional cross-encoder dependency
     from sentence_transformers import CrossEncoder  # type: ignore
@@ -443,8 +445,14 @@ def _vector_candidates(case_id: str, query: str, k: int) -> Dict[str, Dict]:
     lookup = {s.segment_id: s for docs in case_index.values() for s in docs}
 
     if chromadb:
+        host = os.environ.get("CHROMA_HOST", "localhost")
+        port = int(os.environ.get("CHROMA_PORT", "8000"))
         try:  # pragma: no cover - external dependency
-            client = chromadb.Client()
+            client = chromadb.HttpClient(
+                host=host,
+                port=port,
+                settings=Settings(anonymized_telemetry=False),
+            )
             coll = client.get_collection(case_id)
             res = coll.query(query_texts=[query], n_results=k)
             scores: Dict[str, Dict] = {}

--- a/apps/legal_discovery/trial_prep.py
+++ b/apps/legal_discovery/trial_prep.py
@@ -123,9 +123,17 @@ class KnowledgeBase:
 
     def __init__(self) -> None:
         self.nlp = _load_spacy_model()
+        host = os.environ.get("CHROMA_HOST", "localhost")
+        port = int(os.environ.get("CHROMA_PORT", "8000"))
         try:
-            self.client = chromadb.Client(Settings(anonymized_telemetry=False))
-            self.collection = self.client.get_or_create_collection("trial_prep_resources")
+            self.client = chromadb.HttpClient(
+                host=host,
+                port=port,
+                settings=Settings(anonymized_telemetry=False),
+            )
+            self.collection = self.client.get_or_create_collection(
+                "trial_prep_resources"
+            )
             self.use_chroma = True
         except Exception:  # pragma: no cover - environment specific
             self.client = None


### PR DESCRIPTION
## Summary
- Initialize `chromadb.HttpClient` in trial prep knowledge base using `CHROMA_HOST`/`CHROMA_PORT`
- Query Hippo vector index through the same HTTP client and drop local client fallback
- Log update in `apps/legal_discovery/AGENTS.md`

## Testing
- `pytest tests/apps/test_health_endpoint.py::test_health_endpoint_returns_status_keys -q`
- `pytest tests/apps/test_hippo_query.py::test_query_endpoint_returns_paths -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6548c898c8333a84f161a61e87af1