### PR TITLE
Handle missing WeasyPrint dependencies

### DIFF
--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -1218,3 +1218,7 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 ## Update 2025-10-09T05:30Z
 - Set `.env.sample` to point `CHROMA_HOST` at the `chroma` service and documented the port.
 - Next: verify docker-compose startup with new service name.
+
+## Update 2025-10-09T06:00Z
+- Added fallbacks when WeasyPrint dependencies are missing so the server can start without PDF support.
+- Next: verify PDF export after installing WeasyPrint system libraries.

--- a/apps/legal_discovery/interface_flask.py
+++ b/apps/legal_discovery/interface_flask.py
@@ -24,7 +24,10 @@ from more_itertools import chunked
 import structlog
 from pyhocon import ConfigFactory
 from spacy.cli import download as spacy_download
-from weasyprint import HTML
+try:  # pragma: no cover - optional dependency
+    from weasyprint import HTML
+except Exception:  # pragma: no cover - environment specific
+    HTML = None
 from werkzeug.utils import secure_filename
 from pydantic import ValidationError
 
@@ -1355,11 +1358,17 @@ def export_narrative_discrepancies():
     fmt = request.args.get("format", "csv").lower()
     records = NarrativeDiscrepancy.query.all()
     if fmt == "pdf":
+        if HTML is None:
+            return err("WEASYPRINT_MISSING", "WeasyPrint is required for PDF export", status=503)
         rows = [
             f"<tr><td>{r.conflicting_claim}</td><td>{r.evidence_excerpt}</td><td>{r.confidence:.2f}</td></tr>"
             for r in records
         ]
-        html = "<table><tr><th>Claim</th><th>Evidence</th><th>Confidence</th></tr>" + "".join(rows) + "</table>"
+        html = (
+            "<table><tr><th>Claim</th><th>Evidence</th><th>Confidence</th></tr>"
+            + "".join(rows)
+            + "</table>"
+        )
         pdf = HTML(string=html).write_pdf()
         return send_file(
             BytesIO(pdf),

--- a/coded_tools/legal_discovery/auto_drafter.py
+++ b/coded_tools/legal_discovery/auto_drafter.py
@@ -8,7 +8,10 @@ from pathlib import Path
 from google import genai
 import os
 from docx import Document as DocxDocument
-from weasyprint import HTML
+try:  # pragma: no cover - optional dependency
+    from weasyprint import HTML
+except Exception:  # pragma: no cover - environment specific
+    HTML = None
 
 from neuro_san.interfaces.coded_tool import CodedTool
 
@@ -63,6 +66,8 @@ class AutoDrafter(CodedTool):
             if path.suffix.lower() != ".pdf":
                 path = path.with_suffix(".pdf")
             html = f"<pre>{content}</pre>"
+            if HTML is None:
+                raise RuntimeError("WeasyPrint is required to export PDF files")
             HTML(string=html).write_pdf(str(path))
         else:
             if path.suffix.lower() != ".docx":

--- a/coded_tools/legal_discovery/deposition_prep.py
+++ b/coded_tools/legal_discovery/deposition_prep.py
@@ -10,7 +10,10 @@ from google import genai
 import os
 
 from docx import Document as DocxDocument
-from weasyprint import HTML
+try:  # pragma: no cover - optional dependency
+    from weasyprint import HTML
+except Exception:  # pragma: no cover - environment specific
+    HTML = None
 
 from apps.legal_discovery.database import db
 from apps.legal_discovery.models import (
@@ -177,6 +180,8 @@ class DepositionPrep:
         timestamp = datetime.utcnow().strftime("%Y-%m-%d %H:%M UTC")
 
         if final_path.lower().endswith(".pdf"):
+            if HTML is None:
+                raise RuntimeError("WeasyPrint is required to export PDF files")
             items_html = ""
             sources_html = ""
             for idx, q in enumerate(questions, 1):


### PR DESCRIPTION
## Summary
- guard PDF exports against missing WeasyPrint libraries so the dashboard can start without native dependencies
- raise clear errors when PDF generation is requested but WeasyPrint is unavailable
- log the change in AGENTS.md

## Testing
- `npm --prefix apps/legal_discovery run build`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6ea70327c8333bdf654055a38f116