### PR TITLE
Avoid spaCy download during upload

### DIFF
--- a/agents--features and memory/condensed_agents.md
+++ b/agents--features and memory/condensed_agents.md
@@ -321,3 +321,7 @@ WE STARTED ON #3, INSTEAD OF #1. DEAL WITH IT, FINISH IMPLEMENTING #3, AND THEN 
 - Added fallback to legacy `/api/heartbeat` when `/api/v1/heartbeat` returns 404 to keep health checks green across Qdrant versions.
 - Introduced spacing between navigation tabs for cleaner layout.
 - Next: monitor production logs and re-evaluate once all deployments expose the v1 heartbeat.
+
+## Update 2025-10-09T10:30Z
+- Prevented upload hangs by falling back to a blank spaCy model when `en_core_web_sm` is unavailable.
+- Next: ship the language model with releases or document installation requirements.

--- a/apps/legal_discovery/AGENTS.md
+++ b/apps/legal_discovery/AGENTS.md
@@ -1234,3 +1234,7 @@ pip install python-dotenv flask gunicorn pillow requests neuro-san pyvis
 ## Update 2025-10-09T09:00Z
 - Added `qdrant-client` dependency and attempted to regenerate requirements, but `pip-compile` failed with an OpenAI version conflict.
 - Next: reconcile OpenAI and langchain-openai versions so requirements can compile cleanly.
+
+## Update 2025-10-09T10:30Z
+- Prevented upload hangs by falling back to a blank spaCy model when `en_core_web_sm` is missing.
+- Next: bundle the language model or handle optional installation in setup scripts.

--- a/apps/legal_discovery/interface_flask.py
+++ b/apps/legal_discovery/interface_flask.py
@@ -18,12 +18,20 @@ from io import BytesIO, StringIO
 import fitz
 import schedule
 import spacy
-from flask import Flask, Response, jsonify, render_template, request, send_file, send_from_directory, g
+from flask import (
+    Flask,
+    Response,
+    jsonify,
+    render_template,
+    request,
+    send_file,
+    send_from_directory,
+    g,
+)
 import uuid
 from more_itertools import chunked
 import structlog
 from pyhocon import ConfigFactory
-from spacy.cli import download as spacy_download
 try:  # pragma: no cover - optional dependency
     from weasyprint import HTML
 except Exception:  # pragma: no cover - environment specific
@@ -605,9 +613,11 @@ def match_elements(text: str, ontology: dict) -> list[tuple[str, str, float]]:
     if _NLP is None:
         try:
             _NLP = spacy.load("en_core_web_sm")
-        except OSError:  # pragma: no cover - model download is slow
-            spacy_download("en_core_web_sm")
-            _NLP = spacy.load("en_core_web_sm")
+        except OSError:  # pragma: no cover - model may be missing
+            logger.warning(
+                "spaCy model 'en_core_web_sm' not found; using blank 'en' model"
+            )
+            _NLP = spacy.blank("en")
 
     doc = _NLP(text.lower())
     text_lemmas = {t.lemma_ for t in doc if not t.is_stop and t.is_alpha}


### PR DESCRIPTION
## Summary
- Prevent upload hangs by falling back to a blank spaCy model when `en_core_web_sm` is absent.
- Update agent progress logs for legal discovery module.

## Testing
- `npm run build`
- `pytest tests/apps/test_opposition_e2e.py::test_upload_detection_dashboard_flow -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68c22f6b76148333866ca9c48a411e55