### PR TITLE
Add fallback for Chroma heartbeat health check

### DIFF
--- a/apps/legal_discovery/hippo_routes.py
+++ b/apps/legal_discovery/hippo_routes.py
@@ -98,7 +98,14 @@ def health() -> "flask.Response":
                 resp.status_code,
                 getattr(resp, "text", ""),
             )
-        if resp.status_code != 200:
+            if resp.status_code == 404:  # try bare heartbeat endpoint
+                resp = requests.get(f"{base}/heartbeat", timeout=2)
+                logger.debug(
+                    "Chroma bare heartbeat response %s: %s",
+                    resp.status_code,
+                    getattr(resp, "text", ""),
+                )
+        if resp.status_code // 100 != 2:
             raise RuntimeError("chroma heartbeat failed")
     except requests.exceptions.ConnectionError as exc:
         logger.exception("Chroma connection error")

--- a/tests/apps/test_health_endpoint.py
+++ b/tests/apps/test_health_endpoint.py
@@ -165,6 +165,66 @@ def test_health_fallbacks_to_legacy_chroma(monkeypatch):
     assert resp.get_json()["data"]["chroma"] == "ok"
 
 
+def test_health_fallbacks_to_bare_chroma(monkeypatch):
+    app = Flask(__name__)
+    app.register_blueprint(health_bp)
+    client = app.test_client()
+
+    class DummySession:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            pass
+
+        def run(self, query):
+            return None
+
+    class DummyDriver:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            pass
+
+        def session(self, database=None):
+            return DummySession()
+
+    class DummyGraphDB:
+        @staticmethod
+        def driver(*args, **kwargs):
+            return DummyDriver()
+
+    monkeypatch.setattr(hippo_routes, "GraphDatabase", DummyGraphDB)
+
+    class R:
+        def __init__(self, code):
+            self.status_code = code
+            self.text = ""
+
+    def fake_get(url, timeout=0):
+        if url.endswith("/api/v1/heartbeat"):
+            return R(404)
+        if url.endswith("/api/heartbeat"):
+            return R(404)
+        return R(204)
+
+    monkeypatch.setattr(hippo_routes.requests, "get", fake_get)
+    monkeypatch.setattr(hippo_routes.db.session, "execute", lambda *a, **kw: None)
+    monkeypatch.setattr(hippo_routes.db.session, "commit", lambda *a, **kw: None)
+    monkeypatch.setattr(hippo_routes.db.session, "close", lambda *a, **kw: None)
+
+    class DummyRedis:
+        def ping(self):
+            return None
+
+    monkeypatch.setattr(hippo_routes, "redis_client", DummyRedis())
+
+    resp = client.get("/api/health")
+    assert resp.status_code == 200
+    assert resp.get_json()["data"]["chroma"] == "ok"
+
+
 def test_health_reports_chroma_connection_error(monkeypatch):
     app = Flask(__name__)
     app.register_blueprint(health_bp)


### PR DESCRIPTION
## Summary
- attempt `/heartbeat` when new `/api/v1/heartbeat` and `/api/heartbeat` endpoints return 404
- treat any 2xx Chroma heartbeat as healthy to avoid false failures

## Testing
- `npm run build`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b724e4de34833387194b0dddad0dbd