### PR TITLE
feat: add qdrant client dependency

### DIFF
--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -1230,3 +1230,7 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 ## Update 2025-10-09T08:00Z
 - Removed deprecated Chroma references; switched health checks, configs, docs and requirements to Qdrant.
 - Next: verify full vector search flow with Qdrant in staging.
+
+## Update 2025-10-09T09:00Z
+- Added `qdrant-client` dependency and attempted to regenerate requirements, but `pip-compile` failed with an OpenAI version conflict.
+- Next: reconcile OpenAI and langchain-openai versions so requirements can compile cleanly.

--- a/apps/legal_discovery/requirements.in
+++ b/apps/legal_discovery/requirements.in
@@ -34,6 +34,7 @@ python-socketio
 pyttsx3
 pyvis==0.3.2
 pywinpty==2.0.13; platform_system == "Windows"
+qdrant-client==1.15.1  # Needed for trial_preparation module – Python client for Qdrant
 redis
 reportlab==4.4.3
 requests

--- a/apps/legal_discovery/requirements.txt
+++ b/apps/legal_discovery/requirements.txt
@@ -225,6 +225,12 @@ h11==0.16.0
     #   httpcore
     #   uvicorn
     #   wsproto
+h2==4.3.0
+    # via httpx
+hpack==4.1.0
+    # via h2
+hyperframe==6.1.0
+    # via h2
 hf-xet==1.1.8
     # via huggingface-hub
 httpcore==1.0.9
@@ -507,6 +513,8 @@ pillow==11.3.0
     #   reportlab
     #   sentence-transformers
     #   weasyprint
+portalocker==3.2.0
+    # via qdrant-client
 posthog==5.4.0
 preshed==3.0.10
     # via
@@ -654,6 +662,8 @@ pyyaml==6.0.2
     #   langchain-core
     #   transformers
     #   uvicorn
+qdrant-client==1.15.1
+    # via -r requirements.in
 redis==6.4.0
     # via
     #   -r requirements.in


### PR DESCRIPTION
## Summary
- add qdrant-client dependency for trial preparation
- include portalocker and HTTP/2 dependencies in locked requirements

## Testing
- `pip-compile apps/legal_discovery/requirements.in` *(fails: resolution conflict with openai and langchain-openai)*
- `pytest -q` *(fails: qdrant_client.http.exceptions.UnexpectedResponse: Unexpected Response: 503 (Service Unavailable))*
- `docker compose build legal_discovery` *(fails: command not found: docker)*
- `docker compose restart legal_discovery` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68b7c1c8810c8333bbb899b4e5a2bdb7