### PR TITLE
Use config for Chroma defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,10 @@ interact with the server.
   export AGENT_MANIFEST_FILE="./registries/manifest.hocon"
   # Point the server to the directory containing the agent Python tools
   export AGENT_TOOL_PATH="./coded_tools"
+  # Optional: override the Chroma connection
+  # Defaults: CHROMA_HOST=chromadb, CHROMA_PORT=8000
+  # export CHROMA_HOST="chromadb"
+  # export CHROMA_PORT=8000
   ```
 
 * For further instructions, refer to the client/server [setup](https://github.com/cognizant-ai-lab/neuro-san/blob/main/README.md#clientserver-setup)

--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -1206,3 +1206,7 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 - Switched trial prep and Hippo vector search to `chromadb.HttpClient` using `CHROMA_HOST` and `CHROMA_PORT`.
 - Removed local `chromadb.Client` fallbacks so all interactions target the external service.
 - Next: verify external Chroma deployment in staging.
+
+## Update 2025-10-09T04:00Z
+- Pulled Chroma host and port from `config.config` to drop hard-coded defaults in `hippo_routes.py`, `trial_prep.py` and `hippo.py`.
+- Next: confirm remaining modules reference the shared config.

--- a/apps/legal_discovery/hippo.py
+++ b/apps/legal_discovery/hippo.py
@@ -17,6 +17,7 @@ import logging
 from typing import Callable, Dict, Iterable, List, Optional, Tuple
 
 from .cache import invalidate_prefix
+from config.config import CHROMA_HOST, CHROMA_PORT
 
 try:  # pragma: no cover - allows tests without neo4j package
     from neo4j import GraphDatabase, Driver
@@ -445,8 +446,8 @@ def _vector_candidates(case_id: str, query: str, k: int) -> Dict[str, Dict]:
     lookup = {s.segment_id: s for docs in case_index.values() for s in docs}
 
     if chromadb:
-        host = os.environ.get("CHROMA_HOST", "localhost")
-        port = int(os.environ.get("CHROMA_PORT", "8000"))
+        host = CHROMA_HOST
+        port = CHROMA_PORT
         try:  # pragma: no cover - external dependency
             client = chromadb.HttpClient(
                 host=host,

--- a/apps/legal_discovery/hippo_routes.py
+++ b/apps/legal_discovery/hippo_routes.py
@@ -35,6 +35,7 @@ from .models_trial import TranscriptSegment, TrialSession
 from .trial_assistant import bp as trial_bp
 from .trial_assistant.services.objection_engine import engine
 from .tasks import enqueue, index_document_task, analyze_segment_task
+from config.config import CHROMA_HOST, CHROMA_PORT
 
 bp = Blueprint("hippo", __name__, url_prefix="/api/hippo")
 objections_bp = Blueprint("objections", __name__, url_prefix="/api/objections")
@@ -81,8 +82,8 @@ def health() -> "flask.Response":
         neo4j_error = str(exc)
 
     try:  # pragma: no cover - external service
-        host = os.environ.get("CHROMA_HOST", "localhost")
-        port = int(os.environ.get("CHROMA_PORT", "8000"))
+        host = CHROMA_HOST
+        port = CHROMA_PORT
         base = f"http://{host}:{port}"
         resp = requests.get(f"{base}/api/v1/heartbeat", timeout=2)
         logger.debug(

--- a/apps/legal_discovery/trial_prep.py
+++ b/apps/legal_discovery/trial_prep.py
@@ -16,6 +16,7 @@ from bs4 import BeautifulSoup
 from chromadb.config import Settings
 from neo4j import GraphDatabase
 from spacy.cli import download as spacy_download
+from config.config import CHROMA_HOST, CHROMA_PORT
 
 from .database import db
 from .models import LegalResource, Lesson, LessonProgress
@@ -123,8 +124,8 @@ class KnowledgeBase:
 
     def __init__(self) -> None:
         self.nlp = _load_spacy_model()
-        host = os.environ.get("CHROMA_HOST", "localhost")
-        port = int(os.environ.get("CHROMA_PORT", "8000"))
+        host = CHROMA_HOST
+        port = CHROMA_PORT
         try:
             self.client = chromadb.HttpClient(
                 host=host,

--- a/coded_tools/legal_discovery/vector_database_manager.py
+++ b/coded_tools/legal_discovery/vector_database_manager.py
@@ -4,6 +4,8 @@ import os
 import random
 import time
 
+from config.config import CHROMA_HOST, CHROMA_PORT
+
 try:  # pragma: no cover - optional dependency
     import chromadb
     from chromadb.config import Settings
@@ -74,8 +76,8 @@ from neuro_san.interfaces.coded_tool import CodedTool
 class VectorDatabaseManager(CodedTool):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        host = os.getenv("CHROMA_HOST", "localhost")
-        port = int(os.getenv("CHROMA_PORT", "8000"))
+        host = CHROMA_HOST
+        port = CHROMA_PORT
         global _GLOBAL_CLIENT
         if _GLOBAL_CLIENT is None:
             if chromadb is None:

--- a/config/.env.sample
+++ b/config/.env.sample
@@ -84,6 +84,10 @@ NEO4J_URI=bolt://neo4j:7687
 NEO4J_USER=neo4j
 NEO4J_PASSWORD=neo4jPass123
 
+# Chroma vector database configuration
+CHROMA_HOST=chromadb
+CHROMA_PORT=8000
+
 # Flask and JWT secrets for the legal discovery app
 FLASK_SECRET_KEY="change_me"
 JWT_SECRET="change_me"


### PR DESCRIPTION
## Summary
- import `CHROMA_HOST`/`CHROMA_PORT` from `config.config` for Hippo modules and vector manager
- document default Chroma connection values in README and `.env` sample
- record progress in legal discovery AGENTS log

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b6564ff4ac8333b75df598880194e2